### PR TITLE
Fix usage of GlobalInvocationid

### DIFF
--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -6,7 +6,7 @@ buffer into another.
 import wgpu
 import wgpu.backends.rs  # Select backend
 from wgpu.utils import compute_with_buffers  # Convenience function
-from pyshader import python2shader, i32, Array
+from pyshader import python2shader, ivec3, i32, Array
 
 
 # %% Shader and data
@@ -14,11 +14,12 @@ from pyshader import python2shader, i32, Array
 
 @python2shader
 def compute_shader(
-    index: ("input", "GlobalInvocationId", i32),
+    index: ("input", "GlobalInvocationId", ivec3),
     data1: ("buffer", 0, Array(i32)),
     data2: ("buffer", 1, Array(i32)),
 ):
-    data2[index] = data1[index]
+    i = index.x
+    data2[i] = data1[i]
 
 
 # Create input data as a memoryview

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -2,7 +2,7 @@ import random
 import ctypes
 from ctypes import c_int32, c_ubyte
 
-from pyshader import python2shader, Array, i32
+from pyshader import python2shader, Array, i32, ivec3
 import wgpu.backends.rs  # noqa
 from wgpu.utils import compute_with_buffers
 
@@ -17,9 +17,9 @@ if not can_use_wgpu_lib:
 def test_compute_0_1_ctype():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32), out: ("buffer", 0, Array(i32)),
+        index: ("input", "GlobalInvocationId", ivec3), out: ("buffer", 0, Array(i32)),
     ):
-        out[index] = index
+        out[index.x] = index.x
 
     # Create some ints!
     out = compute_with_buffers({}, {0: c_int32 * 100}, compute_shader)
@@ -38,9 +38,9 @@ def test_compute_0_1_ctype():
 def test_compute_0_1_tuple():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32), out: ("buffer", 0, Array(i32)),
+        index: ("input", "GlobalInvocationId", ivec3), out: ("buffer", 0, Array(i32)),
     ):
-        out[index] = index
+        out[index.x] = index.x
 
     out = compute_with_buffers({}, {0: (100, "i")}, compute_shader)
     assert isinstance(out, dict) and len(out) == 1
@@ -51,9 +51,9 @@ def test_compute_0_1_tuple():
 def test_compute_0_1_str():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32), out: ("buffer", 0, Array(i32)),
+        index: ("input", "GlobalInvocationId", ivec3), out: ("buffer", 0, Array(i32)),
     ):
-        out[index] = index
+        out[index.x] = index.x
 
     out = compute_with_buffers({}, {0: "100xi"}, compute_shader)
     assert isinstance(out, dict) and len(out) == 1
@@ -64,9 +64,9 @@ def test_compute_0_1_str():
 def test_compute_0_1_int():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32), out: ("buffer", 0, Array(i32)),
+        index: ("input", "GlobalInvocationId", ivec3), out: ("buffer", 0, Array(i32)),
     ):
-        out[index] = index
+        out[index.x] = index.x
 
     out = compute_with_buffers({}, {0: 400}, compute_shader)
     assert isinstance(out, dict) and len(out) == 1
@@ -77,13 +77,14 @@ def test_compute_0_1_int():
 def test_compute_1_3():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32),
+        index: ("input", "GlobalInvocationId", ivec3),
         in1: ("buffer", 0, Array(i32)),
         out1: ("buffer", 1, Array(i32)),
         out2: ("buffer", 2, Array(i32)),
     ):
-        out1[index] = in1[index]
-        out2[index] = index
+        i = index.x
+        out1[i] = in1[i]
+        out2[i] = i
 
     # Create an array of 100 random int32
     in1 = [int(random.uniform(0, 100)) for i in range(100)]
@@ -103,11 +104,11 @@ def test_compute_1_3():
 def test_compute_indirect():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32),
+        index: ("input", "GlobalInvocationId", ivec3),
         data1: ("buffer", 0, Array(i32)),
         data2: ("buffer", 1, Array(i32)),
     ):
