### PR TITLE
Limit FPS for request_draw in Qt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@ import re
 import sys
 
 from setuptools import find_packages, setup
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from wheel.pep425tags import get_platform
+from wheel.bdist_wheel import get_platform, bdist_wheel as _bdist_wheel
 
 
 NAME = "wgpu"

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -76,6 +76,7 @@ class QtWgpuCanvas(WgpuCanvasBase, QtWidgets.QWidget):
         # A timer for limiting fps
         self._target_fps = 30  # subclasses could edit this value
         self._request_draw_timer = QtCore.QTimer()
+        self._request_draw_timer.setTimerType(QtCore.Qt.PreciseTimer)
         self._request_draw_timer.setSingleShot(True)
         self._request_draw_timer.timeout.connect(self.update)
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -4,6 +4,7 @@ can be used as a standalone window or in a larger GUI.
 """
 
 import sys
+import time
 import ctypes
 import importlib
 
@@ -72,6 +73,12 @@ class QtWgpuCanvas(WgpuCanvasBase, QtWidgets.QWidget):
         self.setLayout(layout)
         layout.addWidget(self._subwidget)
 
+        # A timer for limiting fps
+        self._target_fps = 30  # subclasses could edit this value
+        self._request_draw_timer = QtCore.QTimer()
+        self._request_draw_timer.setSingleShot(True)
+        self._request_draw_timer.timeout.connect(self.update)
+
         self.show()
 
     # Qt methods
@@ -114,7 +121,11 @@ class QtWgpuCanvas(WgpuCanvasBase, QtWidgets.QWidget):
         self.resize(width, height)  # See note on pixel ratio below
 
     def _request_draw(self):
-        self.update()
+        if not self._request_draw_timer.isActive():
+            now = time.perf_counter()
+            target_time = self._subwidget._draw_time + 1 / self._target_fps
+            wait_time = max(0, target_time - now)
+            self._request_draw_timer.start(wait_time * 1000)
 
     def close(self):
         super().close()
@@ -131,12 +142,14 @@ class WgpuSubWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_PaintOnScreen, True)
         self.setAutoFillBackground(False)
+        self._draw_time = 0
 
     def paintEngine(self):  # noqa: N802 - this is a Qt method
         # https://doc.qt.io/qt-5/qt.html#WidgetAttribute-enum  WA_PaintOnScreen
         return None
 
     def paintEvent(self, event):  # noqa: N802 - this is a Qt method
+        self._draw_time = time.perf_counter()
         self.parent()._draw_frame_and_present()
 
 


### PR DESCRIPTION
GLFW has an inherent different loop, where you basically need to write the mainloop yourself, and this is where you'd implement FPS limiting. See the `triangle_glfw.py` example.