### PR TITLE
Updates for latest wgpu-native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,12 @@ jobs:
       run: |
           python download-wgpu-native.py
           python setup.py bdist_wheel
-    - name: Manylinux2010 tag
+    - name: Manylinux tag
       if: startsWith(matrix.os, 'ubuntu')
       run: |
           sudo apt-get update
           sudo apt-get install -y patchelf
-          auditwheel repair --plat manylinux2010_x86_64 dist/*.whl
+          auditwheel repair --plat manylinux_2_24_x86_64 dist/*.whl
           rm dist/*.whl
           cp wheelhouse/*.whl dist/.
     - name: Test wheel

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -30,8 +30,9 @@ struct VertexOutput {
 
 [[stage(vertex)]]
 fn vs_main(in: VertexInput) -> VertexOutput {
-    let positions = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
-    let p: vec2<f32> = positions[in.vertex_index];
+    var positions: array<vec2<f32>, 3> = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
+    let index = i32(in.vertex_index);
+    let p: vec2<f32> = positions[index];
 
     var out: VertexOutput;
     out.pos = vec4<f32>(p, 0.0, 1.0);

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,10 @@ exclude = build,dist,*.egg-info
 # E203 whitespace before ':'
 # F722 syntax error in forward annotation
 # F821 undefined name -> we must get rid of this!
-extend-ignore = E501, E203
+# B006 Do not use mutable data structures for argument defaults.
+# B007 Loop control variable 'j2' not used within the loop body.
+# D docstring checks
+extend-ignore = E501, E203, B006, B007, D
 
 per-file-ignores =
     tests/test_compute.py: F821,F722

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -96,7 +96,7 @@ def test_compute_0_1_str():
 def test_compute_0_1_int():
     compute_shader = simple_compute_shader
 
-    out = compute_with_buffers({}, {0: 400}, compute_shader)
+    out = compute_with_buffers({}, {0: 400}, compute_shader, n=100)
     assert isinstance(out, dict) and len(out) == 1
     assert isinstance(out[0], memoryview)
     assert out[0].cast("i").tolist() == list(range(100))

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -101,7 +101,6 @@ def test_compute_0_1_int():
     assert isinstance(out[0], memoryview)
     assert out[0].cast("i").tolist() == list(range(100))
 
-
 @mark.skipif(is_ci, reason="Cannot use SpirV shader on dx12")
 def test_compute_0_1_spirv():
 

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -101,6 +101,7 @@ def test_compute_0_1_int():
     assert isinstance(out[0], memoryview)
     assert out[0].cast("i").tolist() == list(range(100))
 
+
 @mark.skipif(is_ci, reason="Cannot use SpirV shader on dx12")
 def test_compute_0_1_spirv():
 

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -58,7 +58,7 @@ def test_glfw_canvas_basics():
 shader_source = """
 [[stage(vertex)]]
 fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> [[builtin(position)]] vec4<f32> {
-    let positions = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
+    var positions: array<vec2<f32>, 3> = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
     let p: vec2<f32> = positions[vertex_index];
     return vec4<f32>(p, 0.0, 1.0);
 }

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -68,11 +68,11 @@ def test_tuple_from_tuple_or_dict():
     assert func({"width": 10, "height": 20}, ("width", "height")) == (10, 20)
 
     with raises(TypeError):
-        func("not tuple/dict", ("x", "y")) == (1, 2)
+        func("not tuple/dict", ("x", "y"))
     with raises(ValueError):
-        func([1], ("x", "y")) == (1, 2)
+        func([1], ("x", "y"))
     with raises(ValueError):
-        func([1, 2, 3], ("x", "y")) == (1, 2)
+        func([1, 2, 3], ("x", "y"))
     with raises(ValueError):
         assert func({"x": 1}, ("x", "y"))
 

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -552,7 +552,7 @@ def test_render_orange_dots():
     shader_source = """
         struct VertexOutput {
             [[builtin(position)]] position: vec4<f32>;
-            //[[builtin(gl_PointSize]] point_size: f32;
+            //[[builtin(pointSize]] point_size: f32;
         };
 
         [[stage(vertex)]]

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -20,7 +20,7 @@ elif is_ci:
 default_vertex_shader = """
 [[stage(vertex)]]
 fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> [[builtin(position)]] vec4<f32> {
-    let positions = array<vec3<f32>, 4>(
+    var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
         vec3<f32>(-0.5, -0.5, 0.1),
         vec3<f32>(-0.5,  0.5, 0.1),
         vec3<f32>( 0.5, -0.5, 0.1),
@@ -454,7 +454,7 @@ def test_render_orange_square_depth():
     shader_source = """
         [[stage(vertex)]]
         fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> [[builtin(position)]] vec4<f32> {
-            let positions = array<vec3<f32>, 4>(
+            var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
                 vec3<f32>(-0.5, -0.5, 0.0),
                 vec3<f32>(-0.5,  0.5, 0.0),
                 vec3<f32>( 0.5, -0.5, 0.2),
@@ -557,7 +557,7 @@ def test_render_orange_dots():
 
         [[stage(vertex)]]
         fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> VertexOutput {
-            let positions = array<vec3<f32>, 4>(
+            var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
                 vec3<f32>(-0.5, -0.5, 0.0),
                 vec3<f32>(-0.5,  0.5, 0.0),
                 vec3<f32>( 0.5, -0.5, 0.2),

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -26,7 +26,7 @@ struct VertexOutput {
 
 [[stage(vertex)]]
 fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> VertexOutput {
-    let positions = array<vec2<f32>, 4>(
+    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
         vec2<f32>(-0.5, -0.5),
         vec2<f32>(-0.5,  0.5),
         vec2<f32>( 0.5, -0.5),

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -36,19 +36,18 @@ def _determine_can_use_vulkan_sdk():
 
 
 def _determine_can_use_wgpu_lib():
-    code = "import wgpu.utils; wgpu.utils.get_default_device()"
-    try:
-        subprocess.check_output(
-            [
-                sys.executable,
-                "-c",
-                code,
-            ]
-        )
-    except Exception:
-        return False
-    else:
-        return True
+    # For some reason, since wgpu-native 5c304b5ea1b933574edb52d5de2d49ea04a053db
+    # the process' exit code is not zero, so we test more pragmatically.
+    code = "import wgpu.utils; wgpu.utils.get_default_device(); print('ok')"
+    status, out = subprocess.getstatusoutput(
+        [
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+    print("_determine_can_use_wgpu_lib() status code:", status)
+    return out.endswith("ok") and "traceback" not in out.lower()
 
 
 can_use_vulkan_sdk = _determine_can_use_vulkan_sdk()

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -558,12 +558,12 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
         size = _tuple_from_tuple_or_dict(
             size, ("width", "height", "depth_or_array_layers")
         )
-        # H: width: int, height: int, depth: int
+        # H: width: int, height: int, depthOrArrayLayers: int
         c_size = new_struct(
             "WGPUExtent3D",
             width=size[0],
             height=size[1],
-            depth=size[2],
+            depthOrArrayLayers=size[2],
         )
         # H: nextInChain: WGPUChainedStruct *, label: char *, usage: WGPUTextureUsageFlags/int, dimension: WGPUTextureDimension, size: WGPUExtent3D, format: WGPUTextureFormat, mipLevelCount: int, sampleCount: int
         struct = new_struct_p(
@@ -1408,10 +1408,10 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
                 b=clr[2],
                 a=clr[3],
             )
-            # H: attachment: WGPUTextureView, resolveTarget: WGPUTextureView, loadOp: WGPULoadOp, storeOp: WGPUStoreOp, clearColor: WGPUColor
+            # H: view: WGPUTextureView, resolveTarget: WGPUTextureView, loadOp: WGPULoadOp, storeOp: WGPUStoreOp, clearColor: WGPUColor
             c_attachment = new_struct(
-                "WGPURenderPassColorAttachmentDescriptor",
-                attachment=texture_view_id,
+                "WGPURenderPassColorAttachment",
+                view=texture_view_id,
                 resolveTarget=c_resolve_target,
                 loadOp=c_load_op,
                 storeOp=color_attachment.get("store_op", "store"),
@@ -1420,7 +1420,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
             )
             c_color_attachments_list.append(c_attachment)
         c_color_attachments_array = ffi.new(
-            "WGPURenderPassColorAttachmentDescriptor []", c_color_attachments_list
+            "WGPURenderPassColorAttachment []", c_color_attachments_list
         )
 
         c_depth_stencil_attachment = ffi.NULL
@@ -1432,10 +1432,10 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
             c_stencil_load_op, c_stencil_clear = _loadop_and_clear_from_value(
                 depth_stencil_attachment["stencil_load_value"]
             )
-            # H: attachment: WGPUTextureView, depthLoadOp: WGPULoadOp, depthStoreOp: WGPUStoreOp, clearDepth: float, depthReadOnly: bool, stencilLoadOp: WGPULoadOp, stencilStoreOp: WGPUStoreOp, clearStencil: int, stencilReadOnly: bool
+            # H: view: WGPUTextureView, depthLoadOp: WGPULoadOp, depthStoreOp: WGPUStoreOp, clearDepth: float, depthReadOnly: bool, stencilLoadOp: WGPULoadOp, stencilStoreOp: WGPUStoreOp, clearStencil: int, stencilReadOnly: bool
             c_depth_stencil_attachment = new_struct_p(
-                "WGPURenderPassDepthStencilAttachmentDescriptor *",
-                attachment=depth_stencil_attachment["view"]._internal,
+                "WGPURenderPassDepthStencilAttachment *",
+                view=depth_stencil_attachment["view"]._internal,
                 depthLoadOp=c_depth_load_op,
                 depthStoreOp=depth_stencil_attachment["depth_store_op"],
                 clearDepth=float(c_depth_clear),
@@ -1448,7 +1448,7 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
                 ),
             )
 
-        # H: nextInChain: WGPUChainedStruct *, label: char *, colorAttachmentCount: int, colorAttachments: WGPURenderPassColorAttachmentDescriptor *, depthStencilAttachment: WGPURenderPassDepthStencilAttachmentDescriptor *, occlusionQuerySet: WGPUQuerySet
+        # H: nextInChain: WGPUChainedStruct *, label: char *, colorAttachmentCount: int, colorAttachments: WGPURenderPassColorAttachment *, depthStencilAttachment: WGPURenderPassDepthStencilAttachment *, occlusionQuerySet: WGPUQuerySet
         struct = new_struct_p(
             "WGPURenderPassDescriptor *",
             label=to_c_label(label),
@@ -1526,12 +1526,12 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
         size = _tuple_from_tuple_or_dict(
             copy_size, ("width", "height", "depth_or_array_layers")
         )
-        # H: width: int, height: int, depth: int
+        # H: width: int, height: int, depthOrArrayLayers: int
         c_copy_size = new_struct_p(
             "WGPUExtent3D *",
             width=size[0],
             height=size[1],
-            depth=size[2],
+            depthOrArrayLayers=size[2],
         )
 
         # H: void f(WGPUCommandEncoder commandEncoder, WGPUImageCopyBuffer const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize)
@@ -1586,12 +1586,12 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
         size = _tuple_from_tuple_or_dict(
             copy_size, ("width", "height", "depth_or_array_layers")
         )
-        # H: width: int, height: int, depth: int
+        # H: width: int, height: int, depthOrArrayLayers: int
         c_copy_size = new_struct_p(
             "WGPUExtent3D *",
             width=size[0],
             height=size[1],
-            depth=size[2],
+            depthOrArrayLayers=size[2],
         )
 
         # H: void f(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyBuffer const * destination, WGPUExtent3D const * copySize)
@@ -1648,12 +1648,12 @@ class GPUCommandEncoder(base.GPUCommandEncoder, GPUObjectBase):
         size = _tuple_from_tuple_or_dict(
             copy_size, ("width", "height", "depth_or_array_layers")
         )
-        # H: width: int, height: int, depth: int
+        # H: width: int, height: int, depthOrArrayLayers: int
         c_copy_size = new_struct_p(
             "WGPUExtent3D *",
             width=size[0],
             height=size[1],
-            depth=size[2],
+            depthOrArrayLayers=size[2],
         )
 
         # H: void f(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize)
@@ -1912,7 +1912,7 @@ class GPURenderPassEncoder(
             a=color[3],
         )
         # H: void f(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color)
-        lib.wgpuRenderPassEncoderSetBlendColor(self._internal, c_color)
+        lib.wgpuRenderPassEncoderSetBlendConstant(self._internal, c_color)
 
     def set_stencil_reference(self, reference):
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t reference)
@@ -2063,12 +2063,12 @@ class GPUQueue(base.GPUQueue, GPUObjectBase):
         size = _tuple_from_tuple_or_dict(
             size, ("width", "height", "depth_or_array_layers")
         )
-        # H: width: int, height: int, depth: int
+        # H: width: int, height: int, depthOrArrayLayers: int
         c_size = new_struct_p(
             "WGPUExtent3D *",
             width=size[0],
             height=size[1],
-            depth=size[2],
+            depthOrArrayLayers=size[2],
         )
 
         # H: void f(WGPUQueue queue, WGPUImageCopyTexture const * destination, void const * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize)

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -53,8 +53,8 @@ logger = logging.getLogger("wgpu")  # noqa
 apidiff = ApiDiff()
 
 # The wgpu-native version that we target/expect
-__version__ = "0.8.0.2"
-__commit_sha__ = "66a4139579f2499a67b7ade1a6c3bcb414046c64"
+__version__ = "0.9.2.1"
+__commit_sha__ = "aaa5dcc8ae8fbac8fdcd445016dd643fdab3cfba"
 version_info = tuple(map(int, __version__.split(".")))
 check_expected_version(version_info)  # produces a warning on mismatch
 

--- a/wgpu/backends/rs_mappings.py
+++ b/wgpu/backends/rs_mappings.py
@@ -4,16 +4,22 @@
 
 # flake8: noqa
 
-# There are 169 enum mappings
+# There are 175 enum mappings
 
 enummap = {
     "AddressMode.clamp-to-edge": 2,
     "AddressMode.mirror-repeat": 1,
     "AddressMode.repeat": 0,
+    "BlendFactor.constant": 11,
+    "BlendFactor.dst": 6,
     "BlendFactor.dst-alpha": 8,
     "BlendFactor.one": 1,
+    "BlendFactor.one-minus-constant": 12,
+    "BlendFactor.one-minus-dst": 7,
     "BlendFactor.one-minus-dst-alpha": 9,
+    "BlendFactor.one-minus-src": 3,
     "BlendFactor.one-minus-src-alpha": 5,
+    "BlendFactor.src": 2,
     "BlendFactor.src-alpha": 4,
     "BlendFactor.src-alpha-saturated": 10,
     "BlendFactor.zero": 0,
@@ -195,12 +201,12 @@ cstructfield2enum = {
     "PrimitiveState.topology": "PrimitiveTopology",
     "QuerySetDescriptor.type": "QueryType",
     "RenderBundleEncoderDescriptor.depthStencilFormat": "TextureFormat",
-    "RenderPassColorAttachmentDescriptor.loadOp": "LoadOp",
-    "RenderPassColorAttachmentDescriptor.storeOp": "StoreOp",
-    "RenderPassDepthStencilAttachmentDescriptor.depthLoadOp": "LoadOp",
-    "RenderPassDepthStencilAttachmentDescriptor.depthStoreOp": "StoreOp",
-    "RenderPassDepthStencilAttachmentDescriptor.stencilLoadOp": "LoadOp",
-    "RenderPassDepthStencilAttachmentDescriptor.stencilStoreOp": "StoreOp",
+    "RenderPassColorAttachment.loadOp": "LoadOp",
+    "RenderPassColorAttachment.storeOp": "StoreOp",
+    "RenderPassDepthStencilAttachment.depthLoadOp": "LoadOp",
+    "RenderPassDepthStencilAttachment.depthStoreOp": "StoreOp",
+    "RenderPassDepthStencilAttachment.stencilLoadOp": "LoadOp",
+    "RenderPassDepthStencilAttachment.stencilStoreOp": "StoreOp",
     "SamplerBindingLayout.type": "SamplerBindingType",
     "SamplerDescriptor.addressModeU": "AddressMode",
     "SamplerDescriptor.addressModeV": "AddressMode",

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -3,7 +3,7 @@
 * The webgpu.idl defines 33 classes with 83 functions
 * The webgpu.idl defines 5 flags, 31 enums, 53 structs
 * The wgpu.h defines 106 functions
-* The wgpu.h defines 5 flags, 37 enums, 59 structs
+* The wgpu.h defines 5 flags, 37 enums, 60 structs
 ## Updating API
 * Wrote 5 flags to flags.py
 * Wrote 31 enums to enums.py
@@ -31,15 +31,9 @@
 * Enum field TextureFormat.depth24unorm-stencil8 missing in wgpu.h
 * Enum field TextureFormat.depth32float-stencil8 missing in wgpu.h
 * Enum CompilationMessageType missing in wgpu.h
-* Enum field BlendFactor.src missing in wgpu.h
-* Enum field BlendFactor.one-minus-src missing in wgpu.h
-* Enum field BlendFactor.dst missing in wgpu.h
-* Enum field BlendFactor.one-minus-dst missing in wgpu.h
-* Enum field BlendFactor.constant missing in wgpu.h
-* Enum field BlendFactor.one-minus-constant missing in wgpu.h
 * Enum CanvasCompositingAlphaMode missing in wgpu.h
 * Enum DeviceLostReason missing in wgpu.h
-* Wrote 169 enum mappings and 45 struct-field mappings to rs_mappings.py
+* Wrote 175 enum mappings and 45 struct-field mappings to rs_mappings.py
 * Validated 65 C function calls
 * Not using 46 C functions
 * Validated 66 C structs

--- a/wgpu/resources/webgpu.h
+++ b/wgpu/resources/webgpu.h
@@ -110,17 +110,17 @@ typedef enum WGPUBackendType {
 typedef enum WGPUBlendFactor {
     WGPUBlendFactor_Zero = 0x00000000,
     WGPUBlendFactor_One = 0x00000001,
-    WGPUBlendFactor_SrcColor = 0x00000002,
-    WGPUBlendFactor_OneMinusSrcColor = 0x00000003,
+    WGPUBlendFactor_Src = 0x00000002,
+    WGPUBlendFactor_OneMinusSrc = 0x00000003,
     WGPUBlendFactor_SrcAlpha = 0x00000004,
     WGPUBlendFactor_OneMinusSrcAlpha = 0x00000005,
-    WGPUBlendFactor_DstColor = 0x00000006,
-    WGPUBlendFactor_OneMinusDstColor = 0x00000007,
+    WGPUBlendFactor_Dst = 0x00000006,
+    WGPUBlendFactor_OneMinusDst = 0x00000007,
     WGPUBlendFactor_DstAlpha = 0x00000008,
     WGPUBlendFactor_OneMinusDstAlpha = 0x00000009,
     WGPUBlendFactor_SrcAlphaSaturated = 0x0000000A,
-    WGPUBlendFactor_BlendColor = 0x0000000B,
-    WGPUBlendFactor_OneMinusBlendColor = 0x0000000C,
+    WGPUBlendFactor_Constant = 0x0000000B,
+    WGPUBlendFactor_OneMinusConstant = 0x0000000C,
     WGPUBlendFactor_Force32 = 0x7FFFFFFF
 } WGPUBlendFactor;
 
@@ -275,6 +275,7 @@ typedef enum WGPUSType {
     WGPUSType_SurfaceDescriptorFromCanvasHTMLSelector = 0x00000004,
     WGPUSType_ShaderModuleSPIRVDescriptor = 0x00000005,
     WGPUSType_ShaderModuleWGSLDescriptor = 0x00000006,
+    WGPUSType_PrimitiveDepthClampingState = 0x00000007,
     WGPUSType_Force32 = 0x7FFFFFFF
 } WGPUSType;
 
@@ -577,7 +578,7 @@ typedef struct WGPUDeviceDescriptor {
 typedef struct WGPUExtent3D {
     uint32_t width;
     uint32_t height;
-    uint32_t depth;
+    uint32_t depthOrArrayLayers;
 } WGPUExtent3D;
 
 typedef struct WGPUInstanceDescriptor {
@@ -603,6 +604,11 @@ typedef struct WGPUPipelineLayoutDescriptor {
     uint32_t bindGroupLayoutCount;
     WGPUBindGroupLayout const * bindGroupLayouts;
 } WGPUPipelineLayoutDescriptor;
+
+typedef struct WGPUPrimitiveDepthClampingState {
+    WGPUChainedStruct chain;
+    bool clampDepth;
+} WGPUPrimitiveDepthClampingState;
 
 typedef struct WGPUPrimitiveState {
     WGPUChainedStruct const * nextInChain;
@@ -641,8 +647,8 @@ typedef struct WGPURenderBundleEncoderDescriptor {
     uint32_t sampleCount;
 } WGPURenderBundleEncoderDescriptor;
 
-typedef struct WGPURenderPassDepthStencilAttachmentDescriptor {
-    WGPUTextureView attachment;
+typedef struct WGPURenderPassDepthStencilAttachment {
+    WGPUTextureView view;
     WGPULoadOp depthLoadOp;
     WGPUStoreOp depthStoreOp;
     float clearDepth;
@@ -651,7 +657,7 @@ typedef struct WGPURenderPassDepthStencilAttachmentDescriptor {
     WGPUStoreOp stencilStoreOp;
     uint32_t clearStencil;
     bool stencilReadOnly;
-} WGPURenderPassDepthStencilAttachmentDescriptor;
+} WGPURenderPassDepthStencilAttachment;
 
 typedef struct WGPURequestAdapterOptions {
     WGPUChainedStruct const * nextInChain;
@@ -835,13 +841,13 @@ typedef struct WGPUImageCopyTexture {
     WGPUTextureAspect aspect;
 } WGPUImageCopyTexture;
 
-typedef struct WGPURenderPassColorAttachmentDescriptor {
-    WGPUTextureView attachment;
+typedef struct WGPURenderPassColorAttachment {
+    WGPUTextureView view;
     WGPUTextureView resolveTarget;
     WGPULoadOp loadOp;
     WGPUStoreOp storeOp;
     WGPUColor clearColor;
-} WGPURenderPassColorAttachmentDescriptor;
+} WGPURenderPassColorAttachment;
 
 typedef struct WGPUTextureDescriptor {
     WGPUChainedStruct const * nextInChain;
@@ -879,8 +885,8 @@ typedef struct WGPURenderPassDescriptor {
     WGPUChainedStruct const * nextInChain;
     char const * label;
     uint32_t colorAttachmentCount;
-    WGPURenderPassColorAttachmentDescriptor const * colorAttachments;
-    WGPURenderPassDepthStencilAttachmentDescriptor const * depthStencilAttachment;
+    WGPURenderPassColorAttachment const * colorAttachments;
+    WGPURenderPassDepthStencilAttachment const * depthStencilAttachment;
     WGPUQuerySet occlusionQuerySet;
 } WGPURenderPassDescriptor;
 
@@ -1040,7 +1046,7 @@ typedef void (*WGPUProcRenderPassEncoderInsertDebugMarker)(WGPURenderPassEncoder
 typedef void (*WGPUProcRenderPassEncoderPopDebugGroup)(WGPURenderPassEncoder renderPassEncoder);
 typedef void (*WGPUProcRenderPassEncoderPushDebugGroup)(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel);
 typedef void (*WGPUProcRenderPassEncoderSetBindGroup)(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPUBindGroup group, uint32_t dynamicOffsetCount, uint32_t const * dynamicOffsets);
-typedef void (*WGPUProcRenderPassEncoderSetBlendColor)(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color);
+typedef void (*WGPUProcRenderPassEncoderSetBlendConstant)(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color);
 typedef void (*WGPUProcRenderPassEncoderSetIndexBuffer)(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size);
 typedef void (*WGPUProcRenderPassEncoderSetPipeline)(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline);
 typedef void (*WGPUProcRenderPassEncoderSetScissorRect)(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
@@ -1176,7 +1182,7 @@ WGPU_EXPORT void wgpuRenderPassEncoderInsertDebugMarker(WGPURenderPassEncoder re
 WGPU_EXPORT void wgpuRenderPassEncoderPopDebugGroup(WGPURenderPassEncoder renderPassEncoder);
 WGPU_EXPORT void wgpuRenderPassEncoderPushDebugGroup(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel);
 WGPU_EXPORT void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPUBindGroup group, uint32_t dynamicOffsetCount, uint32_t const * dynamicOffsets);
-WGPU_EXPORT void wgpuRenderPassEncoderSetBlendColor(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color);
+WGPU_EXPORT void wgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color);
 WGPU_EXPORT void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size);
 WGPU_EXPORT void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline);
 WGPU_EXPORT void wgpuRenderPassEncoderSetScissorRect(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height);

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,7 +1,7 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu-headers/webgpu.h"
+#include "webgpu.h"
 
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,7 +1,7 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu.h"
+#include "webgpu-headers/webgpu.h"
 
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes


### PR DESCRIPTION
* [x] (wait for) release wgpu-native
* [x] Bump to latest wgpu-native
* [x] Apply any necessary changes

The wgpu-native has bumped its version of wgpu-core and Naga. The only changes that matter to us are that Naga is a bit more strict with indexing (can't index into arrays created with `let`, but must use `var` instead).