-        data2[index] = data1[index] + 1
+        data2[index.x] = data1[index.x] + 1
 
     # Create an array of 100 random int32
     n = 100
@@ -189,11 +190,11 @@ def test_compute_indirect():
 def test_compute_fails():
     @python2shader
     def compute_shader(
-        index: ("input", "GlobalInvocationId", i32),
+        index: ("input", "GlobalInvocationId", ivec3),
         in1: ("buffer", 0, Array(i32)),
         out1: ("buffer", 1, Array(i32)),
     ):
-        out1[index] = in1[index]
+        out1[index.x] = in1[index.x]
 
     in1 = [int(random.uniform(0, 100)) for i in range(100)]
     in1 = (c_int32 * 100)(*in1)

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -52,9 +52,10 @@ def test_glfw_canvas_basics():
 
     # Close
     assert not canvas.is_closed()
-    canvas.close()
-    glfw.poll_events()
-    assert canvas.is_closed()
+    if sys.platform.startswith("win"):  # On Linux we cant do this multiple times
+        canvas.close()
+        glfw.poll_events()
+        assert canvas.is_closed()
 
 
 @python2shader
@@ -126,7 +127,7 @@ def test_glfw_canvas_render():
     # We should have had just one draw
     assert frame_counter == 3
 
-    canvas.close()
+    # canvas.close()
     glfw.poll_events()
 
 

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -100,9 +100,9 @@ def test_struct_checking():
 
 @pyshader.python2shader
 def compute_shader(
-    index: ("input", "GlobalInvocationId", "i32"), out: ("buffer", 0, "Array(i32)"),
+    index: ("input", "GlobalInvocationId", "ivec3"), out: ("buffer", 0, "Array(i32)"),
 ):
-    out[index] = index
+    out[index.x] = index.x
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -16,7 +16,6 @@ class WgpuCanvasInterface:
     def __init__(self, *args, **kwargs):
         # The args/kwargs are there because we may be mixed with e.g. a Qt widget
         super().__init__(*args, **kwargs)
-        self._display_id = None
 
     def get_window_id(self):
         """ Get the native window id. This is used by the backends
@@ -30,7 +29,7 @@ class WgpuCanvasInterface:
         the X11 lib to get the display id.
         """
         # Re-use to avoid creating loads of id's
-        if self._display_id is not None:
+        if getattr(self, "_display_id", None) is not None:
             return self._display_id
 
         if sys.platform.startswith("linux"):

--- a/wgpu/utils/_compute.py
+++ b/wgpu/utils/_compute.py
@@ -26,7 +26,8 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
             specify the shape. These are used to ``cast()`` the
             memoryview object before it is returned. If the value is a
             ctypes array type, the result will be cast to that instead
-            of a memoryview.
+            of a memoryview. Note that any buffer that is NOT in the
+            output arrays dict will be considered readonly in the shader.
         shader (bytes, shader-object): The SpirV representing the shader,
             as raw bytes or an object implementing ``to_spirv()``
             (e.g. a pyshader SpirV module).

--- a/wgpu/utils/_compute.py
+++ b/wgpu/utils/_compute.py
@@ -141,11 +141,15 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
                 "resource": {"buffer": buffer, "offset": 0, "size": buffer.size},
             }
         )
+        storage_types = (
+            wgpu.BindingType.readonly_storage_buffer,
+            wgpu.BindingType.storage_buffer,
+        )
         binding_layouts.append(
             {
                 "binding": index,
                 "visibility": wgpu.ShaderStage.COMPUTE,
-                "type": wgpu.BindingType.storage_buffer,
+                "type": storage_types[index in output_infos],
                 "has_dynamic_offset": False,
             }
         )


### PR DESCRIPTION
* Fix all occurrences of `GlobalInvocationid` to type it as `ivec3` instead of `i32`.
* Fix glfw tests on Linux
* Change `compute_with_buffers()` so that buffers not marked for output are readonly in the shader.