### PR TITLE
Use queue.write_texture instead of copy_to_texture with a temp buffer

### DIFF
--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -94,11 +94,7 @@ def _main(canvas, device):
             "cull_mode": wgpu.CullMode.none,
         },
         depth_stencil=None,
-        multisample={
-            "count": 1,
-            "mask": 0xFFFFFFFF,
-            "alpha_to_coverage_enabled": False,
-        },
+        multisample=None,
         fragment={
             "module": shader,
             "entry_point": "fs_main",


### PR DESCRIPTION
This is cleaner and shorter, and avoids the (hopefully temporary) bug described in https://github.com/pygfx/pygfx/issues/219.