### PR TITLE
Update to latest webgpu

### DIFF
--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -321,7 +321,9 @@ class IdlPatcherMixin:
         argtypes = [arg.split("=")[0].split()[-2] for arg in args]
 
         # If one arg that is a dict, flatten dict to kwargs
-        if len(argtypes) == 1 and argtypes[0].endswith(("Options", "Descriptor", "Configuration")):
+        if len(argtypes) == 1 and argtypes[0].endswith(
+            ("Options", "Descriptor", "Configuration")
+        ):
             assert argtypes[0].startswith("GPU")
             fields = self.idl.structs[argtypes[0][3:]].values()  # struct fields
             py_args = [self._arg_from_struct_field(field) for field in fields]

--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -321,7 +321,7 @@ class IdlPatcherMixin:
         argtypes = [arg.split("=")[0].split()[-2] for arg in args]
 
         # If one arg that is a dict, flatten dict to kwargs
-        if len(argtypes) == 1 and argtypes[0].endswith(("Options", "Descriptor")):
+        if len(argtypes) == 1 and argtypes[0].endswith(("Options", "Descriptor", "Configuration")):
             assert argtypes[0].startswith("GPU")
             fields = self.idl.structs[argtypes[0][3:]].values()  # struct fields
             py_args = [self._arg_from_struct_field(field) for field in fields]

--- a/codegen/apiwriter.py
+++ b/codegen/apiwriter.py
@@ -133,12 +133,15 @@ class Struct:
 
 
 def write_structs():
+    ignore = ["ImageCopyTextureTagged"]
     idl = get_idl_parser()
     n = len(idl.structs)
     # Generate code
     pylines = [structs_preamble]
     pylines.append(f"# There are {n} structs\n")
     for name, d in idl.structs.items():
+        if name in ignore:
+            continue
         pylines.append(f'{name} = Struct(\n    "{name}",')
         for field in d.values():
             key = to_snake_case(field.name)

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -202,6 +202,7 @@ class IdlParser:
             "boolean": "bool",
             "object": "dict",
             "ImageBitmap": "memoryview",
+            "GPUPipelineConstantValue": "float",
         }
         name = pythonmap.get(name, name)
 
