### PR TITLE
Update to wgpu-native 0.8.0.2

### DIFF
--- a/codegen/rspatcher.py
+++ b/codegen/rspatcher.py
@@ -109,6 +109,28 @@ def write_mappings():
         pylines.append(f'    "{key}": {cstructfield2enum[key]!r},')
     pylines.append("}\n")
 
+    # Write a few native-only mappings: key => int
+    pylines.append("enum_str2int = {")
+    for name in ["BackendType"]:
+        pylines.append(f'    "{name}":' + " {")
+        for key, val in hp.enums[name].items():
+            if key == "Force32":
+                continue
+            pylines.append(f'        "{key}": {val},')
+        pylines.append("    }")
+    pylines.append("}")
+
+    # Write a few native-only mappings: int => key
+    pylines.append("enum_int2str = {")
+    for name in ["BackendType", "AdapterType"]:
+        pylines.append(f'    "{name}":' + " {")
+        for key, val in hp.enums[name].items():
+            if key == "Force32":
+                continue
+            pylines.append(f'        {val}: "{key}",')
+        pylines.append("    },")
+    pylines.append("}")
+
     # Wrap up
     code = blacken("\n".join(pylines))  # just in case; code is already black
     with open(os.path.join(lib_dir, "backends", "rs_mappings.py"), "wb") as f:

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -492,9 +492,11 @@ def render_textured_square(fragment_shader, texture_format, texture_size, textur
     # Determine sampler type.
     # Note that integer texture types cannot even use a sampler.
     sampler_type = wgpu.SamplerBindingType.filtering
-    if "32float" in texture_format:
-        sampler_type = wgpu.SamplerBindingType.non_filtering
-        texture_sample_type = wgpu.TextureSampleType.unfilterable_float
+    # On Vanilla wgpu, float32 textures cannot use a filtering
+    # (interpolating) texture, but we request a feature so that we can.
+    # if "32float" in texture_format:
+    #     sampler_type = wgpu.SamplerBindingType.non_filtering
+    #     texture_sample_type = wgpu.TextureSampleType.unfilterable_float
 
     # Bindings and layout
     bindings = [

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -53,8 +53,8 @@ logger = logging.getLogger("wgpu")  # noqa
 apidiff = ApiDiff()
 
 # The wgpu-native version that we target/expect
-__version__ = "0.8.0.1"
-__commit_sha__ = "691468c9817b51a81530fb277a9b30fcc4a71ea7"
+__version__ = "0.8.0.2"
+__commit_sha__ = "66a4139579f2499a67b7ade1a6c3bcb414046c64"
 version_info = tuple(map(int, __version__.split(".")))
 check_expected_version(version_info)  # produces a warning on mismatch
 

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -41,7 +41,7 @@ from .. import _register_backend
 from .._coreutils import ApiDiff
 
 from .rs_ffi import ffi, lib, check_expected_version
-from .rs_mappings import cstructfield2enum, enummap
+from .rs_mappings import cstructfield2enum, enummap, enum_str2int, enum_int2str
 from .rs_helpers import (
     get_surface_id_from_canvas,
     get_memoryview_from_address,
@@ -212,12 +212,27 @@ class GPU(base.GPU):
         else:
             surface_id = get_surface_id_from_canvas(canvas)
 
+        # Force Vulkan on Windows, to avoid DX12 which seems to ignore
+        # the NVidia control panel settings. I guess Vulkan is more
+        # mature than Metal too, so let's just force that for now.
+        # see https://github.com/gfx-rs/wgpu/issues/1416
+        # force_backend = lib.WGPUBackendType_Vulkan
+        force_backend = enum_str2int["BackendType"]["Vulkan"]
+
+        # H: chain: WGPUChainedStruct, backend: WGPUBackendType
+        extras = new_struct_p(
+            "WGPUAdapterExtras *",
+            backend=force_backend,
+            # not used: chain
+        )
+        extras.chain.sType = lib.WGPUSType_AdapterExtras
+
         # Convert the descriptor
         # H: nextInChain: WGPUChainedStruct *, compatibleSurface: WGPUSurface
         struct = new_struct_p(
             "WGPURequestAdapterOptions *",
             compatibleSurface=surface_id,
-            # not used: nextInChain
+            nextInChain=ffi.cast("WGPUChainedStruct * ", extras),
         )
 
         # Do the API call and get the adapter id
@@ -251,16 +266,19 @@ class GPU(base.GPU):
             # not used: backendType
         )
 
-        # todo: This function exists in the headerfile but not in the lib (yet)
         # H: void f(WGPUAdapter adapter, WGPUAdapterProperties * properties)
-        # lib.wgpuAdapterGetProperties(adapter_id, c_properties)
+        lib.wgpuAdapterGetProperties(adapter_id, c_properties)
         properties = {
             "name": "",
             "vendorID": c_properties.vendorID,
             "deviceID": c_properties.deviceID,
             "driverDescription": "",
-            "adapterType": c_properties.adapterType,
-            "backendType": c_properties.backendType,
+            "adapterType": enum_int2str["AdapterType"].get(
+                c_properties.adapterType, "unknown"
+            ),
+            "backendType": enum_int2str["BackendType"].get(
+                c_properties.backendType, "unknown"
+            ),
         }
         if c_properties.name:
             properties["name"] = ffi.string(c_properties.name).decode(errors="ignore")
@@ -335,13 +353,21 @@ class GPUAdapter(base.GPUAdapter):
         limits2 = base.DEFAULT_ADAPTER_LIMITS.copy()
         limits2.update(limits or {})
 
-        # H: chain: WGPUChainedStruct, maxBindGroups: int, label: char*, tracePath: char*
+        # H: chain: WGPUChainedStruct, maxTextureDimension1D: int, maxTextureDimension2D: int, maxTextureDimension3D: int, maxTextureArrayLayers: int, maxBindGroups: int, maxDynamicStorageBuffersPerPipelineLayout: int, maxStorageBuffersPerShaderStage: int, maxStorageBufferBindingSize: int, nativeFeatures: WGPUNativeFeature, label: char*, tracePath: char*
         extras = new_struct_p(
             "WGPUDeviceExtras *",
             label=to_c_label(label),
             maxBindGroups=limits2["max_bind_groups"],
+            maxStorageBuffersPerShaderStage=6,
             tracePath=c_trace_path,
+            nativeFeatures=lib.WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
             # not used: chain
+            # not used: maxTextureDimension1D
+            # not used: maxTextureDimension2D
+            # not used: maxTextureDimension3D
+            # not used: maxTextureArrayLayers
+            # not used: maxDynamicStorageBuffersPerPipelineLayout
+            # not used: maxStorageBufferBindingSize
         )
         extras.chain.sType = lib.WGPUSType_DeviceExtras
 
@@ -917,34 +943,37 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
         if fragment is not None:
             c_color_targets_list = []
             for target in fragment["targets"]:
-                alpha_blend = _tuple_from_tuple_or_dict(
-                    target["blend"]["alpha"],
-                    ("src_factor", "dst_factor", "operation"),
-                )
-                # H: srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor, operation: WGPUBlendOperation
-                c_alpha_blend = new_struct(
-                    "WGPUBlendComponent",
-                    srcFactor=alpha_blend[0],
-                    dstFactor=alpha_blend[1],
-                    operation=alpha_blend[2],
-                )
-                color_blend = _tuple_from_tuple_or_dict(
-                    target["blend"]["color"],
-                    ("src_factor", "dst_factor", "operation"),
-                )
-                # H: srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor, operation: WGPUBlendOperation
-                c_color_blend = new_struct(
-                    "WGPUBlendComponent",
-                    srcFactor=color_blend[0],
-                    dstFactor=color_blend[1],
-                    operation=color_blend[2],
-                )
-                # H: color: WGPUBlendComponent, alpha: WGPUBlendComponent
-                c_blend = new_struct_p(
-                    "WGPUBlendState *",
-                    color=c_color_blend,
-                    alpha=c_alpha_blend,
-                )
+                if not target.get("blend", None):
+                    c_blend = ffi.NULL
+                else:
+                    alpha_blend = _tuple_from_tuple_or_dict(
+                        target["blend"]["alpha"],
+                        ("src_factor", "dst_factor", "operation"),
+                    )
+                    # H: srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor, operation: WGPUBlendOperation
+                    c_alpha_blend = new_struct(
+                        "WGPUBlendComponent",
+                        srcFactor=alpha_blend[0],
+                        dstFactor=alpha_blend[1],
+                        operation=alpha_blend[2],
+                    )
+                    color_blend = _tuple_from_tuple_or_dict(
+                        target["blend"]["color"],
+                        ("src_factor", "dst_factor", "operation"),
+                    )
+                    # H: srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor, operation: WGPUBlendOperation
+                    c_color_blend = new_struct(
+                        "WGPUBlendComponent",
+                        srcFactor=color_blend[0],
+                        dstFactor=color_blend[1],
+                        operation=color_blend[2],
+                    )
+                    # H: color: WGPUBlendComponent, alpha: WGPUBlendComponent
+                    c_blend = new_struct_p(
+                        "WGPUBlendState *",
+                        color=c_color_blend,
+                        alpha=c_alpha_blend,
+                    )
                 # H: nextInChain: WGPUChainedStruct *, format: WGPUTextureFormat, blend: WGPUBlendState *, writeMask: WGPUColorWriteMaskFlags/int
                 c_color_state = new_struct(
                     "WGPUColorTargetState",

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -215,7 +215,7 @@ class GPU(base.GPU):
         # Force Vulkan on Windows, to avoid DX12 which seems to ignore
         # the NVidia control panel settings. I guess Vulkan is more
         # mature than Metal too, so let's just force that for now.
-        # see https://github.com/gfx-rs/wgpu/issues/1416
+        # See https://github.com/gfx-rs/wgpu/issues/1416
         # force_backend = lib.WGPUBackendType_Vulkan
         force_backend = enum_str2int["BackendType"]["Vulkan"]
 
@@ -352,6 +352,11 @@ class GPUAdapter(base.GPUAdapter):
         # Handle default limits
         limits2 = base.DEFAULT_ADAPTER_LIMITS.copy()
         limits2.update(limits or {})
+
+        # Vanilla WGPU does not support interpolating samplers for float32 textures,
+        # which is sad for scientific data in particular. We can enable it
+        # (on the hardware were wgpu-py likely runs) using the feature:
+        # WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
 
         # H: chain: WGPUChainedStruct, maxTextureDimension1D: int, maxTextureDimension2D: int, maxTextureDimension3D: int, maxTextureArrayLayers: int, maxBindGroups: int, maxDynamicStorageBuffersPerPipelineLayout: int, maxStorageBuffersPerShaderStage: int, maxStorageBufferBindingSize: int, nativeFeatures: WGPUNativeFeature, label: char*, tracePath: char*
         extras = new_struct_p(

--- a/wgpu/backends/rs_mappings.py
+++ b/wgpu/backends/rs_mappings.py
@@ -227,3 +227,32 @@ cstructfield2enum = {
     "VertexAttribute.format": "VertexFormat",
     "VertexBufferLayout.stepMode": "InputStepMode",
 }
+
+enum_str2int = {
+    "BackendType": {
+        "Null": 0,
+        "D3D11": 1,
+        "D3D12": 2,
+        "Metal": 3,
+        "Vulkan": 4,
+        "OpenGL": 5,
+        "OpenGLES": 6,
+    }
+}
+enum_int2str = {
+    "BackendType": {
+        0: "Null",
+        1: "D3D11",
+        2: "D3D12",
+        3: "Metal",
+        4: "Vulkan",
+        5: "OpenGL",
+        6: "OpenGLES",
+    },
+    "AdapterType": {
+        0: "DiscreteGPU",
+        1: "IntegratedGPU",
+        2: "CPU",
+        3: "Unknown",
+    },
+}

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -661,13 +661,13 @@ class GPUDevice(GPUObjectBase):
                 "format": wgpu.TextureFormat.depth24plus_stencil8,
                 "depth_write_enabled": False,  # optional
                 "depth_compare": wgpu.CompareFunction.always,  # optional
-                "front": {  # optional
+                "stencil_front": {  # optional
                     "compare": wgpu.CompareFunction.equal,
                     "fail_op": wgpu.StencilOperation.keep,
                     "depth_fail_op": wgpu.StencilOperation.keep,
                     "pass_op": wgpu.StencilOperation.keep,
                 },
-                "back": {  # optional
+                "stencil_back": {  # optional
                     "compare": wgpu.CompareFunction.equal,
                     "fail_op": wgpu.StencilOperation.keep,
                     "depth_fail_op": wgpu.StencilOperation.keep,
@@ -690,7 +690,8 @@ class GPUDevice(GPUObjectBase):
                 "alpha_to_coverage_enabled": False  # optional
             }
 
-        Example fragment (FragmentState) dict:
+        Example fragment (FragmentState) dict. The `blend` parameter can be None
+        to disable blending (not all texture formats support blending).
 
         .. code-block:: py
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -3,7 +3,7 @@
 * The webgpu.idl defines 34 classes with 82 functions
 * The webgpu.idl defines 5 flags, 31 enums, 52 structs
 * The wgpu.h defines 106 functions
-* The wgpu.h defines 5 flags, 36 enums, 58 structs
+* The wgpu.h defines 5 flags, 37 enums, 59 structs
 ## Updating API
 * Wrote 5 flags to flags.py
 * Wrote 31 enums to enums.py
@@ -41,4 +41,4 @@
 * Wrote 169 enum mappings and 45 struct-field mappings to rs_mappings.py
 * Validated 65 C function calls
 * Not using 46 C functions
-* Validated 65 C structs
+* Validated 66 C structs

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,21 +1,18 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu-headers/webgpu.h"
+#include "webgpu.h"
 
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes
     WGPUSType_DeviceExtras = 0x60000001,
+    WGPUSType_AdapterExtras = 0x60000002,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
-
-typedef struct WGPUDeviceExtras {
-    WGPUChainedStruct chain;
-    uint32_t maxBindGroups;
-    const char* label;
-    const char* tracePath;
-} WGPUDeviceExtras;
+typedef enum WGPUNativeFeature {
+    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x10000000
+} WGPUNativeFeature;
 
 typedef enum WGPULogLevel {
     WGPULogLevel_Off = 0x00000000,
@@ -26,6 +23,30 @@ typedef enum WGPULogLevel {
     WGPULogLevel_Trace = 0x00000005,
     WGPULogLevel_Force32 = 0x7FFFFFFF
 } WGPULogLevel;
+
+typedef struct WGPUAdapterExtras {
+    WGPUChainedStruct chain;
+    WGPUBackendType backend;
+} WGPUAdapterExtras;
+
+typedef struct WGPUDeviceExtras {
+    WGPUChainedStruct chain;
+    uint32_t maxTextureDimension1D;
+    uint32_t maxTextureDimension2D;
+    uint32_t maxTextureDimension3D;
+    uint32_t maxTextureArrayLayers;
+    uint32_t maxBindGroups;
+    uint32_t maxDynamicStorageBuffersPerPipelineLayout;
+    uint32_t maxStorageBuffersPerShaderStage;
+    uint32_t maxStorageBufferBindingSize;
+
+    WGPUNativeFeature nativeFeatures;
+
+    const char* label;
+    const char* tracePath;
+} WGPUDeviceExtras;
+
+
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
 
@@ -39,4 +60,4 @@ uint32_t wgpuGetVersion(void);
 
 void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStage stages, uint32_t offset, uint32_t sizeBytes, void* const data);
 
-#endif 
+#endif


### PR DESCRIPTION
This makes it possible for us to:
* Enable a feature so that float32 textures can still be filtered by the sampler.
* Force vulkan to prevent dx12 being selected.
* Obtain adapter properties so we can see what hardware and backend is selected via `adapter.properties`.
* Includes a small fix in the docs wrt stencil front/back.
