### PR TITLE
Writing to buffer and texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Additions and improvements:
 * Targets wgpu-native v.0.5.2. The first release build from the wgpu-native repo itself.
 * The texture object has more properties to query the parameters that it was created with.
 * The texture view object has a `texture` property.
-* The buffer object has a property `map_mode`.
 * The render and compute pipeline objects have a property `layout` and a method `get_bind_group_layout()`.
 * The shader object got a `compilation_info` method, but this does not do anything yet.
 * The `create_shader_module()` has a `source_map` attribute, but this is yet unused.
@@ -26,12 +25,10 @@ Additions and improvements:
 
 API changes:
 
-* The buffer no longer has a `mapped` attribute.
-* The buffer `map_read` and `map_write` methods have been replaced with `map`,
-  where the first argument is e.g. `wgpu.MapMode.READ`. This method returns
-  a `memoryview` object that can be read from or written to.
-* The device `create_buffer_mapped` method now returns a tuple (buffer, mapped_mem).
-* The device `create_buffer_with_data` is added as a convenience function.
+* The buffer no longer exposes a data mapping API. Instead it has functions
+  `read_data()` and `write_data()`
+* The device `create_buffer_mapped` method is similarly removed. The
+  device `create_buffer_with_data` is added as a convenience function.
 * The `array_layer` in copy operations involving a texture is removed.
 * The `utils.compute_with_buffers` function now accepts *any* data dat supports
   the buffer protocol (not just ctypes arrays). The outputs are `memoryview` objects,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ be precise about tracking changes to the public API.
 
 ### v0.3.0
 
+With this update we're using a later release of wgpu-native, and follow changes
+is the WebGPU spec. Further, we've removed the need for ctypes to communicate
+data arrays. Instead, wgpu-py can consume any object that supports the buffer
+protocol, and it returns `memoryview` objects.
+
 Additions and improvements:
 
 * Targets wgpu-native v.0.5.2. The first release build from the wgpu-native repo itself.
@@ -16,14 +21,23 @@ Additions and improvements:
 * The render and compute pipeline objects have a property `layout` and a method `get_bind_group_layout()`.
 * The shader object got a `compilation_info` method, but this does not do anything yet.
 * The `create_shader_module()` has a `source_map` attribute, but this is yet unused.
+* Log messages from wgpu-native (Rust) are now injected into Python's logger.
+* The `queue` object got two new methods `write_buffer` and `write_texture`.
 
 API changes:
 
+* The buffer no longer has a `mapped` attribute.
 * The buffer `map_read` and `map_write` methods have been replaced with `map`,
-  where the first argument is e.g. `wgpu.MapMode.READ`.
-* The device `create_buffer_mapped` is removed, instead `create_buffer`
-  has a `mapped_at_creation` argument.
+  where the first argument is e.g. `wgpu.MapMode.READ`. This method returns
+  a `memoryview` object that can be read from or written to.
+* The device `create_buffer_mapped` method now returns a tuple (buffer, mapped_mem).
+* The device `create_buffer_with_data` is added as a convenience function.
 * The `array_layer` in copy operations involving a texture is removed.
+* The `utils.compute_with_buffers` function now accepts *any* data dat supports
+  the buffer protocol (not just ctypes arrays). The outputs are `memoryview` objects,
+  which shape and format can be specified. When a ctypes array type is specified,
+  the output will be an instance of that type. This means that these changes are
+  fully backwards compatible.
 
 
 ### v0.2.0

--- a/codegen-script.py
+++ b/codegen-script.py
@@ -372,6 +372,10 @@ for fname in ("base.py", "backends/rs.py"):
             args = idl_line.split("(", 1)[1].split(")", 1)[0].split(",")
             args = [arg.strip() for arg in args if arg.strip()]
             defaults = [arg.partition("=")[2].strip() for arg in args]
+            defaults = [
+                default or (arg.startswith("optional ") and "None")
+                for default, arg in zip(defaults, args)
+            ]
             argnames = [arg.split("=")[0].split()[-1] for arg in args]
             argnames = [to_python_name(argname) for argname in argnames]
             argnames = [(f"{n}={v}" if v else n) for n, v in zip(argnames, defaults)]

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -68,8 +68,7 @@ object. These objects provide a quite versatile view on ndarray data:
 .. code-block:: py
 
     # One could, for instance read the content of a buffer
-    m = buffer.map(wgpu.MapMode.READ)
-    buffer.unmap()
+    m = buffer.read_data()
     # Cast it to float32
     m = m.cast("f")
     # Index it

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -60,7 +60,7 @@ Communicating array data
 The wgpu-py library makes no assumptions about how you store your data.
 In places where you provide data to the API, it can consume any data
 that supports the buffer protocol, which includes ``bytes``,
-``bytearray``, ctypes arrays, and numpy arrays.
+``bytearray``, ``memoryview``, ctypes arrays, and numpy arrays.
 
 In places where data is returned, the API returns a ``memoryview``
 object. These objects provide a quite versatile view on ndarray data:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -54,6 +54,37 @@ be between 0.0 and 1.0 inclusive. Vertices out of this range in NDC
 will not introduce any errors, but they will be clipped.
 
 
+Communicating array data
+------------------------
+
+The wgpu-py library makes no assumptions about how you store your data.
+In places where you provide data to the API, it can consume any data
+that supports the buffer protocol, which includes ``bytes``,
+``bytearray``, ctypes arrays, and numpy arrays.
+
+In places where data is returned, the API returns a ``memoryview``
+object. These objects provide a quite versatile view on ndarray data:
+
+.. code-block:: py
+
+    # One could, for instance read the content of a buffer
+    m = buffer.map(wgpu.MapMode.READ)
+    buffer.unmap()
+    # Cast it to float32
+    m = m.cast("f")
+    # Index it
+    m[0]
+    # Show the content
+    print(m.tolist())
+
+Chances are that you prefer Numpy. Converting the ``memoryview`` to a
+numpy array (without copying the data) is easy:
+
+.. code-block:: py
+
+    array = np.frombuffer(m, np.float32)
+
+
 Debugging
 ---------
 

--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -98,7 +98,5 @@ compute_pass.end_pass()
 device.default_queue.submit([command_encoder.finish()])
 
 # Read result
-result = buffer2.map(wgpu.MapMode.READ).cast("i")
-buffer2.unmap()
-
+result = buffer2.read_data().cast("i")
 print(result.tolist())

