### PR TITLE
Force backend by WGPU_BACKEND_TYPE env var

### DIFF
--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -223,24 +223,13 @@ class GPU(base.GPU):
         force_backend = enum_str2int["BackendType"]["Null"]
         if "WGPU_BACKEND_TYPE" in os.environ:
             try:
-                backend = int(os.environ["WGPU_BACKEND_TYPE"])
-                value = next(
-                    (
-                        key
-                        for key, value in enum_str2int["BackendType"].items()
-                        if value == backend
-                    ),
-                    None,
-                )
-                if not value:
-                    logger.warn(f"Invalid value for WGPU_BACKEND_TYPE: '{backend}'")
-                else:
-                    logger.warn(f"Forcing backend: {value} ({backend})")
-                    force_backend = backend
-            except ValueError:
+                backend = os.environ["WGPU_BACKEND_TYPE"]
+                force_backend = enum_str2int["BackendType"][backend]
+                logger.warn(f"Forcing backend: {backend} ({force_backend})")
+            except KeyError:
                 logger.warn(
-                    "Could not parse value for WGPU_BACKEND_TYPE: "
-                    f"{os.environ.get('WGPU_BACKEND_TYPE')}."
+                    f"Invalid value for WGPU_BACKEND_TYPE: '{backend}'.\n"
+                    f"Valid values are: {list(enum_str2int['BackendType'].keys())}"
                 )
 
         # H: chain: WGPUChainedStruct, backend: WGPUBackendType

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -30,6 +30,7 @@ Developer notes and tips:
 
 
 import os
+import sys
 import ctypes
 import logging
 import ctypes.util
@@ -217,7 +218,9 @@ class GPU(base.GPU):
         # mature than Metal too, so let's just force that for now.
         # See https://github.com/gfx-rs/wgpu/issues/1416
         # force_backend = lib.WGPUBackendType_Vulkan
-        force_backend = enum_str2int["BackendType"]["Vulkan"]
+        force_backend = enum_str2int["BackendType"][
+            "Vulkan" if sys.platform.startswith("win") else "Null"
+        ]
 
         # H: chain: WGPUChainedStruct, backend: WGPUBackendType
         extras = new_struct_p(

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -30,7 +30,6 @@ Developer notes and tips:
 
 
 import os
-import sys
 import ctypes
 import logging
 import ctypes.util


### PR DESCRIPTION
This makes sure that on other platforms than Windows any available backend is picked.