### PR TITLE
Request draw

### DIFF
--- a/docs/reference_gui.rst
+++ b/docs/reference_gui.rst
@@ -53,9 +53,8 @@ library you are using by looking what module has been imported.
     # Instantiate the canvas
     canvas = WgpuCanvas(title="Example")
 
-    # Tell the canvas what function to draw to update itself.
-    # Alternatively you can create a subclass and implement draw_frame().
-    canvas.draw_frame = your_draw_function
+    # Tell the canvas what drawing function to call
+    canvas.request_draw(your_draw_function)
 
     # Enter Qt's event loop, as usual
     app.exec_()
@@ -83,9 +82,8 @@ Glfw is a lightweight windowing toolkit. Install it with ``pip install glfw``.
     # Instantiate the canvas
     canvas = WgpuCanvas(title="Example")
 
-    # Tell the canvas what function to draw to update itself.
-    # Alternatively you can create a subclass and implement draw_frame().
-    canvas.draw_frame = your_draw_function
+    # Tell the canvas what drawing function to call
+    canvas.request_draw(your_draw_function)
 
     # Enter a main loop (this stops when all windows are closed)
     while update_glfw_canvasses():

--- a/examples/cube_glfw.py
+++ b/examples/cube_glfw.py
@@ -371,7 +371,7 @@ def draw_frame():
     canvas.request_draw()
 
 
-canvas.draw_frame = draw_frame
+canvas.request_draw(draw_frame)
 
 
 # %% Run the event loop

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -136,4 +136,4 @@ def _main(canvas, device):
             render_pass.end_pass()
             device.default_queue.submit([command_encoder.finish()])
 
-    canvas.draw_frame = draw_frame
+    canvas.request_draw(draw_frame)

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -301,7 +301,7 @@ def render_to_screen(
             render_pass.end_pass()
             device.default_queue.submit([command_encoder.finish()])
 
-    canvas.draw_frame = draw_frame
+    canvas.request_draw(draw_frame)
 
     # Enter main loop
     while update_glfw_canvasses():

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -97,7 +97,7 @@ def test_glfw_canvas_render():
         frame_counter += 1
         draw_frame1()
 
-    canvas.draw_frame = draw_frame2
+    canvas.request_draw(draw_frame2)
 
     # Give it a few rounds to start up
     for i in range(5):

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -69,7 +69,7 @@ class WgpuCanvasBase(WgpuCanvasInterface):
 
     def draw_frame(self):
         """ The function that gets called at each draw. You can implement
-        this method in a subclass, or assign the attribute directly.
+        this method in a subclass, or set it via a call to request_draw().
         """
         pass
 

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -73,6 +73,15 @@ class WgpuCanvasBase(WgpuCanvasInterface):
         """
         pass
 
+    def request_draw(self, draw_function=None):
+        """ Request from the main loop to schedule a new draw event,
+        so that the canvas will be updated. If draw_function is not
+        given, the last set drawing function is used.
+        """
+        if draw_function is not None:
+            self.draw_frame = draw_function
+        self._request_draw()
+
     def _draw_frame_and_present(self):
         """ Draw the frame and present the swapchain. Errors are logged to the
         "wgpu" logger. Should be called by the subclass at an appropriate time.
@@ -125,12 +134,6 @@ class WgpuCanvasBase(WgpuCanvasInterface):
         """
         raise NotImplementedError()
 
-    def request_draw(self):
-        """ Request from the main loop to schedule a new draw event,
-        so that the canvas will be updated.
-        """
-        raise NotImplementedError()
-
     def close(self):
         """ Close the window.
         """
@@ -139,4 +142,7 @@ class WgpuCanvasBase(WgpuCanvasInterface):
     def is_closed(self):
         """ Get whether the window is closed.
         """
+        raise NotImplementedError()
+
+    def _request_draw(self):
         raise NotImplementedError()

--- a/wgpu/gui/flexx.py
+++ b/wgpu/gui/flexx.py
@@ -27,7 +27,7 @@ class WgpuCanvas(flx.CanvasWidget):
         self._draw_pending = False
         self.draw_frame()
 
-    def request_draw(self):
+    def _request_draw(self):
         if not self._draw_pending:
             self._draw_pending = True
             window.requestAnimationFrame(self._draw_frame_and_present)

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -181,7 +181,7 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
         self._logical_size = float(width), float(height)
         self._set_logical_size()
 
-    def request_draw(self):
+    def _request_draw(self):
         self._need_draw = True
         glfw.post_empty_event()  # Awake the event loop, if it's in wait-mode
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -108,7 +108,7 @@ class QtWgpuCanvas(WgpuCanvasBase, QtWidgets.QWidget):
             raise ValueError("Window width and height must not be negative")
         self.resize(width, height)  # See note on pixel ratio below
 
-    def request_draw(self):
+    def _request_draw(self):
         self.update()
 
     def close(self):


### PR DESCRIPTION
Closes #101 

The `canvas.request_draw()` method can now be given a callable, which will be used to draw the frame. This way there is no need to set `canvas.draw_frame`. Less API!

The argument is optional, which means it can be called once with the drawing function, and later it can be called from code that simply wants to schedule a new draw and may not be aware of the drawing function. Plus it makes things backwards compatible.