--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -3,8 +3,6 @@ Example compute shader that does ... nothing but copy a value from one
 buffer into another.
 """
 
-import ctypes
-
 import wgpu
 import wgpu.backends.rs  # Select backend
 from wgpu.utils import compute_with_buffers  # Convenience function
@@ -23,33 +21,33 @@ def compute_shader(
     data2[index] = data1[index]
 
 
-# Create input data as a ctypes array
+# Create input data as a memoryview
 n = 20
-IntArrayType = ctypes.c_int32 * n
-data = IntArrayType(*range(n))
+data = memoryview(bytearray(n * 4)).cast("i")
+for i in range(n):
+    data[i] = i
 
 
-# %% The short version, using ctypes arrays
+# %% The short version, using memoryview
 
 # The first arg is the input data, per binding
 # The second arg are the ouput types, per binding
-out = compute_with_buffers({0: data}, {1: IntArrayType}, compute_shader, n=n)
+out = compute_with_buffers({0: data}, {1: (n, "i")}, compute_shader, n=n)
 
 # The result is a dict matching the output types
 # Select data from buffer at binding 1
 result = out[1]
-print(result[:])
+print(result.tolist())
 
 
 # %% The short version, using numpy
 
 # import numpy as np
 #
-# numpy_data = np.arange(n, dtype=np.int32)
-#
-# data = IntArrayType.from_address(numpy_data.ctypes.data)
-# out = compute_with_buffers({0: data}, {1: IntArrayType}, compute_shader, n=n)
-# print(np.frombuffer(out[1], dtype=np.int32))
+# numpy_data = np.frombuffer(data, np.int32)
+# out = compute_with_buffers({0: numpy_data}, {1: numpy_data.nbytes}, compute_shader, n=n)
+# result = np.frombuffer(out[1], dtype=np.int32)
+# print(result)
 
 
 # %% The long version using the wgpu API
@@ -59,21 +57,10 @@ device = wgpu.utils.get_default_device()
 cshader = device.create_shader_module(code=compute_shader)
 
 # Create buffer objects, input buffer is mapped.
-buffer1 = device.create_buffer(
-    mapped_at_creation=True, size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE
-)
+buffer1 = device.create_buffer_with_data(data=data, usage=wgpu.BufferUsage.STORAGE)
 buffer2 = device.create_buffer(
-    size=ctypes.sizeof(data), usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ
+    size=data.nbytes, usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ
 )
-
-# Cast buffer array
-array1 = IntArrayType.from_buffer(buffer1.mapping)
-# With Numpy this would be:
-# array1 = np.frombuffer(buffer1.mapping, np.int32)
-
-# Copy data and then unmap
-array1[:] = data
-buffer1.unmap()
 
 # Setup layout and bindings
 binding_layouts = [
@@ -111,9 +98,7 @@ compute_pass.end_pass()
 device.default_queue.submit([command_encoder.finish()])
 
 # Read result
-result = buffer2.map(wgpu.MapMode.READ)
-result = IntArrayType.from_buffer(result)  # cast
-print(result[:])
+result = buffer2.map(wgpu.MapMode.READ).cast("i")
+buffer2.unmap()
 
-# With Numpy this would be:
-# print(np.frombuffer(buffer2.mapRead(), np.int32))
+print(result.tolist())

--- a/examples/cube_glfw.py
+++ b/examples/cube_glfw.py
@@ -3,7 +3,6 @@ This example renders a simple textured rotating cube.
 """
 
 import time
-import ctypes
 
 import glfw
 import wgpu
@@ -97,26 +96,14 @@ uniform_data = np.asarray(shadertype_as_ctype(uniform_type)())
 # %% Create resource objects (buffers, textures, samplers)
 
 # Create vertex buffer, and upload data
