### PR TITLE
Mark props as @apidiff.add

### DIFF
--- a/wgpu/_coreutils.py
+++ b/wgpu/_coreutils.py
@@ -65,7 +65,8 @@ class ApiDiff:
     def _diff(self, method, func_or_text):
         def wrapper(f):
             d = getattr(self, method)
-            d[f.__qualname__] = text
+            name = f.__qualname__ if hasattr(f, "__qualname__") else f.fget.__qualname__
+            d[name] = text
             return f
 
         if callable(func_or_text):

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -726,13 +726,13 @@ class GPUBuffer(GPUObjectBase):
         self._state = state
         self._map_mode = 3 if state == "mapped at creation" else 0
 
-    # FIXME: unknown api: prop GPUBuffer.size
+    @apidiff.add("Too useful to not-have")
     @property
     def size(self):
         """The length of the GPUBuffer allocation in bytes."""
         return self._size
 
-    # FIXME: unknown api: prop GPUBuffer.usage
+    @apidiff.add("Too useful to not-have")
     @property
     def usage(self):
         """The allowed usages (int bitmap) for this GPUBuffer, specifying
@@ -835,39 +835,39 @@ class GPUTexture(GPUObjectBase):
         super().__init__(label, internal, device)
         self._tex_info = tex_info
 
-    # FIXME: unknown api: prop GPUTexture.texture_size
+    @apidiff.add("Too useful to not-have")
     @property
-    def texture_size(self):
+    def size(self):
         """The size of the texture in mipmap level 0, as a 3-tuple of ints."""
         return self._tex_info["size"]
 
-    # FIXME: unknown api: prop GPUTexture.mip_level_count
+    @apidiff.add("Too useful to not-have")
     @property
     def mip_level_count(self):
         """The total number of the mipmap levels of the texture."""
         return self._tex_info["mip_level_count"]
 
-    # FIXME: unknown api: prop GPUTexture.sample_count
+    @apidiff.add("Too useful to not-have")
     @property
     def sample_count(self):
         """The number of samples in each texel of the texture."""
         return self._tex_info["sample_count"]
 
-    # FIXME: unknown api: prop GPUTexture.dimension
+    @apidiff.add("Too useful to not-have")
     @property
     def dimension(self):
         """The dimension of the texture."""
         return self._tex_info["dimension"]
 
-    # FIXME: unknown api: prop GPUTexture.format
+    @apidiff.add("Too useful to not-have")
     @property
     def format(self):
         """The format of the texture."""
         return self._tex_info["format"]
 
-    # FIXME: unknown api: prop GPUTexture.texture_usage
+    @apidiff.add("Too useful to not-have")
     @property
-    def texture_usage(self):  # Not sure why there's a "texture_" prefix
+    def usage(self):
         """The allowed usages for this texture."""
         return self._tex_info["usage"]
 
@@ -923,13 +923,13 @@ class GPUTextureView(GPUObjectBase):
         self._texture = texture
         self._size = size
 
-    # FIXME: unknown api: prop GPUTextureView.size
+    @apidiff.add("Too useful to not-have")
     @property
     def size(self):
         """The texture size (as a 3-tuple)."""
         return self._size
 
-    # FIXME: unknown api: prop GPUTextureView.texture
+    @apidiff.add("Too useful to not-have")
     @property
     def texture(self):
         """The texture object to which this is a view."""
@@ -1010,12 +1010,6 @@ class GPUPipelineBase:
     def __init__(self, label, internal, device, layout):
         super().__init__(label, internal, device)
         self._layout = layout
-
-    # FIXME: unknown api: prop GPUPipelineBase.layout
-    @property
-    def layout(self):
-        """The layout of this pipeline."""
-        return self._layout
 
     # IDL: GPUBindGroupLayout getBindGroupLayout(unsigned long index);
     def get_bind_group_layout(self, index):

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -9,19 +9,17 @@
 * Wrote 26 enums to enums.py
 * Wrote 45 structs to structs.py
 ### Patching API for base.py
-* Warning: unknown api: prop GPUBuffer.size
-* Warning: unknown api: prop GPUBuffer.usage
-* Warning: unknown api: prop GPUTexture.texture_size
-* Warning: unknown api: prop GPUTexture.mip_level_count
-* Warning: unknown api: prop GPUTexture.sample_count
-* Warning: unknown api: prop GPUTexture.dimension
-* Warning: unknown api: prop GPUTexture.format
-* Warning: unknown api: prop GPUTexture.texture_usage
-* Warning: unknown api: prop GPUTextureView.size
-* Warning: unknown api: prop GPUTextureView.texture
-* Warning: unknown api: prop GPUPipelineBase.layout
-* Validated 34 classes, 108 methods, 28 properties
+* Diffs for GPU: change request_adapter, change request_adapter_async
+* Diffs for GPUDevice: add create_buffer_with_data, hide create_buffer_mapped, hide pop_error_scope, hide push_error_scope
+* Diffs for GPUBuffer: add read_data, add read_data_async, add size, add usage, add write_data, hide get_mapped_range, hide map_async, hide unmap
+* Diffs for GPUTexture: add dimension, add format, add mip_level_count, add sample_count, add size, add usage
+* Diffs for GPUTextureView: add size, add texture
+* Diffs for GPUComputePassEncoder: hide begin_pipeline_statistics_query, hide end_pipeline_statistics_query
+* Diffs for GPURenderPassEncoder: hide begin_pipeline_statistics_query, hide end_pipeline_statistics_query
+* Diffs for GPUQueue: hide create_fence, hide signal
+* Validated 34 classes, 108 methods, 27 properties
 ### Patching API for backends/rs.py
+* Diffs for GPUAdapter: add request_device_tracing
 * Validated 34 classes, 88 methods, 0 properties
 ## Validating rs.py
 * Flag field BufferUsage.QUERY_RESOLVE missing in wgpu.h


### PR DESCRIPTION
The WebGPU spec does not expose properties like `buffer.size`. It is recognized that these are very useful though, and there are discussions to some let the API expose them. See e.g. https://github.com/gpuweb/gpuweb/issues/1498.

Since we also make use of some of these in pygfx, I think it makes sense to (for now) deviate from the WebGPU API. 