@@ -391,7 +392,7 @@ class IdlParser:
         """
 
         # Drop some toplevel names
-        for name in ["NavigatorGPU", "GPUAdapterLimits", "GPUSupportedFeatures"]:
+        for name in ["NavigatorGPU", "GPUSupportedLimits", "GPUSupportedFeatures"]:
             self._interfaces.pop(name, None)
 
         # Divide flags and actual class definitions

--- a/codegen/rspatcher.py
+++ b/codegen/rspatcher.py
@@ -43,6 +43,7 @@ def compare_flags():
 
     name_map = {"ColorWrite": "ColorWriteMask"}
 
+
     for name, flag in idl.flags.items():
         name = name_map.get(name, name)
         if name not in hp.flags:
@@ -65,6 +66,8 @@ def write_mappings():
     idl = get_idl_parser()
     hp = get_h_parser()
 
+    field_map = {"discard": "clear"}
+
     # Init generated code
     pylines = [mappings_preamble]
 
@@ -77,7 +80,10 @@ def write_mappings():
             continue
         hp_enum = {key.lower(): val for key, val in hp.enums[name].items()}
         for ikey in idl.enums[name].values():
-            hkey = ikey.lower().replace("-", "")
+            if ikey in field_map:
+                hkey = field_map[ikey]
+            else:
+                hkey = ikey.lower().replace("-", "")
             if hkey in hp_enum:
                 enummap[name + "." + ikey] = hp_enum[hkey]
             else:

--- a/codegen/rspatcher.py
+++ b/codegen/rspatcher.py
@@ -43,7 +43,6 @@ def compare_flags():
 
     name_map = {"ColorWrite": "ColorWriteMask"}
 
-
     for name, flag in idl.flags.items():
         name = name_map.get(name, name)
         if name not in hp.flags:

--- a/docs/reference_gui.rst
+++ b/docs/reference_gui.rst
@@ -14,8 +14,7 @@ The canvas interface
 
 To render to a window, an object is needed that implements the few
 functions on the canvas interface, and provide that object to
-:func:`request_adapter() <wgpu.request_adapter>` and
-:func:`device.configure_swap_chain() <wgpu.GPUDevice.configure_swap_chain>`.
+:func:`request_adapter() <wgpu.request_adapter>`.
 This interface makes it possible to hook wgpu-py to any GUI that supports GPU rendering.
 
 .. autoclass:: wgpu.gui.WgpuCanvasInterface
@@ -25,11 +24,22 @@ This interface makes it possible to hook wgpu-py to any GUI that supports GPU re
 The WgpuCanvas classes
 ----------------------
 
-For each GUI toolkit that wgpu-py has builtin support, there is a
+For each GUI toolkit that wgpu-py has builtin support for, there is a
 ``WgpuCanvas`` class, which all derive from the following class. This thus
 provides a single (simple) API to work with windows.
 
 .. autoclass:: wgpu.gui.WgpuCanvasBase
+    :members:
+
+
+Offscreen canvases
+------------------
+
+A base class is provided to implement off-screen canvases. Note that you can
+render to a texture without using any canvas object, but in some cases it's
+convenient to do so with a canvas-like API, which is what this class provides.
+
+.. autoclass:: wgpu.gui.WgpuOffscreenCanvas
     :members:
 
 

--- a/docs/reference_wgpu.rst
+++ b/docs/reference_wgpu.rst
@@ -212,21 +212,14 @@ Command buffers and encoders
     :members:
 
 
-Queue and swap chain
---------------------
-
-.. autoclass:: wgpu.GPUQueue
-    :members:
-
-.. autoclass:: wgpu.GPUSwapChain
-    :members:
-
 
 Other
 -----
 
+.. autoclass:: wgpu.GPUPresentationContext
+    :members:
 
-.. autoclass:: wgpu.GPUCanvasContext
+.. autoclass:: wgpu.GPUQueue
     :members:
 
 .. autoclass:: wgpu.GPUQuerySet

--- a/examples/cube_glfw.py
+++ b/examples/cube_glfw.py
@@ -316,6 +316,7 @@ render_pipeline = device.create_render_pipeline(
 
 # %% Setup the render function
 
+
 def draw_frame():
 
     # Update uniform transform

--- a/examples/cube_glfw.py
+++ b/examples/cube_glfw.py
@@ -22,6 +22,11 @@ canvas = WgpuCanvas(title="wgpu cube with GLFW")
 adapter = wgpu.request_adapter(canvas=canvas, power_preference="high-performance")
 device = adapter.request_device()
 
+# Prepare present context
+present_context = canvas.get_context()
+render_texture_format = present_context.get_preferred_format(device.adapter)
+present_context.configure(device=device, format=render_texture_format)
+
 
 # %% Generate data
 
@@ -290,7 +295,7 @@ render_pipeline = device.create_render_pipeline(
         "entry_point": "fs_main",
         "targets": [
             {
-                "format": wgpu.TextureFormat.bgra8unorm_srgb,
+                "format": render_texture_format,
                 "blend": {
                     "alpha": (
                         wgpu.BlendFactor.one,
@@ -310,9 +315,6 @@ render_pipeline = device.create_render_pipeline(
 
 
 # %% Setup the render function
-
-swap_chain = canvas.configure_swap_chain(device=device)
-
 
 def draw_frame():
 
@@ -351,32 +353,32 @@ def draw_frame():
         data=uniform_data, usage=wgpu.BufferUsage.COPY_SRC
     )
 
-    with swap_chain as current_texture_view:
-        command_encoder = device.create_command_encoder()
-        command_encoder.copy_buffer_to_buffer(
-            tmp_buffer, 0, uniform_buffer, 0, uniform_data.nbytes
-        )
+    current_texture_view = present_context.get_current_texture()
+    command_encoder = device.create_command_encoder()
+    command_encoder.copy_buffer_to_buffer(
+        tmp_buffer, 0, uniform_buffer, 0, uniform_data.nbytes
+    )
 
-        render_pass = command_encoder.begin_render_pass(
-            color_attachments=[
-                {
-                    "view": current_texture_view,
-                    "resolve_target": None,
-                    "load_value": (0.1, 0.3, 0.2, 1),
-                    "store_op": wgpu.StoreOp.store,
-                }
-            ],
-        )
+    render_pass = command_encoder.begin_render_pass(
+        color_attachments=[
+            {
+                "view": current_texture_view,
+                "resolve_target": None,
+                "load_value": (0.1, 0.3, 0.2, 1),
+                "store_op": wgpu.StoreOp.store,
+            }
+        ],
+    )
 
-        render_pass.set_pipeline(render_pipeline)
-        render_pass.set_index_buffer(index_buffer, wgpu.IndexFormat.uint32)
-        render_pass.set_vertex_buffer(0, vertex_buffer)
-        for bind_group_id, bind_group in enumerate(bind_groups):
-            render_pass.set_bind_group(bind_group_id, bind_group, [], 0, 99)
-        render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
+    render_pass.set_pipeline(render_pipeline)
+    render_pass.set_index_buffer(index_buffer, wgpu.IndexFormat.uint32)
+    render_pass.set_vertex_buffer(0, vertex_buffer)
+    for bind_group_id, bind_group in enumerate(bind_groups):
+        render_pass.set_bind_group(bind_group_id, bind_group, [], 0, 99)
+    render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
 
-        render_pass.end_pass()
-        device.queue.submit([command_encoder.finish()])
+    render_pass.end_pass()
+    device.queue.submit([command_encoder.finish()])
 
     canvas.request_draw()
 

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -259,51 +259,52 @@ def render_to_screen(
         },
     )
 
-    swap_chain = canvas.configure_swap_chain(device=device)
+    present_context = canvas.get_context()
+    present_context.configure(device=device, format=None)
 
     def draw_frame():
-        with swap_chain as current_texture_view:
-            command_encoder = device.create_command_encoder()
+        current_texture_view = present_context.get_current_texture()
+        command_encoder = device.create_command_encoder()
 
-            ca = color_attachment or {
-                "resolve_target": None,
-                "load_value": (0, 0, 0, 0),  # LoadOp.load or color
-                "store_op": wgpu.StoreOp.store,
-            }
-            ca["view"] = current_texture_view
-            render_pass = command_encoder.begin_render_pass(
-                color_attachments=[ca],
-                depth_stencil_attachment=depth_stencil_attachment,
-                occlusion_query_set=None,
-            )
-            render_pass.push_debug_group("foo")
+        ca = color_attachment or {
+            "resolve_target": None,
+            "load_value": (0, 0, 0, 0),  # LoadOp.load or color
+            "store_op": wgpu.StoreOp.store,
+        }
+        ca["view"] = current_texture_view
+        render_pass = command_encoder.begin_render_pass(
+            color_attachments=[ca],
+            depth_stencil_attachment=depth_stencil_attachment,
+            occlusion_query_set=None,
+        )
+        render_pass.push_debug_group("foo")
 
-            render_pass.insert_debug_marker("setting pipeline")
-            render_pass.set_pipeline(render_pipeline)
-            render_pass.insert_debug_marker("setting bind group")
-            render_pass.set_bind_group(
-                0, bind_group, [], 0, 999999
-            )  # last 2 elements not used
-            for slot, vbo in enumerate(vbos):
-                render_pass.insert_debug_marker(f"setting vbo {slot}")
-                render_pass.set_vertex_buffer(slot, vbo, 0, vbo.size)
-            render_pass.insert_debug_marker("invoking callback")
-            renderpass_callback(render_pass)
-            render_pass.insert_debug_marker("draw!")
-            if ibo is None:
-                if indirect_buffer is None:
-                    render_pass.draw(4, 1, 0, 0)
-                else:
-                    render_pass.draw_indirect(indirect_buffer, 0)
+        render_pass.insert_debug_marker("setting pipeline")
+        render_pass.set_pipeline(render_pipeline)
+        render_pass.insert_debug_marker("setting bind group")
+        render_pass.set_bind_group(
+            0, bind_group, [], 0, 999999
+        )  # last 2 elements not used
+        for slot, vbo in enumerate(vbos):
+            render_pass.insert_debug_marker(f"setting vbo {slot}")
+            render_pass.set_vertex_buffer(slot, vbo, 0, vbo.size)
+        render_pass.insert_debug_marker("invoking callback")
+        renderpass_callback(render_pass)
+        render_pass.insert_debug_marker("draw!")
+        if ibo is None:
+            if indirect_buffer is None:
+                render_pass.draw(4, 1, 0, 0)
             else:
-                render_pass.set_index_buffer(ibo, wgpu.IndexFormat.uint32, 0, ibo.size)
-                if indirect_buffer is None:
-                    render_pass.draw_indexed(6, 1, 0, 0, 0)
-                else:
-                    render_pass.draw_indexed_indirect(indirect_buffer, 0)
-            render_pass.pop_debug_group()
-            render_pass.end_pass()
-            device.queue.submit([command_encoder.finish()])
+                render_pass.draw_indirect(indirect_buffer, 0)
+        else:
+            render_pass.set_index_buffer(ibo, wgpu.IndexFormat.uint32, 0, ibo.size)
+            if indirect_buffer is None:
+                render_pass.draw_indexed(6, 1, 0, 0, 0)
+            else:
+                render_pass.draw_indexed_indirect(indirect_buffer, 0)
+        render_pass.pop_debug_group()
+        render_pass.end_pass()
+        device.queue.submit([command_encoder.finish()])
 
     canvas.request_draw(draw_frame)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,7 @@ def test_enums_and_flags_and_structs():
     # Structs are dict-like, their values str
     assert isinstance(wgpu.structs.DeviceDescriptor, wgpu.structs.Struct)
     assert isinstance(wgpu.structs.DeviceDescriptor.label, str)
-    assert isinstance(wgpu.structs.DeviceDescriptor.non_guaranteed_features, str)
+    assert isinstance(wgpu.structs.DeviceDescriptor.required_features, str)
 
     # Structs show their field names
     for key in wgpu.structs.DeviceDescriptor:

--- a/tests/test_gui_base.py
+++ b/tests/test_gui_base.py
@@ -31,7 +31,9 @@ class TheTestCanvas(wgpu.gui.WgpuCanvasBase):
 
 
 def test_base_canvas_context():
-    assert not issubclass(wgpu.gui.WgpuCanvasInterface, wgpu.base.GPUPresentationContext)
+    assert not issubclass(
+        wgpu.gui.WgpuCanvasInterface, wgpu.base.GPUPresentationContext
+    )
     assert hasattr(wgpu.gui.WgpuCanvasInterface, "get_context")
     # Provides good default already
     canvas = wgpu.gui.WgpuCanvasInterface()
@@ -77,7 +79,6 @@ def test_canvas_logging(caplog):
 
 
 class MyOffscreenCanvas(wgpu.gui.WgpuOffscreenCanvas):
-
     def get_pixel_ratio(self):
         return 1
 

--- a/tests/test_gui_base.py
+++ b/tests/test_gui_base.py
@@ -31,10 +31,12 @@ class TheTestCanvas(wgpu.gui.WgpuCanvasBase):
 
 
 def test_base_canvas_context():
-    assert issubclass(wgpu.gui.WgpuCanvasInterface, wgpu.base.GPUCanvasContext)
+    assert not issubclass(wgpu.gui.WgpuCanvasInterface, wgpu.base.GPUPresentationContext)
+    assert hasattr(wgpu.gui.WgpuCanvasInterface, "get_context")
     # Provides good default already
-    ctx = wgpu.GPUCanvasContext()
-    assert ctx.get_swap_chain_preferred_format(None) == "bgra8unorm-srgb"
+    canvas = wgpu.gui.WgpuCanvasInterface()
+    ctx = wgpu.GPUPresentationContext(canvas)
+    assert ctx.get_preferred_format(None) == "bgra8unorm-srgb"
 
 
 def test_canvas_logging(caplog):
@@ -74,8 +76,7 @@ def test_canvas_logging(caplog):
     assert text.count("division by zero") == 4
 
 
-class MyOffscreenCanvas(wgpu.gui.WgpuCanvasBase):
-    _PRESENT_TO_SURFACE = False
+class MyOffscreenCanvas(wgpu.gui.WgpuOffscreenCanvas):
 
     def get_pixel_ratio(self):
         return 1
@@ -86,14 +87,11 @@ class MyOffscreenCanvas(wgpu.gui.WgpuCanvasBase):
     def get_physical_size(self):
         return 100, 100
 
-    def get_swap_chain_preferred_format(self, adapter):
-        return "rgba8unorm"
-
     def _request_draw(self):
         # Note: this would normaly schedule a call in a later event loop iteration
         self._draw_frame_and_present()
 
-    def _present(self, texture_view):
+    def present(self, texture_view):
         device = texture_view._device
         size = texture_view.size
         bytes_per_pixel = 4
@@ -118,24 +116,25 @@ def test_offscreen_canvas():
 
     canvas = MyOffscreenCanvas()
     device = wgpu.utils.get_default_device()
-    swap_chain = canvas.configure_swap_chain(device=device)
+    present_context = canvas.get_context()
+    present_context.configure(device=device, format=None)
 
     @canvas.request_draw
     def draw_frame():
-        with swap_chain as current_texture_view:
-            command_encoder = device.create_command_encoder()
-            render_pass = command_encoder.begin_render_pass(
-                color_attachments=[
-                    {
-                        "view": current_texture_view,
-                        "resolve_target": None,
-                        "load_value": (0, 1, 0, 1),  # LoadOp.load or color
-                        "store_op": wgpu.StoreOp.store,
-                    }
-                ],
-            )
-            render_pass.end_pass()
-            device.queue.submit([command_encoder.finish()])
+        current_texture_view = present_context.get_current_texture()
+        command_encoder = device.create_command_encoder()
+        render_pass = command_encoder.begin_render_pass(
+            color_attachments=[
+                {
+                    "view": current_texture_view,
+                    "resolve_target": None,
+                    "load_value": (0, 1, 0, 1),  # LoadOp.load or color
+                    "store_op": wgpu.StoreOp.store,
+                }
+            ],
+        )
+        render_pass.end_pass()
+        device.queue.submit([command_encoder.finish()])
 
     assert canvas.array.shape == (100, 100, 4)
     assert np.all(canvas.array[:, :, 0] == 0)

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -2187,8 +2187,9 @@ class GPUExternalTexture(base.GPUExternalTexture, GPUObjectBase):
 
 
 def _copy_docstrings():
+    base_classes = GPUObjectBase, GPUPresentationContext
     for ob in globals().values():
-        if not (isinstance(ob, type) and issubclass(ob, GPUObjectBase)):
+        if not (isinstance(ob, type) and issubclass(ob, base_classes)):
             continue
         elif ob.__module__ != __name__:
             continue  # no-cover

--- a/wgpu/backends/rs_mappings.py
+++ b/wgpu/backends/rs_mappings.py
@@ -4,7 +4,7 @@
 
 # flake8: noqa
 
-# There are 169 enum mappings
+# There are 168 enum mappings
 
 enummap = {
     "AddressMode.clamp-to-edge": 2,
@@ -73,7 +73,6 @@ enummap = {
     "StencilOperation.zero": 1,
     "StorageTextureAccess.read-only": 1,
     "StorageTextureAccess.write-only": 2,
-    "StoreOp.clear": 1,
     "StoreOp.store": 0,
     "TextureAspect.all": 0,
     "TextureAspect.depth-only": 2,

--- a/wgpu/backends/rs_mappings.py
+++ b/wgpu/backends/rs_mappings.py
@@ -4,7 +4,7 @@
 
 # flake8: noqa
 
-# There are 168 enum mappings
+# There are 169 enum mappings
 
 enummap = {
     "AddressMode.clamp-to-edge": 2,
@@ -73,6 +73,7 @@ enummap = {
     "StencilOperation.zero": 1,
     "StorageTextureAccess.read-only": 1,
     "StorageTextureAccess.write-only": 2,
+    "StoreOp.discard": 1,
     "StoreOp.store": 0,
     "TextureAspect.all": 0,
     "TextureAspect.depth-only": 2,

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -267,7 +267,8 @@ class GPUAdapter:
     # IDL: readonly attribute boolean isSoftware;
     @property
     def is_software(self):
-        raise NotImplementedError()
+        """ Whether this adapter runs on software (rather than dedicated hardware)."""
+        return self._properties.get("adapterType", "").lower() in ("software", "cpu")
 
 
 class GPUObjectBase:

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -14,7 +14,6 @@ Developer notes and tips:
 
 """
 