-vertex_buffer = device.create_buffer(
-    mapped_at_creation=True, size=vertex_data.nbytes, usage=wgpu.BufferUsage.VERTEX
+vertex_buffer = device.create_buffer_with_data(
+    data=vertex_data, usage=wgpu.BufferUsage.VERTEX
 )
-ctypes.memmove(
-    ctypes.addressof(vertex_buffer.mapping),
-    vertex_data.ctypes.data,
-    vertex_data.nbytes,
-)
-vertex_buffer.unmap()
-
 
 # Create index buffer, and upload data
-index_buffer = device.create_buffer(
-    mapped_at_creation=True, size=index_data.nbytes, usage=wgpu.BufferUsage.INDEX
+index_buffer = device.create_buffer_with_data(
+    data=index_data, usage=wgpu.BufferUsage.INDEX
 )
-ctypes.memmove(
-    ctypes.addressof(index_buffer.mapping), index_data.ctypes.data, index_data.nbytes,
-)
-index_buffer.unmap()
-
 
 # Create uniform buffer - data is uploaded each frame
 uniform_buffer = device.create_buffer(
@@ -134,13 +121,9 @@ texture = device.create_texture(
     sample_count=1,
 )
 texture_view = texture.create_view()
-tmp_buffer = device.create_buffer(
-    mapped_at_creation=True, size=texture_data.nbytes, usage=wgpu.BufferUsage.COPY_SRC
+tmp_buffer = device.create_buffer_with_data(
+    data=texture_data, usage=wgpu.BufferUsage.COPY_SRC
 )
-ctypes.memmove(
-    ctypes.addressof(tmp_buffer.mapping), texture_data.ctypes.data, texture_data.nbytes,
-)
-vertex_buffer.unmap()
 command_encoder = device.create_command_encoder()
 command_encoder.copy_buffer_to_texture(
     {
@@ -354,13 +337,9 @@ def draw_frame():
 
     # Upload the uniform struct
     uniform_nbytes = uniform_data.nbytes
-    tmp_buffer = device.create_buffer(
-        mapped_at_creation=True, size=uniform_nbytes, usage=wgpu.BufferUsage.COPY_SRC
+    tmp_buffer = device.create_buffer_with_data(
+        data=uniform_data, usage=wgpu.BufferUsage.COPY_SRC
     )
-    ctypes.memmove(
-        ctypes.addressof(tmp_buffer.mapping), uniform_data.ctypes.data, uniform_nbytes
-    )
-    tmp_buffer.unmap()
 
     with swap_chain as current_texture_view:
         command_encoder = device.create_command_encoder()

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -15,13 +15,7 @@ def upload_to_texture(device, texture, data, nx, ny, nz):
     bpp = nbytes // (nx * ny * nz)
 
     # Create a buffer to get the data into the GPU
-    buffer = device.create_buffer(
-        mapped_at_creation=True, size=nbytes, usage=wgpu.BufferUsage.COPY_SRC
-    )
-
-    # Upload to buffer
-    ctypes.memmove(buffer.mapping, data, nbytes)
-    buffer.unmap()
+    buffer = device.create_buffer_with_data(data=data, usage=wgpu.BufferUsage.COPY_SRC)
 
     # Copy to texture (rows_per_image must only be nonzero for 3D textures)
     command_encoder = device.create_command_encoder()
@@ -51,8 +45,8 @@ def download_from_texture(device, texture, data_type, nx, ny, nz):
 
     # Download
     mapped_array = buffer.map(wgpu.MapMode.READ)
-    data = data_type.from_buffer(mapped_array)
     buffer.unmap()
+    data = data_type.from_buffer(mapped_array)
     return data
 
 

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -44,10 +44,7 @@ def download_from_texture(device, texture, data_type, nx, ny, nz):
     device.default_queue.submit([command_encoder.finish()])
 
     # Download
-    mapped_array = buffer.map(wgpu.MapMode.READ)
-    buffer.unmap()
-    data = data_type.from_buffer(mapped_array)
-    return data
+    return data_type.from_buffer(buffer.read_data())
 
 
 def render_to_texture(
@@ -181,8 +178,8 @@ def render_to_texture(
     device.default_queue.submit([command_encoder.finish()])
 
     # Read the current data of the output buffer - numpy is much easier to work with
-    array_uint8 = buffer.map(wgpu.MapMode.READ)  # slow, can also be done async
-    data = (ctypes.c_uint8 * 4 * nx * ny).from_buffer(array_uint8)
+    mem = buffer.read_data()  # slow, can also be done async
+    data = (ctypes.c_uint8 * 4 * nx * ny).from_buffer(mem)
     return np.frombuffer(data, dtype=np.uint8).reshape(size[0], size[1], 4)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 import subprocess
 
 import wgpu
@@ -19,6 +20,29 @@ def test_basic_api():
         wgpu.base.request_adapter.__code__.co_varnames
         == wgpu.base.request_adapter_async.__code__.co_varnames
     )
+
+
+def test_logging():
+    level = [-1]
+
+    def set_level_test(lvl):
+        level[0] = lvl
+
+    wgpu._coreutils.logger_set_level_callbacks.append(set_level_test)
+    logger = logging.getLogger("wgpu")
+    logger.setLevel("ERROR")
+    assert level[0] == 40
+    logger.setLevel("INFO")
+    assert level[0] == 20
+    logger.setLevel("DEBUG")
+    assert level[0] == 10
+    logger.setLevel(5)
+    assert level[0] == 5  # "trace" in wgpu-native
+    logger.setLevel(0)
+    assert level[0] == 0  # off
+    # Reset
+    logger.setLevel("WARNING")
+    assert level[0] == 30
 
 
 def test_enums_and_flags():
@@ -137,7 +161,7 @@ def test_help3(capsys):
     assert captured.err == ""
     assert "1 flags" in captured.out
     assert "3 enums" in captured.out
-    assert "15 functions" in captured.out
+    assert "17 functions" in captured.out
 
 
 def test_help4(capsys):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,7 +161,7 @@ def test_help3(capsys):
     assert captured.err == ""
     assert "1 flags" in captured.out
     assert "3 enums" in captured.out
-    assert "17 functions" in captured.out
+    assert "0 functions" not in captured.out
 
 
 def test_help4(capsys):

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -14,12 +14,6 @@ if not can_use_wgpu_lib:
     skip("Skipping tests that need the wgpu lib", allow_module_level=True)
 
 
-def test_compute_formats():
-    # Test that we have a size for all supported formats
-    for c in set(wgpu.utils._compute.FORMAT_MAP.values()):
-        assert c in wgpu.utils._compute.FORMAT_SIZES
-
-
 def test_compute_0_1_ctype():
     @python2shader
     def compute_shader(
@@ -48,7 +42,7 @@ def test_compute_0_1_tuple():
     ):
         out[index] = index
 
-    out = compute_with_buffers({}, {0: (100, "i32")}, compute_shader)
+    out = compute_with_buffers({}, {0: (100, "i")}, compute_shader)
     assert isinstance(out, dict) and len(out) == 1
     assert isinstance(out[0], memoryview)
     assert out[0].tolist() == list(range(100))
@@ -61,7 +55,7 @@ def test_compute_0_1_str():
     ):
         out[index] = index
 
-    out = compute_with_buffers({}, {0: "100xi4"}, compute_shader)
+    out = compute_with_buffers({}, {0: "100xi"}, compute_shader)
     assert isinstance(out, dict) and len(out) == 1
     assert isinstance(out[0], memoryview)
     assert out[0].tolist() == list(range(100))

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -178,7 +178,7 @@ def test_compute_indirect():
     device.default_queue.submit([command_encoder.finish()])
 
     # Read result
-    out1 = in1.__class__.from_buffer(buffer2.map(wgpu.MapMode.READ))
+    out1 = in1.__class__.from_buffer(buffer2.read_data())
     in2 = list(in1)[:]
     out2 = [i - 1 for i in out1]
     # The shader was applied to all but the last two elements

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -106,6 +106,23 @@ def compute_shader(
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_logging():
+    # Do *something* while we set the log level low
+    device = wgpu.utils.get_default_device()
+
+    wgpu.logger.setLevel("DEBUG")
+
+    device.create_shader_module(code=compute_shader.to_spirv())
+
+    wgpu.logger.setLevel("WARNING")
+
+    # yeah, would be nice to be able to capture the logs. But if we don't crash
+    # and see from the coverage that we touched the logger integration code,
+    # we're doing pretty good ...
+    # (capsys does not work because it logs to the raw stderr)
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_shader_module_creation():
 
     device = wgpu.utils.get_default_device()
@@ -140,6 +157,72 @@ def test_adapter_destroy():
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_buffer_init1():
+    # Initializing a buffer with data
+
+    device = wgpu.utils.get_default_device()
+    data1 = b"abcdefghijkl"
+
+    # Create buffer
+    buf = device.create_buffer_with_data(data=data1, usage=wgpu.BufferUsage.MAP_READ)
+
+    # Download from buffer to CPU
+    data2 = buf.map(wgpu.MapMode.READ).tobytes()
+    buf.unmap()
+    assert data1 == data2
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_buffer_init2():
+    # Initializing a buffer as mapped, to directly set the data
+
+    device = wgpu.utils.get_default_device()
+    data1 = b"abcdefghijkl"
+
+    # Create buffer
+    buf, data2 = device.create_buffer_mapped(
+        size=len(data1), usage=wgpu.BufferUsage.MAP_READ
+    )
+    data2[:] = data1
+    buf.unmap()
+
+    # Download from buffer to CPU
+    data3 = buf.map(wgpu.MapMode.READ).tobytes()
+    buf.unmap()
+    assert data1 == data3
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_buffer_init3():
+    # Initializing a buffer unmapped, then mapping it.
+    # Note the extra usage that we need in this case.
+
+    device = wgpu.utils.get_default_device()
+    data1 = b"abcdefghijkl"
+
+    # First fail
+    with raises(ValueError):
+        device.create_buffer(
+            mapped_at_creation=True, size=len(data1), usage=wgpu.BufferUsage.MAP_READ
+        )
+
+    # Create buffer
+    buf = device.create_buffer(
+        size=len(data1), usage=wgpu.BufferUsage.MAP_READ | wgpu.BufferUsage.MAP_WRITE
+    )
+
+    # Map it
+    data2 = buf.map(wgpu.MapMode.WRITE)
+    data2[:] = data1
+    buf.unmap()
+
+    # Download from buffer to CPU
+    data3 = buf.map(wgpu.MapMode.READ).tobytes()
+    buf.unmap()
+    assert data1 == data3
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_do_a_copy_roundtrip():
     # Let's take some data, and copy it to buffer to texture to
     # texture to buffer to buffer and back to CPU.
@@ -147,8 +230,8 @@ def test_do_a_copy_roundtrip():
     device = wgpu.utils.get_default_device()
 
     nx, ny, nz = 100, 1, 1
-    data1 = (ctypes.c_float * 100)(*[random.random() for i in range(nx * ny * nz)])
-    nbytes = ctypes.sizeof(data1)
+    data1 = np.random.random(size=nx * ny * nz).astype(np.float32)
+    nbytes = data1.nbytes
     bpp = nbytes // (nx * ny * nz)
     texture_format = wgpu.TextureFormat.r32float
     texture_dim = wgpu.TextureDimension.d1
@@ -189,7 +272,7 @@ def test_do_a_copy_roundtrip():
     assert buf1.state == "unmapped"
     mapped_data = buf1.map(wgpu.MapMode.WRITE)
     assert buf1.state == "mapped"
-    ctypes.memmove(mapped_data, data1, nbytes)
+    mapped_data.cast("f")[:] = data1
     buf1.unmap()
     assert buf1.state == "unmapped"
 
@@ -225,18 +308,19 @@ def test_do_a_copy_roundtrip():
     # Download from buffer to CPU
     assert buf5.state == "unmapped"
     assert buf5.map_mode == 0
-    mapped_data = buf5.map(wgpu.MapMode.READ)  # always an uint8 array
+    mapped_data = buf5.map(wgpu.MapMode.READ)  # a memoryview
     assert buf5.state == "mapped"
     assert buf5.map_mode == wgpu.MapMode.READ
+    buf5.unmap()
+    assert buf5.state == "unmapped"
 
     # CHECK!
-    data2 = data1.__class__.from_buffer(mapped_data)
-    buf5.unmap()
-    assert iters_equal(data1, data2)
+    data2 = np.frombuffer(mapped_data, dtype=np.float32)
+    assert np.all(data1 == data2)
 
     # Do another round-trip, but now using a single pass
-    data3 = data1.__class__(*[i + 1 for i in list(data1)])
-    assert not iters_equal(data1, data3)
+    data3 = data1 + 1
+    assert np.all(data1 != data3)
 
     # Upload from CPU to buffer
     assert buf1.state == "unmapped"
@@ -244,7 +328,7 @@ def test_do_a_copy_roundtrip():
     mapped_data = buf1.map(wgpu.MapMode.WRITE)
     assert buf1.state == "mapped"
     assert buf1.map_mode == wgpu.MapMode.WRITE
-    ctypes.memmove(mapped_data, data3, nbytes)
+    mapped_data.cast("f")[:] = data3
     buf1.unmap()
     assert buf1.state == "unmapped"
     assert buf1.map_mode == 0
@@ -277,11 +361,12 @@ def test_do_a_copy_roundtrip():
     assert buf5.state == "unmapped"
     mapped_data = buf5.map(wgpu.MapMode.READ)  # always an uint8 array
     assert buf5.state == "mapped"
+    buf5.unmap()
+    assert buf5.state == "unmapped"
 
     # CHECK!
-    data4 = data3.__class__.from_buffer(mapped_data)
-    buf5.unmap()
-    assert iters_equal(data3, data4)
+    data4 = np.frombuffer(mapped_data, dtype=np.float32)
+    assert np.all(data3 == data4)
 
 
 def test_get_memoryview_and_address():
@@ -319,13 +404,11 @@ def test_get_memoryview_and_address():
 def test_write_buffer1():
     device = wgpu.utils.get_default_device()
 
-    nx, ny, nz = 100, 1, 1
-    data1 = (ctypes.c_float * 100)(*[random.random() for i in range(nx * ny * nz)])
-    nbytes = ctypes.sizeof(data1)
+    data1 = memoryview(np.random.random(size=100).astype(np.float32))
 
     # Create buffer
     buf4 = device.create_buffer(
-        size=nbytes, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ
+        size=data1.nbytes, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ
     )
 
     # Upload from CPU to buffer
@@ -334,10 +417,13 @@ def test_write_buffer1():
     device.default_queue.submit([])
 
     # Download from buffer to CPU
-    mapped_data = buf4.map(wgpu.MapMode.READ)
-    data2 = data1.__class__.from_buffer(mapped_data)
+    data2 = buf4.map(wgpu.MapMode.READ).cast("f")
     buf4.unmap()
-    assert iters_equal(data1, data2)
+    assert data1 == data2
+
+    # Yes, you can compare memoryviews! Check this:
+    data1[0] += 1
+    assert data1 != data2
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
@@ -388,14 +474,13 @@ def test_write_buffer3():
 
     # Upload from CPU to buffer, using bytes
     device.create_command_encoder()  # we seem to need to create one
-    device.default_queue.write_buffer(buf4, 0, b"abcdefghijkl")
+    device.default_queue.write_buffer(buf4, 0, b"abcdefghijkl", 0, nbytes)
     device.default_queue.submit([])
 
     # Download from buffer to CPU
     mapped_data = buf4.map(wgpu.MapMode.READ)
-    result = ctypes.string_at(mapped_data)
     buf4.unmap()
-    assert result == b"abcdefghijkl"
+    assert mapped_data.tobytes() == b"abcdefghijkl"
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
@@ -403,9 +488,8 @@ def test_write_texture1():
     device = wgpu.utils.get_default_device()
 
     nx, ny, nz = 100, 1, 1
-    data1 = (ctypes.c_float * 100)(*[random.random() for i in range(nx * ny * nz)])
-    nbytes = ctypes.sizeof(data1)
-    bpp = nbytes // (nx * ny * nz)
+    data1 = memoryview(np.random.random(size=100).astype(np.float32))
+    bpp = data1.nbytes // (nx * ny * nz)
     texture_format = wgpu.TextureFormat.r32float
     texture_dim = wgpu.TextureDimension.d1
 
@@ -417,7 +501,7 @@ def test_write_texture1():
         usage=wgpu.TextureUsage.COPY_SRC | wgpu.TextureUsage.COPY_DST,
     )
     buf4 = device.create_buffer(
-        size=nbytes, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ
+        size=data1.nbytes, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ
     )
 
     # Upload from CPU to texture
@@ -439,10 +523,9 @@ def test_write_texture1():
     device.default_queue.submit([command_encoder.finish()])
 
     # Download from buffer to CPU
-    mapped_data = buf4.map(wgpu.MapMode.READ)
-    data2 = data1.__class__.from_buffer(mapped_data)
+    data2 = buf4.map(wgpu.MapMode.READ).cast("f")
     buf4.unmap()
-    assert iters_equal(data1, data2)
+    assert data1 == data2
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -329,6 +329,7 @@ def test_write_buffer():
     )
 
     # Upload from CPU to buffer
+    device.create_command_encoder()  # we seem to need to create one
     device.default_queue.write_buffer(buf4, 0, data1)
     device.default_queue.submit([])
 
@@ -362,6 +363,7 @@ def test_write_texture():
     )
 
     # Upload from CPU to texture
+    command_encoder = device.create_command_encoder()
     device.default_queue.write_texture(
         {"texture": tex3},
         data1,
@@ -371,7 +373,6 @@ def test_write_texture():
     # device.default_queue.submit([])  -> call further down
 
     # Copy from texture to buffer
-    command_encoder = device.create_command_encoder()
     command_encoder.copy_texture_to_buffer(
         {"texture": tex3, "mip_level": 0, "origin": (0, 0, 0)},
         {"buffer": buf4, "offset": 0, "bytes_per_row": bpp * nx, "rows_per_image": ny},

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -373,30 +373,30 @@ def test_get_memoryview_and_address():
 
     get_memoryview_and_address = wgpu.backends.rs._get_memoryview_and_address
 
-    data = b"bytes are readonly, so this does not work"
+    data = b"bytes are readonly, but we can map it. Don't abuse this :)"
     m, address = get_memoryview_and_address(data)
-    assert m.nbytes > 0
+    assert m.nbytes == len(data)
     assert address > 0
 
-    data = bytearray(b"but a bytearray works")
+    data = bytearray(b"A bytearray works too")
     m, address = get_memoryview_and_address(data)
-    assert m.nbytes > 0
+    assert m.nbytes == len(data)
     assert address > 0
 
     data = (ctypes.c_float * 100)()
     m, address = get_memoryview_and_address(data)
-    assert m.nbytes > 0
+    assert m.nbytes == ctypes.sizeof(data)
     assert address > 0
 
     data = np.array([1, 2, 3, 4])
     m, address = get_memoryview_and_address(data)
-    assert m.nbytes > 0
+    assert m.nbytes == data.nbytes
     assert address > 0
 
     data = np.array([1, 2, 3, 4])
     data.flags.writeable = False
     m, address = get_memoryview_and_address(data)
-    assert m.nbytes > 0
+    assert m.nbytes == data.nbytes
     assert address > 0
 
 

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -425,11 +425,7 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
         | wgpu.BufferUsage.COPY_SRC
         | wgpu.BufferUsage.COPY_DST
     )
-    buffer = device.create_buffer(
-        mapped_at_creation=True, size=nbytes, usage=buffer_usage
-    )
-    ctypes.memmove(buffer.mapping, data1, nbytes)
-    buffer.unmap()
+    buffer = device.create_buffer_with_data(data=data1, usage=buffer_usage)
     assert buffer.usage == buffer_usage
 
     # Define bindings

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -501,8 +501,7 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
     device.default_queue.submit([command_encoder.finish()])
 
     # Read the current data of the output buffer
-    array_uint8 = buffer.map(wgpu.MapMode.READ)  # slow, can also be done async
-    data2 = data1.__class__.from_buffer(array_uint8)
+    data2 = data1.__class__.from_buffer(buffer.read_data())
 
     # Numpy arrays are easier to work with
     a1 = np.ctypeslib.as_array(data1).reshape(nz, ny, nx, nc)

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -94,13 +94,9 @@ def test_render_orange_square_indexed():
 
     # Index buffer
     indices = (ctypes.c_int32 * 6)(0, 1, 2, 2, 1, 3)
-    ibo = device.create_buffer(
-        mapped_at_creation=True,
-        size=ctypes.sizeof(indices),
-        usage=wgpu.BufferUsage.INDEX | wgpu.BufferUsage.MAP_WRITE,
+    ibo = device.create_buffer_with_data(
+        data=indices, usage=wgpu.BufferUsage.INDEX | wgpu.BufferUsage.MAP_WRITE,
     )
-    ctypes.memmove(ibo.mapping, indices, ctypes.sizeof(indices))
-    ibo.unmap()
 
     # Render
     render_args = device, vertex_shader, fragment_shader, pipeline_layout, bind_group
@@ -144,13 +140,9 @@ def test_render_orange_square_indirect():
 
     # Buffer with draw parameters for indirect draw call
     params = (ctypes.c_int32 * 4)(4, 1, 0, 0)
-    indirect_buffer = device.create_buffer(
-        mapped_at_creation=True,
-        size=ctypes.sizeof(params),
-        usage=wgpu.BufferUsage.INDIRECT,
+    indirect_buffer = device.create_buffer_with_data(
+        data=params, usage=wgpu.BufferUsage.INDIRECT,
     )
-    ctypes.memmove(indirect_buffer.mapping, params, ctypes.sizeof(params))
-    indirect_buffer.unmap()
 
     # Render
     render_args = device, vertex_shader, fragment_shader, pipeline_layout, bind_group
@@ -189,23 +181,15 @@ def test_render_orange_square_indexed_indirect():
 
     # Index buffer
     indices = (ctypes.c_int32 * 6)(0, 1, 2, 2, 1, 3)
-    ibo = device.create_buffer(
-        mapped_at_creation=True,
-        size=ctypes.sizeof(indices),
-        usage=wgpu.BufferUsage.INDEX | wgpu.BufferUsage.MAP_WRITE,
+    ibo = device.create_buffer_with_data(
+        data=indices, usage=wgpu.BufferUsage.INDEX | wgpu.BufferUsage.MAP_WRITE,
     )
-    ctypes.memmove(ibo.mapping, indices, ctypes.sizeof(indices))
-    ibo.unmap()
 
     # Buffer with draw parameters for indirect draw call
     params = (ctypes.c_int32 * 5)(6, 1, 0, 0, 0)
-    indirect_buffer = device.create_buffer(
-        mapped_at_creation=True,
-        size=ctypes.sizeof(params),
-        usage=wgpu.BufferUsage.INDIRECT,
+    indirect_buffer = device.create_buffer_with_data(
+        data=params, usage=wgpu.BufferUsage.INDIRECT,
     )
-    ctypes.memmove(indirect_buffer.mapping, params, ctypes.sizeof(params))
-    indirect_buffer.unmap()
 
     # Render
     render_args = device, vertex_shader, fragment_shader, pipeline_layout, bind_group
@@ -256,13 +240,9 @@ def test_render_orange_square_vbo():
 
     # Vertex buffer
     pos_data = (ctypes.c_float * 8)(-0.5, -0.5, -0.5, +0.5, +0.5, -0.5, +0.5, +0.5)
-    vbo = device.create_buffer(
-        mapped_at_creation=True,
-        size=ctypes.sizeof(pos_data),
-        usage=wgpu.BufferUsage.VERTEX | wgpu.BufferUsage.MAP_WRITE,
+    vbo = device.create_buffer_with_data(
+        data=pos_data, usage=wgpu.BufferUsage.VERTEX | wgpu.BufferUsage.MAP_WRITE,
     )
-    ctypes.memmove(vbo.mapping, pos_data, ctypes.sizeof(pos_data))
-    vbo.unmap()
 
     # Vertex buffer views
     vbo_view = {

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -1420,9 +1420,9 @@ class GPUQueue(GPUObject):
     # IDL: void writeBuffer( GPUBuffer buffer, GPUSize64 bufferOffset, [AllowShared] ArrayBuffer data, optional GPUSize64 dataOffset = 0, optional GPUSize64 size);
     def write_buffer(self, buffer, buffer_offset, data, data_offset=0, size=None):
         """ Takes the data contents and schedules a write operation of
-        these contents to the buffer. Any subsequent modifications to
-        data do not affect what is written at the time that the
-        scheduled operation runs.
+        these contents to the buffer. A snapshot of the data is taken;
+        any changes to the data after this function is called do not
+        affect the buffer contents.
 
         Arguments:
             buffer: The :class:`GPUBuffer` object to write to.
@@ -1437,9 +1437,9 @@ class GPUQueue(GPUObject):
     # IDL: void writeTexture( GPUTextureCopyView destination, [AllowShared] ArrayBuffer data, GPUTextureDataLayout dataLayout, GPUExtent3D size);
     def write_texture(self, destination, data, data_layout, size):
         """ Takes the data contents and schedules a write operation of
-        these contents to the destination texture in the queue. Any
-        subsequent modifications to data do not affect what is written
-        at the time that the scheduled operation runs.
+        these contents to the destination texture in the queue. A
+        snapshot of the data is taken; any changes to the data after
+        this function is called do not affect the texture contents.
 
         Arguments:
             destination: A dict with fields: "texture" (a texture object),

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -592,7 +592,7 @@ class GPUDevice(GPUObject):
         In the WebGPU spec this is a method of the canvas. In wgpu-py
         it's a method of the device.
 
-        Parameters:
+        Arguments:
             canvas (WgpuCanvasInterface): An object implementing the canvas interface.
             format (TextureFormat): The texture format, e.g. "bgra8unorm-srgb".
             usage (TextureUsage): Default ``TextureUsage.OUTPUT_ATTACHMENT``.
@@ -964,7 +964,7 @@ class GPUCommandEncoder(GPUObject):
         """ Record the beginning of a compute pass. Returns a
         :class:`GPUComputePassEncoder` object.
 
-        Parameters:
+        Arguments:
             label (str): A human readable label. Optional.
         """
         raise NotImplementedError()
@@ -1092,7 +1092,7 @@ class GPUCommandEncoder(GPUObject):
         """ Finish recording. Returns a :class:`GPUCommandBuffer` to
         submit to a :class:`GPUQueue`.
 
-        Parameters:
+        Arguments:
             label (str): A human readable label. Optional.
         """
         raise NotImplementedError()
@@ -1385,7 +1385,7 @@ class GPURenderBundleEncoder(GPURenderEncoderBase):
     def finish(self, *, label=""):
         """ Finish recording and return a :class:`GPURenderBundle`.
 
-        Parameters:
+        Arguments:
             label (str): A human readable label. Optional.
         """
         raise NotImplementedError()
@@ -1413,6 +1413,41 @@ class GPUQueue(GPUObject):
     def copy_image_bitmap_to_texture(self, source, destination, copy_size):
         """
         TODO: not yet available in wgpu-native
+        """
+        raise NotImplementedError()
+
+    # wgpu.help('Buffer', 'Size64', 'queuewritebuffer', dev=True)
+    # IDL: void writeBuffer( GPUBuffer buffer, GPUSize64 bufferOffset, [AllowShared] ArrayBuffer data, optional GPUSize64 dataOffset = 0, optional GPUSize64 size);
+    def write_buffer(self, buffer, buffer_offset, data, data_offset=0, size=None):
+        """ Takes the data contents and schedules a write operation of
+        these contents to the buffer. Any subsequent modifications to
+        data do not affect what is written at the time that the
+        scheduled operation runs.
+
+        Arguments:
+            buffer: The :class:`GPUBuffer` object to write to.
+            buffer_offset (int): The offset in the buffer to start writing at.
+            data: The data to write.
+            data_offset: The byte offset in the data. Default 0.
+            size: The number of bytes to write. Default all minus offset.
+        """
+        raise NotImplementedError()
+
+    # wgpu.help('Extent3D', 'TextureCopyView', 'TextureDataLayout', 'queuewritetexture', dev=True)
+    # IDL: void writeTexture( GPUTextureCopyView destination, [AllowShared] ArrayBuffer data, GPUTextureDataLayout dataLayout, GPUExtent3D size);
+    def write_texture(self, destination, data, data_layout, size):
+        """ Takes the data contents and schedules a write operation of
+        these contents to the destination texture in the queue. Any
+        subsequent modifications to data do not affect what is written
+        at the time that the scheduled operation runs.
+
+        Arguments:
+            destination: A dict with fields: "texture" (a texture object),
+                "origin" (a 3-tuple), "mip_level" (an int, default 0).
+            data: The data to write.
+            data_layout: A dict with fields: "offset" (an int, default 0),
+                "bytes_per_row" (an int), "rows_per_image" (an int, default 0).
+            size: A 3-tuple of ints specifying the size to write.
         """
         raise NotImplementedError()
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -104,7 +104,7 @@
 ## Checking and patching hand-written API code
 
 ### Check functions in base.py
-*  Found 60 functions already implemented
+*  Found 62 functions already implemented
 *  Not implemented: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor); (devicecreatebuffermapped)
 *  Not implemented: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); (devicecreatequeryset)
 *  Not implemented: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffergetmappedrange)
@@ -120,8 +120,6 @@
 *  Not implemented: void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex); (renderpassencoderwritetimestamp)
 *  Not implemented: GPUFence createFence(optional GPUFenceDescriptor descriptor = {}); (queuecreatefence)
 *  Not implemented: void signal(GPUFence fence, GPUFenceValue signalValue); (queuesignal)
-*  Not implemented: void writeBuffer( GPUBuffer buffer, GPUSize64 bufferOffset, [AllowShared] ArrayBuffer data, optional GPUSize64 dataOffset = 0, optional GPUSize64 size); (queuewritebuffer)
-*  Not implemented: void writeTexture( GPUTextureCopyView destination, [AllowShared] ArrayBuffer data, GPUTextureDataLayout dataLayout, GPUExtent3D size); (queuewritetexture)
 *  Not implemented: GPUFenceValue getCompletedValue(); (fencegetcompletedvalue)
 *  Not implemented: Promise<void> onCompletion(GPUFenceValue completionValue); (fenceoncompletion)
 *  Not implemented: void destroy(); (querysetdestroy)
@@ -130,7 +128,7 @@
 *  Injected IDL lines into base.py
 
 ### Check functions in backends/rs.py
-*  Found 50 functions already implemented
+*  Found 52 functions already implemented
 *  Not implemented: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor); (devicecreatebuffermapped)
 *  Not implemented: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor); (devicecreaterenderbundleencoder)
 *  Not implemented: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); (devicecreatequeryset)
@@ -153,8 +151,6 @@
 *  Not implemented: GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {}); (renderbundleencoderfinish)
 *  Not implemented: GPUFence createFence(optional GPUFenceDescriptor descriptor = {}); (queuecreatefence)
 *  Not implemented: void signal(GPUFence fence, GPUFenceValue signalValue); (queuesignal)
-*  Not implemented: void writeBuffer( GPUBuffer buffer, GPUSize64 bufferOffset, [AllowShared] ArrayBuffer data, optional GPUSize64 dataOffset = 0, optional GPUSize64 size); (queuewritebuffer)
-*  Not implemented: void writeTexture( GPUTextureCopyView destination, [AllowShared] ArrayBuffer data, GPUTextureDataLayout dataLayout, GPUExtent3D size); (queuewritetexture)
 *  Not implemented: void copyImageBitmapToTexture( GPUImageBitmapCopyView source, GPUTextureCopyView destination, GPUExtent3D copySize); (queuecopyimagebitmaptotexture)
 *  Not implemented: GPUFenceValue getCompletedValue(); (fencegetcompletedvalue)
 *  Not implemented: Promise<void> onCompletion(GPUFenceValue completionValue); (fenceoncompletion)

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -104,9 +104,12 @@
 ## Checking and patching hand-written API code
 
 ### Check functions in base.py
-*  Found 62 functions already implemented
+*  Found 58 functions already implemented
+*  Not implemented: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor); (devicecreatebuffermapped)
 *  Not implemented: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); (devicecreatequeryset)
+*  Not implemented: Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffermapasync)
 *  Not implemented: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffergetmappedrange)
