### PR TITLE
debug mode via WGPU_DEBUG

### DIFF
--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -98,8 +98,10 @@ def main(version, os_string, arch, upstream):
         extract_file(zip_filename, headerfile, RESOURCE_DIR)
         print(f"Extracting {binaryfile} to {RESOURCE_DIR}")
         extract_file(zip_filename, binaryfile, RESOURCE_DIR)
-        os.rename(os.path.join(RESOURCE_DIR, binaryfile),
-                  os.path.join(RESOURCE_DIR, binaryfile_name))
+        os.rename(
+            os.path.join(RESOURCE_DIR, binaryfile),
+            os.path.join(RESOURCE_DIR, binaryfile_name),
+        )
     current_version = get_current_version()
     if version != current_version:
         print(f"Version changed, updating {VERSION_FILE}")

--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -45,15 +45,15 @@ def download_file(url, filename):
             fh.write(chunk)
 
 
-def extract_files(zip_filename, members, path):
+def extract_file(zip_filename, member, path):
     z = ZipFile(zip_filename)
-    for member in members:
-        z.extract(member, path=path)
-        if member.endswith(".h") and FORCE_SIMPLE_NEWLINES:
-            filename = os.path.join(path, member)
-            bb = open(filename, "rb").read()
-            with open(filename, "wb") as f:
-                f.write(bb.replace(b"\r\n", b"\n"))
+    os.makedirs(path, exist_ok=True)
+    z.extract(member, path=path)
+    if member.endswith(".h") and FORCE_SIMPLE_NEWLINES:
+        filename = os.path.join(path, member)
+        bb = open(filename, "rb").read()
+        with open(filename, "wb") as f:
+            f.write(bb.replace(b"\r\n", b"\n"))
 
 
 def get_os_string():
@@ -74,24 +74,32 @@ def get_arch():
     return "64" if sys.maxsize > 2 ** 32 else "32"  # True on 64-bit Python interpreters
 
 
-def main(version, os_string, arch, upstream, build):
-    filename = f"wgpu-{os_string}-{arch}-{build}.zip"
-    url = f"https://github.com/{upstream}/releases/download/v{version}/{filename}"
-    tmp = tempfile.gettempdir()
-    zip_filename = os.path.join(tmp, filename)
-    print(f"Downloading {url} to {zip_filename}")
-    download_file(url, zip_filename)
-    members = ["wgpu.h"]
-    if os_string == "linux":
-        members.append("libwgpu_native.so")
-    elif os_string == "macos":
-        members.append("libwgpu_native.dylib")
-    elif os_string == "windows":
-        members.append("wgpu_native.dll")
-    else:
-        raise RuntimeError(f"Platform '{os_string}' not supported")
-    print(f"Extracting {members} to {RESOURCE_DIR}")
-    extract_files(zip_filename, members, RESOURCE_DIR)
+def main(version, os_string, arch, upstream):
+    for build in ("release", "debug"):
+        filename = f"wgpu-{os_string}-{arch}-{build}.zip"
+        url = f"https://github.com/{upstream}/releases/download/v{version}/{filename}"
+        tmp = tempfile.gettempdir()
+        zip_filename = os.path.join(tmp, filename)
+        print(f"Downloading {url} to {zip_filename}")
+        download_file(url, zip_filename)
+        headerfile = "wgpu.h"
+        binaryfile = None
+        if os_string == "linux":
+            binaryfile = "libwgpu_native.so"
+        elif os_string == "macos":
+            binaryfile = "libwgpu_native.dylib"
+        elif os_string == "windows":
+            binaryfile = "wgpu_native.dll"
+        else:
+            raise RuntimeError(f"Platform '{os_string}' not supported")
+        root, ext = os.path.splitext(binaryfile)
+        binaryfile_name = root + "-" + build + ext
+        print(f"Extracting {headerfile} to {RESOURCE_DIR}")
+        extract_file(zip_filename, headerfile, RESOURCE_DIR)
+        print(f"Extracting {binaryfile} to {RESOURCE_DIR}")
+        extract_file(zip_filename, binaryfile, RESOURCE_DIR)
+        os.rename(os.path.join(RESOURCE_DIR, binaryfile),
+                  os.path.join(RESOURCE_DIR, binaryfile_name))
     current_version = get_current_version()
     if version != current_version:
         print(f"Version changed, updating {VERSION_FILE}")
@@ -133,13 +141,6 @@ if __name__ == "__main__":
         help=f"Upstream repository to download release from (default: {upstream})",
         default=upstream,
     )
-    build = "release"
-    parser.add_argument(
-        "--build",
-        help=f"Type of build to download (default: {build})",
-        default=build,
-        choices=("debug", "release"),
-    )
     args = parser.parse_args()
 
-    main(args.version, args.os, args.arch, args.upstream, args.build)
+    main(args.version, args.os, args.arch, args.upstream)

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -90,13 +90,17 @@ def _get_wgpu_lib_path():
     if override_path:
         return override_path
 
+    # Load the debug binary if requested
+    debug_mode = bool(os.getenv("WGPU_DEBUG", "").strip())
+    build = "debug" if debug_mode else "release"
+
     # Get lib filename for supported platforms
     if sys.platform.startswith("win"):  # no-cover
-        lib_filename = "wgpu_native.dll"
+        lib_filename = f"wgpu_native-{build}.dll"
     elif sys.platform.startswith("darwin"):  # no-cover
-        lib_filename = "libwgpu_native.dylib"
+        lib_filename = f"libwgpu_native-{build}.dylib"
     elif sys.platform.startswith("linux"):  # no-cover
-        lib_filename = "libwgpu_native.so"
+        lib_filename = f"libwgpu_native-{build}.so"
     else:  # no-cover
         raise RuntimeError(
             f"No WGPU library shipped for platform {sys.platform}. Set WGPU_LIB_PATH instead."

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -91,7 +91,7 @@ def _get_wgpu_lib_path():
         return override_path
 
     # Load the debug binary if requested
-    debug_mode = bool(os.getenv("WGPU_DEBUG", "").strip())
+    debug_mode = os.getenv("WGPU_DEBUG", "").strip() == "1"
     build = "debug" if debug_mode else "release"
 
     # Get lib filename for supported platforms


### PR DESCRIPTION
Closes #108

With this change, we package both the release and the debug build of wgpu-native and allow users to load the debug build by setting the environment variable `WGPU_DEBUG=1`