-import sys
 import weakref
 import logging
 from typing import List, Dict
@@ -267,7 +266,7 @@ class GPUAdapter:
     # IDL: readonly attribute boolean isSoftware;
     @property
     def is_software(self):
-        """ Whether this adapter runs on software (rather than dedicated hardware)."""
+        """Whether this adapter runs on software (rather than dedicated hardware)."""
         return self._properties.get("adapterType", "").lower() in ("software", "cpu")
 
 

--- a/wgpu/enums.py
+++ b/wgpu/enums.py
@@ -308,7 +308,7 @@ LoadOp = Enum(
 StoreOp = Enum(
     "StoreOp",
     store="store",
-    clear="clear",
+    discard="discard",
 )  #:
 
 QueryType = Enum(

--- a/wgpu/gui/__init__.py
+++ b/wgpu/gui/__init__.py
@@ -3,3 +3,4 @@ Code to provide a canvas to render to.
 """
 
 from .base import WgpuCanvasInterface, WgpuCanvasBase  # noqa: F401
+from .offscreen import WgpuOffscreenCanvas

--- a/wgpu/gui/__init__.py
+++ b/wgpu/gui/__init__.py
@@ -3,4 +3,4 @@ Code to provide a canvas to render to.
 """
 
 from .base import WgpuCanvasInterface, WgpuCanvasBase  # noqa: F401
-from .offscreen import WgpuOffscreenCanvas
+from .offscreen import WgpuOffscreenCanvas  # noqa: F401

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -9,29 +9,27 @@ from .. import base, GPUDevice, flags, enums
 logger = logging.getLogger("wgpu")
 
 
-class WgpuCanvasInterface(base.GPUCanvasContext):
+class WgpuCanvasInterface:
     """This is the interface that a canvas object must implement in order
     to be a valid canvas that wgpu can work with.
     """
 
-    # NOTE: It is not necessary to actually subclass this class.
-
-    # Whether to present to a surface or to a texture
-    _PRESENT_TO_SURFACE = True
+    # NOTE: This is an interface - it should not be necessary to actually subclass
 
     def __init__(self, *args, **kwargs):
         # The args/kwargs are there because we may be mixed with e.g. a Qt widget
         super().__init__(*args, **kwargs)
+        self._present_context = None
 
     def get_window_id(self):
-        """Get the native window id. This is used by the backends
-        to obtain a surface id.
+        """Get the native window id. This is used to obtain a surface id,
+        so that wgpu can render to the region of the screen occupied by the canvas.
         """
         raise NotImplementedError()
 
     def get_display_id(self):
-        """Get the native display id on Linux. This is used by the backends
-        to obtain a surface id on Linux. The default implementation calls into
+        """Get the native display id on Linux. This is needed in addition to the
+        window id to obtain a surface id. The default implementation calls into
         the X11 lib to get the display id.
         """
         # Re-use to avoid creating loads of id's
@@ -54,39 +52,31 @@ class WgpuCanvasInterface(base.GPUCanvasContext):
         return self._display_id
 
     def get_physical_size(self):
-        """Get the physical size in integer pixels."""
+        """Get the physical size of the canvas in integer pixels."""
         raise NotImplementedError()
 
-    def configure_swap_chain(
-        self,
-        *,
-        label="",
-        device: "GPUDevice",
-        format: "enums.TextureFormat" = None,
-        usage: "flags.TextureUsage" = None,
-    ):
-        """Obtain a swap-chain object."""
-        # Let's be nice and allow not-specifying the format
-        format = format or self.get_swap_chain_preferred_format(device.adapter)
-        return super().configure_swap_chain(
-            label=label, device=device, format=format, usage=usage
-        )
-
-    def get_swap_chain_preferred_format(self, adapter):
-        """Get the preferred swap-chain texture format for this canvas."""
-        return "bgra8unorm-srgb"  # seems to be a good default, can be overridden
-
-    def _present(self, texture_view):
-        """Offscreen canvases must implement this and set _PRESENT_TO_SURFACE to False."""
-        raise NotImplementedError()
+    def get_context(self, kind='gpupresent'):
+        """ Get the GPUPresentationContext object corresponding to this canvas,
+        which can be used to e.g. obtain a texture to render to.
+        """
+        # Note that this function is analog to HtmlCanvas.get_context(), except
+        # here the only valid arg is 'gpupresent', which is also made the default.
+        assert kind == "gpupresent"
+        if self._present_context is None:
+            # Get the active wgpu backend module
+            backend_module = sys.modules["wgpu"].GPU.__module__
+            # Instantiate the context
+            GPUPresentationContext = sys.modules[backend_module].GPUPresentationContext
+            self._present_context = GPUPresentationContext(self)
+        return self._present_context
 
 
 class WgpuCanvasBase(WgpuCanvasInterface):
-    """An abstract class, extending :class:`WgpuCanvasInterface`,
+    """An abstract class extending :class:`WgpuCanvasInterface`,
     that provides a base canvas for various GUI toolkits, so
     that basic canvas functionality is available via a common API.
 
-    It convenient, but not required to use this class (or any of its
+    It is convenient - but not required - to use this class (or any of its
     subclasses) to use wgpu-py.
     """
 
@@ -110,7 +100,7 @@ class WgpuCanvasBase(WgpuCanvasInterface):
         self._request_draw()
 
     def _draw_frame_and_present(self):
-        """Draw the frame and present the swapchain. Errors are logged to the
+        """Draw the frame and present the result. Errors are logged to the
         "wgpu" logger. Should be called by the subclass at an appropriate time.
         """
         # Perform the user-defined drawing code. When this errors,
@@ -119,6 +109,11 @@ class WgpuCanvasBase(WgpuCanvasInterface):
             self.draw_frame()
         except Exception as err:
             self._log_exception("Draw error", err)
+        try:
+            if self._present_context:
+                self._present_context.present()
+        except Exception as err:
+            self._log_exception("Present error", err)
 
     def _log_exception(self, kind, err):
         """Log the given exception instance, but only log a one-liner for
@@ -172,39 +167,3 @@ class WgpuCanvasBase(WgpuCanvasInterface):
         the FPS is limited to avoid draining CPU and power.
         """
         raise NotImplementedError()
-
-
-class GPUSwapChainOffScreen(base.GPUSwapChain):
-    """Helper class for canvases that render to a texture."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._surface_size = (-1, -1)
-        self._texture = None
-
-    def _create_new_texture_if_needed(self):
-        canvas = self._canvas
-        psize = canvas.get_physical_size()
-        if psize == self._surface_size:
-            return
-        self._surface_size = psize
-
-        self._texture = self._device.create_texture(
-            label="swapchain",
-            size=(max(psize[0], 1), max(psize[1], 1), 1),
-            format=self._format,
-            usage=self._usage | flags.TextureUsage.COPY_SRC,
-        )
-        self._texture_view = self._texture.create_view()
-
-    def __enter__(self):
-        # Get the current texture view, and make sure it is presented when done
-        self._create_new_texture_if_needed()
-        return self._texture_view
-
-    def __exit__(self, type, value, tb):
-        self._canvas._present(self._texture_view)
-
-
-# todo: ugly hack to avoid circular import. Fix that when we refactor swap chain
-base.GPUSwapChainOffScreen = GPUSwapChainOffScreen

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -3,9 +3,6 @@ import sys
 import logging
 import ctypes.util
 
-from .. import base, GPUDevice, flags, enums
-
-
 logger = logging.getLogger("wgpu")
 
 
@@ -55,8 +52,8 @@ class WgpuCanvasInterface:
         """Get the physical size of the canvas in integer pixels."""
         raise NotImplementedError()
 
-    def get_context(self, kind='gpupresent'):
-        """ Get the GPUPresentationContext object corresponding to this canvas,
+    def get_context(self, kind="gpupresent"):
+        """Get the GPUPresentationContext object corresponding to this canvas,
         which can be used to e.g. obtain a texture to render to.
         """
         # Note that this function is analog to HtmlCanvas.get_context(), except
@@ -66,8 +63,8 @@ class WgpuCanvasInterface:
             # Get the active wgpu backend module
             backend_module = sys.modules["wgpu"].GPU.__module__
             # Instantiate the context
-            GPUPresentationContext = sys.modules[backend_module].GPUPresentationContext
-            self._present_context = GPUPresentationContext(self)
+            PC = sys.modules[backend_module].GPUPresentationContext  # noqa: N806
+            self._present_context = PC(self)
         return self._present_context
 
 

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -1,0 +1,71 @@
+from .. import base, flags
+from ..gui.base import WgpuCanvasBase
+
+
+class WgpuOffscreenCanvas(WgpuCanvasBase):
+    """ Base class for off-screen canvases, providing a custom presentation
+    context that renders to a tetxure instead of a surface/screen.
+    The resulting texture view is passed to the ``present()`` method.
+    """
+
+    def get_window_id(self):
+        """ This canvas does not correspond to an on-screen window.
+        """
+        return None
+
+    def get_context(self, kind='gpupresent'):
+        """ Get the GPUPresentationContext object to obtain a texture to render to.
+        """
+        assert kind == "gpupresent"
+        if self._present_context is None:
+            self._present_context = GPUPresentationContextOffline(self)
+        return self._present_context
+
+    def present(self, texture_view):
+        """ Method that gets called at the end of each draw event. Subclasses
+        should provide the approproate implementation.
+        """
+        pass
+
+
+class GPUPresentationContextOffline(base.GPUPresentationContext):
+    """Helper class for canvases that render to a texture."""
+
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self._surface_size = (-1, -1)
+        self._texture = None
+        self._texture_view = None
+
+    def unconfigure(self):
+        super().unconfigure()
+        # todo: maybe destroy texture? (currently API is unclear about destroying)
+        self._texture = None
+
+    def get_preferred_format(self, adapter):
+        return "rgba8unorm"
+
+    def get_current_texture(self):
+        self._create_new_texture_if_needed()
+        # todo: we return a view here, to align with the rs implementation, even though its wrong.
+        return self._texture_view
+
+    def present(self):
+        if self._texture_view is not None:
+            canvas = self._get_canvas()
+            canvas.present(self._texture_view)
+
+    def _create_new_texture_if_needed(self):
+        canvas = self._get_canvas()
+        psize = canvas.get_physical_size()
+        if psize == self._surface_size:
+            return
+        self._surface_size = psize
+
+        self._texture = self._device.create_texture(
+            label="presentation-context",
+            size=(max(psize[0], 1), max(psize[1], 1), 1),
+            format=self._format,
+            usage=self._usage | flags.TextureUsage.COPY_SRC,
+        )
+        self._texture_view = self._texture.create_view()

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -3,26 +3,24 @@ from ..gui.base import WgpuCanvasBase
 
 
 class WgpuOffscreenCanvas(WgpuCanvasBase):
-    """ Base class for off-screen canvases, providing a custom presentation
+    """Base class for off-screen canvases, providing a custom presentation
     context that renders to a tetxure instead of a surface/screen.
     The resulting texture view is passed to the ``present()`` method.
     """
 
     def get_window_id(self):
-        """ This canvas does not correspond to an on-screen window.
-        """
+        """This canvas does not correspond to an on-screen window."""
         return None
 
-    def get_context(self, kind='gpupresent'):
-        """ Get the GPUPresentationContext object to obtain a texture to render to.
-        """
+    def get_context(self, kind="gpupresent"):
+        """Get the GPUPresentationContext object to obtain a texture to render to."""
         assert kind == "gpupresent"
         if self._present_context is None:
             self._present_context = GPUPresentationContextOffline(self)
         return self._present_context
 
     def present(self, texture_view):
-        """ Method that gets called at the end of each draw event. Subclasses
+        """Method that gets called at the end of each draw event. Subclasses
         should provide the approproate implementation.
         """
         pass

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -37,10 +37,9 @@
 * Enum field BlendFactor.one-minus-dst missing in wgpu.h
 * Enum field BlendFactor.constant missing in wgpu.h
 * Enum field BlendFactor.one-minus-constant missing in wgpu.h
-* Enum field StoreOp.discard missing in wgpu.h
 * Enum CanvasCompositingAlphaMode missing in wgpu.h
 * Enum DeviceLostReason missing in wgpu.h
-* Wrote 168 enum mappings and 45 struct-field mappings to rs_mappings.py
+* Wrote 169 enum mappings and 45 struct-field mappings to rs_mappings.py
 * Validated 65 C function calls
 * Not using 46 C functions
 * Validated 66 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -1,15 +1,16 @@
 # Code generatation report
 ## Preparing
-* The webgpu.idl defines 34 classes with 82 functions
-* The webgpu.idl defines 5 flags, 31 enums, 52 structs
+* The webgpu.idl defines 33 classes with 83 functions
+* The webgpu.idl defines 5 flags, 31 enums, 53 structs
 * The wgpu.h defines 106 functions
 * The wgpu.h defines 5 flags, 37 enums, 59 structs
 ## Updating API
 * Wrote 5 flags to flags.py
 * Wrote 31 enums to enums.py
-* Wrote 52 structs to structs.py
+* Wrote 53 structs to structs.py
 ### Patching API for base.py
 * Diffs for GPU: change request_adapter, change request_adapter_async
+* Diffs for GPUPresentationContext: add present
 * Diffs for GPUAdapter: add properties
 * Diffs for GPUDevice: add adapter, add create_buffer_with_data, hide import_external_texture, hide pop_error_scope, hide push_error_scope
 * Diffs for GPUBuffer: add map_read, add map_write, add size, add usage, hide get_mapped_range, hide map_async, hide unmap
@@ -18,10 +19,10 @@
 * Diffs for GPUComputePassEncoder: hide begin_pipeline_statistics_query, hide end_pipeline_statistics_query
 * Diffs for GPURenderPassEncoder: hide begin_pipeline_statistics_query, hide end_pipeline_statistics_query
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 34 classes, 109 methods, 33 properties
+* Validated 33 classes, 110 methods, 34 properties
 ### Patching API for backends/rs.py
 * Diffs for GPUAdapter: add request_device_tracing
-* Validated 34 classes, 95 methods, 0 properties
+* Validated 33 classes, 95 methods, 0 properties
 ## Validating rs.py
 * Enum PredefinedColorSpace missing in wgpu.h
 * Enum PowerPreference missing in wgpu.h
@@ -36,9 +37,10 @@
 * Enum field BlendFactor.one-minus-dst missing in wgpu.h
 * Enum field BlendFactor.constant missing in wgpu.h
 * Enum field BlendFactor.one-minus-constant missing in wgpu.h
+* Enum field StoreOp.discard missing in wgpu.h
 * Enum CanvasCompositingAlphaMode missing in wgpu.h
 * Enum DeviceLostReason missing in wgpu.h
-* Wrote 169 enum mappings and 45 struct-field mappings to rs_mappings.py
+* Wrote 168 enum mappings and 45 struct-field mappings to rs_mappings.py
 * Validated 65 C function calls
 * Not using 46 C functions
 * Validated 66 C structs

--- a/wgpu/resources/webgpu.idl
+++ b/wgpu/resources/webgpu.idl
@@ -22,7 +22,7 @@ dictionary GPUObjectDescriptorBase {
 
 
 [Exposed=Window]
-interface GPUAdapterLimits {
+interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;
     readonly attribute unsigned long maxTextureDimension3D;
@@ -37,9 +37,15 @@ interface GPUAdapterLimits {
     readonly attribute unsigned long maxUniformBuffersPerShaderStage;
     readonly attribute unsigned long maxUniformBufferBindingSize;
     readonly attribute unsigned long maxStorageBufferBindingSize;
+    readonly attribute unsigned long minUniformBufferOffsetAlignment;
+    readonly attribute unsigned long minStorageBufferOffsetAlignment;
     readonly attribute unsigned long maxVertexBuffers;
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
+    readonly attribute unsigned long maxInterStageShaderComponents;
+    readonly attribute unsigned long maxComputeWorkgroupStorageSize;
+    readonly attribute unsigned long maxComputeWorkgroupInvocations;
+    readonly attribute unsigned long maxComputePerDimensionDispatchSize;
 };
 
 
@@ -69,6 +75,7 @@ interface GPU {
 
 dictionary GPURequestAdapterOptions {
     GPUPowerPreference powerPreference;
+    boolean forceSoftware = false;
 };
 
 
@@ -82,15 +89,16 @@ enum GPUPowerPreference {
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
-    [SameObject] readonly attribute GPUAdapterLimits limits;
+    [SameObject] readonly attribute GPUSupportedLimits limits;
+    readonly attribute boolean isSoftware;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
 
 
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    sequence<GPUFeatureName> nonGuaranteedFeatures = [];
-    record<DOMString, GPUSize32> nonGuaranteedLimits = {};
+    sequence<GPUFeatureName> requiredFeatures = [];
+    record<DOMString, GPUSize32> requiredLimits = {};
 };
 
 
@@ -107,7 +115,7 @@ enum GPUFeatureName {
 [Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
-    readonly attribute object limits;
+    [SameObject] readonly attribute GPUSupportedLimits limits;
 
     [SameObject] readonly attribute GPUQueue queue;
 
@@ -557,7 +565,10 @@ interface mixin GPUPipelineBase {
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;
     required USVString entryPoint;
+    record<USVString, GPUPipelineConstantValue> constants;
 };
+
+typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32.
 
 
 [Exposed=Window, Serializable]
@@ -878,6 +889,12 @@ dictionary GPUImageCopyTexture {
 };
 
 
+dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
+    GPUPredefinedColorSpace colorSpace = "srgb";
+    boolean premultipliedAlpha = false;
+};
+
+
 dictionary GPUImageCopyExternalImage {
     required (ImageBitmap or HTMLCanvasElement or OffscreenCanvas) source;
     GPUOrigin2D origin = {};
@@ -924,8 +941,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 interface mixin GPURenderEncoderBase {
     undefined setPipeline(GPURenderPipeline pipeline);
 
-    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
+    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
 
     undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
               optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
@@ -1002,7 +1019,7 @@ enum GPULoadOp {
 
 enum GPUStoreOp {
     "store",
-    "clear"
+    "discard"
 };
 
 
@@ -1053,7 +1070,7 @@ interface GPUQueue {
 
     undefined copyExternalImageToTexture(
         GPUImageCopyExternalImage source,
-        GPUImageCopyTexture destination,
+        GPUImageCopyTextureTagged destination,
         GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
@@ -1090,10 +1107,12 @@ enum GPUPipelineStatisticName {
 
 
 [Exposed=Window]
-interface GPUCanvasContext {
-    GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
+interface GPUPresentationContext {
+    undefined configure(GPUPresentationConfiguration configuration);
+    undefined unconfigure();
 
-    GPUTextureFormat getSwapChainPreferredFormat(GPUAdapter adapter);
+    GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
+    GPUTexture getCurrentTexture();
 };
 
 
@@ -1103,19 +1122,14 @@ enum GPUCanvasCompositingAlphaMode {
     "premultiplied",
 };
 
-dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
+dictionary GPUPresentationConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
+    GPUPredefinedColorSpace colorSpace = "srgb";
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
+    GPUExtent3D size;
 };
-
-
-[Exposed=Window]
-interface GPUSwapChain {
-    GPUTexture getCurrentTexture();
-};
-GPUSwapChain includes GPUObjectBase;
 
 
 enum GPUDeviceLostReason {

--- a/wgpu/structs.py
+++ b/wgpu/structs.py
@@ -23,18 +23,19 @@ class Struct:
         return f"<{self.__class__.__name__} {self._name}: {options}>"
 
 
-# There are 52 structs
+# There are 53 structs
 
 RequestAdapterOptions = Struct(
     "RequestAdapterOptions",
     power_preference="enums.PowerPreference",
+    force_software="bool",
 )  #:
 
 DeviceDescriptor = Struct(
     "DeviceDescriptor",
     label="str",
-    non_guaranteed_features="List[enums.FeatureName]",
-    non_guaranteed_limits="Dict[str, int]",
+    required_features="List[enums.FeatureName]",
+    required_limits="Dict[str, int]",
 )  #:
 
 BufferDescriptor = Struct(
@@ -174,6 +175,7 @@ ProgrammableStage = Struct(
     "ProgrammableStage",
     module="GPUShaderModule",
     entry_point="str",
+    constants="Dict[str, float]",
 )  #:
 
 ComputePipelineDescriptor = Struct(
@@ -214,6 +216,7 @@ FragmentState = Struct(
     "FragmentState",
     module="GPUShaderModule",
     entry_point="str",
+    constants="Dict[str, float]",
     targets="List[structs.ColorTargetState]",
 )  #:
 
@@ -263,6 +266,7 @@ VertexState = Struct(
     "VertexState",
     module="GPUShaderModule",
     entry_point="str",
+    constants="Dict[str, float]",
     buffers="List[structs.VertexBufferLayout]",
 )  #:
 
@@ -312,6 +316,16 @@ ImageCopyTexture = Struct(
     mip_level="int",
     origin="Union[List[int], structs.Origin3D]",
     aspect="enums.TextureAspect",
+)  #:
+
+ImageCopyTextureTagged = Struct(
+    "ImageCopyTextureTagged",
+    texture="GPUTexture",
+    mip_level="int",
+    origin="Union[List[int], structs.Origin3D]",
+    aspect="enums.TextureAspect",
+    color_space="enums.PredefinedColorSpace",
+    premultiplied_alpha="bool",
 )  #:
 
 ImageCopyExternalImage = Struct(
@@ -373,13 +387,14 @@ QuerySetDescriptor = Struct(
     pipeline_statistics="List[enums.PipelineStatisticName]",
 )  #:
 
-SwapChainDescriptor = Struct(
-    "SwapChainDescriptor",
-    label="str",
+PresentationConfiguration = Struct(
+    "PresentationConfiguration",
     device="GPUDevice",
     format="enums.TextureFormat",
     usage="flags.TextureUsage",
+    color_space="enums.PredefinedColorSpace",
     compositing_alpha_mode="enums.CanvasCompositingAlphaMode",
+    size="structs.Extent3D",
 )  #:
 
 UncapturedErrorEventInit = Struct(

--- a/wgpu/structs.py
+++ b/wgpu/structs.py
@@ -318,16 +318,6 @@ ImageCopyTexture = Struct(
     aspect="enums.TextureAspect",
 )  #:
 
-ImageCopyTextureTagged = Struct(
-    "ImageCopyTextureTagged",
-    texture="GPUTexture",
-    mip_level="int",
-    origin="Union[List[int], structs.Origin3D]",
-    aspect="enums.TextureAspect",
-    color_space="enums.PredefinedColorSpace",
-    premultiplied_alpha="bool",
-)  #:
-
 ImageCopyExternalImage = Struct(
     "ImageCopyExternalImage",
     source="Union[memoryview, object, object]",


### PR DESCRIPTION
* The swap-chain class has been removed. This object was used as a context manager.
  One should now use the present context object instead (see below). The
  drawn result is now automatically presented to the screen at the end of a draw event.
* The `canvas.configure_swap_chain()` method has been removed. Instead,
  `canvas.get_context()` should be used, to obtain a present context.
* The new `GPUPresentationContext` class can be `configure()`'d, and a texture can be obtained via
  `context.get_current_texture()`.
* Adds `WgpuOffscreenCanvas` to support off-screen rendering while using a canvas API.
* The `adapter.request_device()` method has its arguments `non_guaranteed_features` and `non_guaranteed_limits`
  replaced with `required_features` and `required_limits`.
* The enum field `StoreOp.clear` is now `StoreOp.discard`.
* Adds `adapter.is_software` property.