+*  Not implemented: void unmap(); (bufferunmap)
 *  Not implemented: void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex); (commandencoderwritetimestamp)
 *  Not implemented: void resolveQuerySet( GPUQuerySet querySet, GPUSize32 firstQuery, GPUSize32 queryCount, GPUBuffer destination, GPUSize64 destinationOffset); (commandencoderresolvequeryset)
 *  Not implemented: void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex); (computepassencoderbeginpipelinestatisticsquery)
@@ -125,13 +128,19 @@
 *  Found unknown function create_buffer_with_data (devicecreatebufferwithdata)
 *  Found unknown function configure_swap_chain (deviceconfigureswapchain)
 *  Found unknown function get_swap_chain_preferred_format (devicegetswapchainpreferredformat)
+*  Found unknown function read_data (bufferreaddata)
+*  Found unknown function read_data_async (bufferreaddataasync)
+*  Found unknown function write_data (bufferwritedata)
 *  Injected IDL lines into base.py
 
 ### Check functions in backends/rs.py
-*  Found 52 functions already implemented
+*  Found 48 functions already implemented
+*  Not implemented: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor); (devicecreatebuffermapped)
 *  Not implemented: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor); (devicecreaterenderbundleencoder)
 *  Not implemented: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); (devicecreatequeryset)
