### PR TITLE
Add experimental support for running CI tests with offscreen canvas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.pyversion }}
+    - name: Install llvmpipe and lavapipe for offscreen canvas
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update -y -qq
+        sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+        sudo apt-get update
+        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This installs a nightly `mesa` build from oibaf's PPA with `lavapipe`, which has now (limited) support for Vulkan 1.2. With this it is possible to get an offscreen canvas.

Inspired by: https://github.com/gfx-rs/wgpu/blob/b679342d9e62e50eff307d785590ffcbcc39b0d8/.github/workflows/ci.yml#L111