### PR TITLE
Add support for WGSL

### DIFF
--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -694,9 +694,11 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
 
         if isinstance(code, str):
             # WGSL
+            # H: chain: WGPUChainedStruct, source: const char
             source_struct = new_struct_p(
                 "WGPUShaderModuleWGSLDescriptor *",
                 source=ffi.new("char []", code.encode()),
+                # not used: chain
             )
             source_struct[0].chain.next = ffi.NULL
             source_struct[0].chain.s_type = lib.WGPUSType_ShaderModuleWGSLDescriptor

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -539,8 +539,8 @@ class GPUDevice(GPUObjectBase):
 
         Arguments:
             label (str): A human readable label. Optional.
-            code (bytes): The shadercode, as binary SpirV, or an object
-                implementing ``to_spirv()`` or ``to_bytes()``.
+            code (str | bytes): The shadercode, as WGSL text or binary SpirV
+            (or an object implementing ``to_spirv()`` or ``to_bytes()``).
         """
         raise NotImplementedError()
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -61,4 +61,4 @@
 * Wrote 134 enum mappings and 38 struct-field mappings to rs_mappings.py
 * Validated 81 C function calls
 * Not using 26 C functions
-* Validated 61 C structs
+* Validated 62 C structs


### PR DESCRIPTION
This allows consuming WGSL in addition to SpirV.

I'm having some trouble rewriting the examples though, and the error messages are not very helpful, e.g.:
```
Running script: "C:\dev\pylib\wgpu\examples\triangle_glfw.py"
|	[[stage(vertex)]]
>	fn vs_main([[builtin(vertex_index)]] index: u32) -> [[builtin(position)]] vec4<f32> {
|	             ^
thread '<unnamed>' panicked at 'Parsing', src\device.rs:694:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I'm having more luck by using Naga to compile some wgsl to spirv and then using that. This suggests that we may just need a newer version of wgpu-native that has a newer naga. But even then, arrays seem problematic, or I am doing them wrong.

We can merge this as-is and continue when we've updated to a more recent wgpu-native.
 