+*  Not implemented: Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffermapasync)
 *  Not implemented: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffergetmappedrange)
+*  Not implemented: void unmap(); (bufferunmap)
 *  Not implemented: GPUBindGroupLayout getBindGroupLayout(unsigned long index); (pipelinebasegetbindgrouplayout)
 *  Not implemented: void pushDebugGroup(USVString groupLabel); (commandencoderpushdebuggroup)
 *  Not implemented: void popDebugGroup(); (commandencoderpopdebuggroup)
@@ -158,4 +167,7 @@
 *  Found unknown function new_struct_p (newstructp)
 *  Found unknown function create_buffer_with_data (devicecreatebufferwithdata)
 *  Found unknown function configure_swap_chain (deviceconfigureswapchain)
+*  Found unknown function read_data (bufferreaddata)
+*  Found unknown function read_data_async (bufferreaddataasync)
+*  Found unknown function write_data (bufferwritedata)
 *  Injected IDL lines into backends/rs.py

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -105,7 +105,6 @@
 
 ### Check functions in base.py
 *  Found 62 functions already implemented
-*  Not implemented: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor); (devicecreatebuffermapped)
 *  Not implemented: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); (devicecreatequeryset)
 *  Not implemented: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffergetmappedrange)
 *  Not implemented: void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex); (commandencoderwritetimestamp)
