### PR TITLE
Implement support for off-screen canvases

### DIFF
--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -72,6 +72,7 @@ def _main(canvas, device):
     # No bind group and layout, we should not create empty ones.
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
 
+    render_texture_format = canvas.get_swap_chain_preferred_format(device.adapter)
     render_pipeline = device.create_render_pipeline(
         layout=pipeline_layout,
         vertex={
@@ -95,7 +96,7 @@ def _main(canvas, device):
             "entry_point": "fs_main",
             "targets": [
                 {
-                    "format": wgpu.TextureFormat.bgra8unorm_srgb,
+                    "format": render_texture_format,
                     "blend": {
                         "color": (
                             wgpu.BlendFactor.one,

--- a/tests/test_gui_base.py
+++ b/tests/test_gui_base.py
@@ -2,7 +2,10 @@
 Test the canvas basics.
 """
 
+import numpy as np
 import wgpu.gui  # noqa
+from testutils import run_tests, can_use_wgpu_lib
+from pytest import mark
 
 
 class TheTestCanvas(wgpu.gui.WgpuCanvasBase):
@@ -69,3 +72,75 @@ def test_canvas_logging(caplog):
 
     assert text.count("spam_method") == 2
     assert text.count("division by zero") == 4
+
+
+class MyOffscreenCanvas(wgpu.gui.WgpuCanvasBase):
+    _PRESENT_TO_SURFACE = False
+
+    def get_pixel_ratio(self):
+        return 1
+
+    def get_logical_size(self):
+        return self.get_physical_size()
+
+    def get_physical_size(self):
+        return 100, 100
+
+    def get_swap_chain_preferred_format(self, adapter):
+        return "rgba8unorm"
+
+    def _request_draw(self):
+        # Note: this would normaly schedule a call in a later event loop iteration
+        self._draw_frame_and_present()
+
+    def _present(self, texture_view):
+        device = texture_view._device
+        size = texture_view.size
+        bytes_per_pixel = 4
+        data = device.queue.read_texture(
+            {
+                "texture": texture_view.texture,
+                "mip_level": 0,
+                "origin": (0, 0, 0),
+            },
+            {
+                "offset": 0,
+                "bytes_per_row": bytes_per_pixel * size[0],
+                "rows_per_image": size[1],
+            },
+            size,
+        )
+        self.array = np.frombuffer(data, np.uint8).reshape(size[1], size[0], 4)
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_offscreen_canvas():
+
+    canvas = MyOffscreenCanvas()
+    device = wgpu.utils.get_default_device()
+    swap_chain = canvas.configure_swap_chain(device=device)
+
+    @canvas.request_draw
+    def draw_frame():
+        with swap_chain as current_texture_view:
+            command_encoder = device.create_command_encoder()
+            render_pass = command_encoder.begin_render_pass(
+                color_attachments=[
+                    {
+                        "view": current_texture_view,
+                        "resolve_target": None,
+                        "load_value": (0, 1, 0, 1),  # LoadOp.load or color
+                        "store_op": wgpu.StoreOp.store,
+                    }
+                ],
+            )
+            render_pass.end_pass()
+            device.queue.submit([command_encoder.finish()])
+
+    assert canvas.array.shape == (100, 100, 4)
+    assert np.all(canvas.array[:, :, 0] == 0)
+    assert np.all(canvas.array[:, :, 1] == 255)
+
+
+if __name__ == "__main__":
+    run_tests(globals())

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -209,8 +209,10 @@ class GPU(base.GPU):
         # able to create a swapchain for it (from this adapter).
         if canvas is None:
             surface_id = ffi.NULL
-        else:
+        elif canvas._PRESENT_TO_SURFACE:
             surface_id = get_surface_id_from_canvas(canvas)
+        else:
+            surface_id = ffi.NULL  # off-screen canvas
 
         # Try to read the WGPU_BACKEND_TYPE environment variable to see
         # if a backend should be forced. When you run into trouble with

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -1758,38 +1758,6 @@ class GPUSwapChain(GPUObjectBase):
         raise NotImplementedError()  # Present the current texture
 
 
-class GPUSwapChainOffScreen(GPUSwapChain):
-    """Helper class for canvases that render to a texture."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._surface_size = (-1, -1)
-        self._texture = None
-
-    def _create_new_texture_if_needed(self):
-        canvas = self._canvas
-        psize = canvas.get_physical_size()
-        if psize == self._surface_size:
-            return
-        self._surface_size = psize
-
-        self._texture = self._device.create_texture(
-            label="swapchain",
-            size=(max(psize[0], 1), max(psize[1], 1), 1),
-            format=self._format,
-            usage=self._usage | flags.TextureUsage.COPY_SRC,
-        )
-        self._texture_view = self._texture.create_view()
-
-    def __enter__(self):
-        # Get the current texture view, and make sure it is presented when done
-        self._create_new_texture_if_needed()
-        return self._texture_view
-
-    def __exit__(self, type, value, tb):
-        self._canvas._present(self._texture_view)
-
-
 # %% Further non-GPUObject classes
 
 

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -137,7 +137,10 @@ class GPUCanvasContext:
             compositing_alpha_mode (CanvasCompositingAlphaMode): Default opaque.
         """
         usage = usage or flags.TextureUsage.RENDER_ATTACHMENT
-        GPUSwapChain = sys.modules[device.__module__].GPUSwapChain  # noqa: N806
+        if self._PRESENT_TO_SURFACE:
+            GPUSwapChain = sys.modules[device.__module__].GPUSwapChain  # noqa: N806
+        else:
+            GPUSwapChain = GPUSwapChainOffScreen  # noqa: N806
         return GPUSwapChain(
             label, None, device, self, format, usage, compositing_alpha_mode
         )
@@ -1753,6 +1756,38 @@ class GPUSwapChain(GPUObjectBase):
 
     def __exit__(self, type, value, tb):
         raise NotImplementedError()  # Present the current texture
+
+
+class GPUSwapChainOffScreen(GPUSwapChain):
+    """Helper class for canvases that render to a texture."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._surface_size = (-1, -1)
+        self._texture = None
+
+    def _create_new_texture_if_needed(self):
+        canvas = self._canvas
+        psize = canvas.get_physical_size()
+        if psize == self._surface_size:
+            return
+        self._surface_size = psize
+
+        self._texture = self._device.create_texture(
+            label="swapchain",
+            size=(max(psize[0], 1), max(psize[1], 1), 1),
+            format=self._format,
+            usage=self._usage | flags.TextureUsage.COPY_SRC,
+        )
+        self._texture_view = self._texture.create_view()
+
+    def __enter__(self):
+        # Get the current texture view, and make sure it is presented when done
+        self._create_new_texture_if_needed()
+        return self._texture_view
+
+    def __exit__(self, type, value, tb):
+        self._canvas._present(self._texture_view)
 
 
 # %% Further non-GPUObject classes

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -140,7 +140,7 @@ class GPUCanvasContext:
         if self._PRESENT_TO_SURFACE:
             GPUSwapChain = sys.modules[device.__module__].GPUSwapChain  # noqa: N806
         else:
-            GPUSwapChain = GPUSwapChainOffScreen  # noqa: N806
+            GPUSwapChain = GPUSwapChainOffScreen  # noqa: F821, N806
         return GPUSwapChain(
             label, None, device, self, format, usage, compositing_alpha_mode
         )

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -16,6 +16,9 @@ class WgpuCanvasInterface(base.GPUCanvasContext):
 
     # NOTE: It is not necessary to actually subclass this class.
 
+    # Whether to present to a surface or to a texture
+    _PRESENT_TO_SURFACE = True
+
     def __init__(self, *args, **kwargs):
         # The args/kwargs are there because we may be mixed with e.g. a Qt widget
         super().__init__(*args, **kwargs)
@@ -72,6 +75,10 @@ class WgpuCanvasInterface(base.GPUCanvasContext):
     def get_swap_chain_preferred_format(self, adapter):
         """Get the preferred swap-chain texture format for this canvas."""
         return "bgra8unorm-srgb"  # seems to be a good default, can be overridden
+
+    def _present(self, texture_view):
+        """Offscreen canvases must implement this and set _PRESENT_TO_SURFACE to False."""
+        raise NotImplementedError()
 
 
 class WgpuCanvasBase(WgpuCanvasInterface):

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -172,3 +172,39 @@ class WgpuCanvasBase(WgpuCanvasInterface):
         the FPS is limited to avoid draining CPU and power.
         """
         raise NotImplementedError()
+
+
+class GPUSwapChainOffScreen(base.GPUSwapChain):
+    """Helper class for canvases that render to a texture."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._surface_size = (-1, -1)
+        self._texture = None
+
+    def _create_new_texture_if_needed(self):
+        canvas = self._canvas
+        psize = canvas.get_physical_size()
+        if psize == self._surface_size:
+            return
+        self._surface_size = psize
+
+        self._texture = self._device.create_texture(
+            label="swapchain",
+            size=(max(psize[0], 1), max(psize[1], 1), 1),
+            format=self._format,
+            usage=self._usage | flags.TextureUsage.COPY_SRC,
+        )
+        self._texture_view = self._texture.create_view()
+
+    def __enter__(self):
+        # Get the current texture view, and make sure it is presented when done
+        self._create_new_texture_if_needed()
+        return self._texture_view
+
+    def __exit__(self, type, value, tb):
+        self._canvas._present(self._texture_view)
+
+
+# todo: ugly hack to avoid circular import. Fix that when we refactor swap chain
+base.GPUSwapChainOffScreen = GPUSwapChainOffScreen


### PR DESCRIPTION
This makes it possible to write Canvas classes that do not render to a screen, but instead get a texture on each draw, which can be processed  in whatever way makes sense.

This paves the way for e.g. a Jupyter widget.

Note that the WebGPU API for CanvasContext and GPUChain has changed (they are merged into a GPUPresentContext). We should update accordingly soon, because that might affect the API a bit.