### PR TITLE
Improve wayland support ... a bit

### DIFF
--- a/examples/cube_glfw.py
+++ b/examples/cube_glfw.py
@@ -17,6 +17,7 @@ from pyshader import Struct, mat4, vec4, vec2
 
 # Create a canvas to render to
 glfw.init()
+glfw.ERROR_REPORTING = "warn"
 canvas = WgpuCanvas(title="wgpu cube with GLFW")
 
 # Create a wgpu device

--- a/examples/triangle_glfw.py
+++ b/examples/triangle_glfw.py
@@ -15,6 +15,7 @@ from triangle import main
 
 
 glfw.init()
+glfw.ERROR_REPORTING = "warn"
 canvas = WgpuCanvas(title="wgpu triangle with GLFW")
 main(canvas)
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -21,6 +21,11 @@ else:
         "Import one of PySide2, PyQt5 before the WgpuCanvas to select a Qt toolkit"
     )
 
+# Make Qt not ignore XDG_SESSION_TYPE
+# is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+# if is_wayland:
+#     os.environ["QT_QPA_PLATFORM"] = "wayland"
+
 
 def enable_hidpi():
     """ Enable high-res displays.


### PR DESCRIPTION
This gets things running a bit better on Wayland. Things are still far from great, that is mostly due to Wayland or Glfw or the integration between the two.

* Can now run glfw examples.
* Still no Qt yet.
* Fixed recursion error.
* Fixed weird window sizing behavior (might be an issue specific to hidpi screens on Wayland).
* In the examples, prevent glfw from shutting down on Wayland warnings.