@@ -123,13 +122,13 @@
 *  Not implemented: GPUFenceValue getCompletedValue(); (fencegetcompletedvalue)
 *  Not implemented: Promise<void> onCompletion(GPUFenceValue completionValue); (fenceoncompletion)
 *  Not implemented: void destroy(); (querysetdestroy)
+*  Found unknown function create_buffer_with_data (devicecreatebufferwithdata)
 *  Found unknown function configure_swap_chain (deviceconfigureswapchain)
 *  Found unknown function get_swap_chain_preferred_format (devicegetswapchainpreferredformat)
 *  Injected IDL lines into base.py
 
 ### Check functions in backends/rs.py
 *  Found 52 functions already implemented
-*  Not implemented: GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor); (devicecreatebuffermapped)
 *  Not implemented: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor); (devicecreaterenderbundleencoder)
 *  Not implemented: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); (devicecreatequeryset)
 *  Not implemented: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0); (buffergetmappedrange)
@@ -157,5 +156,6 @@
 *  Not implemented: void destroy(); (querysetdestroy)
 *  Not implemented: GPUTexture getCurrentTexture(); (swapchaingetcurrenttexture)
 *  Found unknown function new_struct_p (newstructp)
+*  Found unknown function create_buffer_with_data (devicecreatebufferwithdata)
 *  Found unknown function configure_swap_chain (deviceconfigureswapchain)
 *  Injected IDL lines into backends/rs.py

--- a/wgpu/utils/_compute.py
+++ b/wgpu/utils/_compute.py
@@ -174,8 +174,7 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
     output = {}
     for index, info in output_infos.items():
         buffer = buffers[index]
-        m = buffer.map(wgpu.MapMode.READ)  # slow, can also be done async
-        buffer.unmap()
+        m = buffer.read_data()  # slow, can also be done async
         if "ctypes_array_type" in info:
             output[index] = info["ctypes_array_type"].from_buffer(m)
         else:

--- a/wgpu/utils/_compute.py
+++ b/wgpu/utils/_compute.py
@@ -13,16 +13,19 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
     using storage buffer objects.
 
     Parameters:
-        input_arrays (dict): A dict mapping int bindings to ctypes arrays.
-            The type of the array does not need to match the type with which
-            the shader will interpret the buffer data (though it probably
-            makes the code easier to follow).
-        output_arrays (dict): A dict mapping int bindings to ctypes
-            array types. This function uses the given type to determine
-            the buffer size (in bytes), and returns arrays of matching
-            type. Example: ``ctypes.c_float * 20``. If you don't care
-            about the type (e.g. because you re-cast it later), you can
-            just specify the buffer size using ``ctypes.c_ubyte * nbytes``.
+        input_arrays (dict): A dict mapping int bindings to arrays. The array
+            can be anything that supports the buffer protocol, including
+            bytes, memoryviews, ctypes arrays and numpy arrays. The
+            type and shape of the array does not need to match the type
+            with which the shader will interpret the buffer data (though
+            it probably makes your code easier to follow).
+        output_arrays (dict): A dict mapping int bindings to output shapes.
+            If the value is int, it represents the size (in bytes) of
+            the buffer. If the value is a tuple, it must have at least
+            2 elements, where the last is a format string and the
+            preceding elements the shape. The returned memoryview will
+            be cast accordingly. If the value is a ctypes array type,
+            the result will be cast to that instead of a memoryview.
         shader (bytes, shader-object): The SpirV representing the shader,
             as raw bytes or an object implementing ``to_spirv()``
             (e.g. a pyshader SpirV module).
@@ -31,9 +34,7 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
             the length of the first output array type is used.
 
     Returns:
-        output (dict): A dict mapping int bindings to ctypes arrays. The
-        keys match those of ``output_arrays``, and the arrays are instances
-        of the corresponding array types.
+        output (dict): A dict mapping int bindings to memoryviews.
     """
 
     # Check input arrays
@@ -42,22 +43,58 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
     for key, array in input_arrays.items():
         if not isinstance(key, int):
             raise TypeError("keys of input_arrays must be int.")
-        if not isinstance(array, ctypes.Array):
-            raise TypeError("values of input_arrays must be ctypes arrays.")
+        # Simply wrapping in a memoryview ensures that it supports the buffer protocol
+        memoryview(array)
 
     # Check output arrays
+    output_infos = {}
     if not isinstance(output_arrays, dict) or not output_arrays:
         raise TypeError("output_arrays must be a nonempty dict.")
-    for key, array_type in output_arrays.items():
+    for key, array_descr in output_arrays.items():
         if not isinstance(key, int):
             raise TypeError("keys of output_arrays must be int.")
-        if not (isinstance(array_type, type) and issubclass(array_type, ctypes.Array)):
-            raise TypeError("values of output_arrays must be ctypes array subclasses.")
+        if isinstance(array_descr, str) and "x" in array_descr:
+            array_descr = tuple(array_descr.split("x"))
+        if isinstance(array_descr, int):
+            output_infos[key] = {
+                "length": array_descr,
+                "nbytes": array_descr,
+                "format": "B",
+                "shape": (array_descr,),
+            }
+        elif isinstance(array_descr, tuple):
+            format = array_descr[-1]
+            try:
+                format = FORMAT_MAP[format]
+            except KeyError:
+                raise ValueError(f"Invalid format for output array {key}: {format}")
+            shape = tuple(int(i) for i in array_descr[:-1])
+            if not (shape and all(i > 0 for i in shape)):
+                raise ValueError(f"Invalid shape for output array {key}: {shape}")
+            nbytes = FORMAT_SIZES[format]
+            for i in shape:
+                nbytes *= i
+            output_infos[key] = {
+                "length": shape[0],
+                "nbytes": nbytes,
+                "format": format,
+                "shape": shape,
+            }
+        elif isinstance(array_descr, type) and issubclass(array_descr, ctypes.Array):
+            output_infos[key] = {
+                "length": array_descr._length_,
+                "nbytes": ctypes.sizeof(array_descr),
+                "ctypes_array_type": array_descr,
+            }
+        else:
+            raise TypeError(
+                f"Invalid value for output array description: {array_descr}"
+            )
 
     # Get nx, ny, nz from n
     if n is None:
-        array_type = list(output_arrays.values())[0]
-        nx, ny, nz = array_type._length_, 1, 1
+        output_info = list(output_infos.values())[0]
+        nx, ny, nz = output_info["length"], 1, 1
     elif isinstance(n, int):
         nx, ny, nz = int(n), 1, 1
     elif isinstance(n, tuple) and len(n) == 3:
@@ -73,38 +110,31 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
 
     # Create buffers for input and output arrays
     buffers = {}
-    for binding_index, array in input_arrays.items():
-        # Create the buffer object
-        nbytes = ctypes.sizeof(array)
+    for index, array in input_arrays.items():
         usage = wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_WRITE
-        if binding_index in output_arrays:
+        if index in output_arrays:
             usage |= wgpu.BufferUsage.MAP_READ
-        buffer = device.create_buffer(mapped_at_creation=True, size=nbytes, usage=usage)
-        # Copy data from array to buffer
-        ctypes.memmove(buffer.mapping, array, nbytes)
-        buffer.unmap()
-        # Store
-        buffers[binding_index] = buffer
-    for binding_index, array_type in output_arrays.items():
-        if binding_index in input_arrays:
+        buffer = device.create_buffer_with_data(data=array, usage=usage)
+        buffers[index] = buffer
+    for index, info in output_infos.items():
+        if index in input_arrays:
             continue  # We already have this buffer
-        nbytes = ctypes.sizeof(array_type)
         usage = wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.MAP_READ
-        buffers[binding_index] = device.create_buffer(size=nbytes, usage=usage)
+        buffers[index] = device.create_buffer(size=info["nbytes"], usage=usage)
 
     # Create bindings and binding layouts
     bindings = []
     binding_layouts = []
-    for binding_index, buffer in buffers.items():
+    for index, buffer in buffers.items():
         bindings.append(
             {
-                "binding": binding_index,
+                "binding": index,
                 "resource": {"buffer": buffer, "offset": 0, "size": buffer.size},
             }
         )
         binding_layouts.append(
             {
-                "binding": binding_index,
+                "binding": index,
                 "visibility": wgpu.ShaderStage.COMPUTE,
                 "type": wgpu.BindingType.storage_buffer,
                 "has_dynamic_offset": False,
@@ -133,9 +163,53 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
 
     # Read the current data of the output buffers
     output = {}
-    for binding_index, array_type in output_arrays.items():
-        buffer = buffers[binding_index]
-        array_uint8 = buffer.map(wgpu.MapMode.READ)  # slow, can also be done async
-        output[binding_index] = array_type.from_buffer(array_uint8)
+    for index, info in output_infos.items():
+        buffer = buffers[index]
+        m = buffer.map(wgpu.MapMode.READ)  # slow, can also be done async
+        buffer.unmap()
+        if "ctypes_array_type" in info:
+            output[index] = info["ctypes_array_type"].from_buffer(m)
+        else:
+            output[index] = m.cast(info["format"], shape=info["shape"])
 
     return output
+
+
+FORMAT_SIZES = {"b": 1, "B": 1, "h": 2, "H": 2, "i": 4, "I": 4, "e": 2, "f": 4}
+
+FORMAT_MAP = {
+    # Alt struct types
+    "?": "B",
+    "c": "B",
+    "l": "i",
+    "L": "I",
+    # Numpy-ish
+    "int8": "b",
+    "uint8": "B",
+    "in16": "h",
+    "uint16": "H",
+    "int32": "i",
+    "uint32": "I",
+    "float16": "e",
+    "float32": "f",
+    # Short notation
+    "i8": "b",
+    "u8": "B",
+    "i16": "h",
+    "u16": "H",
+    "i32": "i",
+    "u32": "I",
+    "f16": "e",
+    "f32": "f",
+    # Alt short notation
+    "i1": "b",
+    "u1": "B",
+    "i2": "h",
+    "u2": "H",
+    "i4": "i",
+    "u4": "I",
+    "f2": "e",
+    "f4": "f",
+}
+
+FORMAT_MAP.update({k: k for k in FORMAT_SIZES})


### PR DESCRIPTION
Closes #98 

* [x] Implement `write_buffer`.
* [x] Implement `write_texture`.
* [x] Unit tests.
* [x] Test that we don't need to hold on to the data reference.
* [x] Document the above.
* [x] No more need for ctypes (see #98).
* [x] Update changelog.
* [x] Somehow guard user from using mapped memory when buffer is unmapped. Look at wgpu-rs and WebGPU?
* [x] WebGPU removed `createBufferMapped` (but forgot to remove all references, which got me confused). Use `buffer.getMappedRange` instead.