### PR TITLE
Add event pubsub for glfw and jupyter canvas

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ import wgpu.gui  # noqa: E402
 with open(os.path.join(ROOT_DIR, "docs", "reference_wgpu.rst"), "rb") as f:
     wgpu_api_docs_text = f.read().decode()
 for cls_name in wgpu.base.__all__:
-    expected_line = f".. autoclass:: wgpu.{cls_name}\n"
+    expected_line = f".. autoclass:: wgpu.{cls_name}"
     assert expected_line in wgpu_api_docs_text, f"Missing docs for {cls_name}"
 
 # Make flags and enum appear better in docs

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -314,11 +314,23 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
         for callback in self._event_handlers[event_type]:
             callback(event)
 
-    def add_event_handler(self, type, callback):
-        self._event_handlers[type].add(callback)
+    def add_event_handler(self, *args):
+        decorating = callable(args[0])
+        callback = args[0] if decorating else None
+        types = args[1:] if decorating else args
 
-    def remove_event_handler(self, type, callback):
-        self._event_handlers[type].remove(callback)
+        def decorator(_callback):
+            for type in types:
+                self._event_handlers[type].add(_callback)
+            return _callback
+
+        if not decorating:
+            return decorator
+        return decorator(callback)
+
+    def remove_event_handler(self, callback, *types):
+        for type in types:
+            self._event_handlers[type].remove(callback)
 
     # User events
 

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -7,6 +7,7 @@ On Linux, install the glfw lib using ``sudo apt install libglfw3``,
 or ``sudo apt install libglfw3-wayland`` when using Wayland.
 """
 
+from collections import defaultdict
 import os
 import sys
 import time
@@ -138,6 +139,7 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
         self._need_draw = False
         self._request_draw_timer_running = False
         self._changing_pixel_ratio = False
+        self._event_handlers = defaultdict(set)
 
         # Register ourselves
         all_glfw_canvases.add(self)
@@ -308,7 +310,15 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
         is a dict with at least the key event_type. For details, see
         https://jupyter-rfb.readthedocs.io/en/latest/events.html
         """
-        pass
+        event_type = event.get("event_type")
+        for callback in self._event_handlers[event_type]:
+            callback(event)
+
+    def add_event_handler(self, type, callback):
+        self._event_handlers[type].add(callback)
+
+    def remove_event_handler(self, type, callback):
+        self._event_handlers[type].remove(callback)
 
     # User events
 

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -315,16 +315,16 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
             callback(event)
 
     def add_event_handler(self, *args):
-        decorating = callable(args[0])
-        callback = args[0] if decorating else None
-        types = args[1:] if decorating else args
+        decorating = not callable(args[0])
+        callback = None if decorating else args[0]
+        types = args if decorating else args[1:]
 
         def decorator(_callback):
             for type in types:
                 self._event_handlers[type].add(_callback)
             return _callback
 
-        if not decorating:
+        if decorating:
             return decorator
         return decorator(callback)
 

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -315,6 +315,35 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
             callback(event)
 
     def add_event_handler(self, *args):
+        """Register an event handler.
+
+        Arguments:
+            callback (callable): The event handler. Must accept a
+                single event argument.
+            *types (list of strings): A list of event types.
+
+        For the available events, see
+        https://jupyter-rfb.readthedocs.io/en/latest/events.html
+
+        Can also be used as a decorator.
+
+        Example:
+
+        .. code-block:: py
+
+            def my_handler(event):
+                print(event)
+
+            canvas.add_event_handler(my_handler, "pointer_up", "pointer_down")
+
+        Decorator usage example:
+
+        .. code-block:: py
+
+            @canvas.add_event_handler("pointer_up", "pointer_down")
+            def my_handler(event):
+                print(event)
+        """
         decorating = not callable(args[0])
         callback = None if decorating else args[0]
         types = args if decorating else args[1:]
@@ -329,6 +358,12 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
         return decorator(callback)
 
     def remove_event_handler(self, callback, *types):
+        """Unregister an event handler.
+
+        Arguments:
+            callback (callable): The event handler.
+            *types (list of strings): A list of event types.
+        """
         for type in types:
             self._event_handlers[type].remove(callback)
 

--- a/wgpu/gui/jupyter.py
+++ b/wgpu/gui/jupyter.py
@@ -94,7 +94,7 @@ class JupyterWgpuCanvas(WgpuOffscreenCanvas, RemoteFrameBuffer):
         return decorator(callback)
 
     def remove_event_handler(self, callback, *types):
-        """Unregister an event hand ler.
+        """Unregister an event handler.
 
         Arguments:
             callback (callable): The event handler.

--- a/wgpu/gui/jupyter.py
+++ b/wgpu/gui/jupyter.py
@@ -51,6 +51,35 @@ class JupyterWgpuCanvas(WgpuOffscreenCanvas, RemoteFrameBuffer):
             callback(event)
 
     def add_event_handler(self, *args):
+        """Register an event handler.
+
+        Arguments:
+            callback (callable): The event handler. Must accept a
+                single event argument.
+            *types (list of strings): A list of event types.
+
+        For the available events, see
+        https://jupyter-rfb.readthedocs.io/en/latest/events.html
+
+        Can also be used as a decorator.
+
+        Example:
+
+        .. code-block:: py
+
+            def my_handler(event):
+                print(event)
+
+            canvas.add_event_handler(my_handler, "pointer_up", "pointer_down")
+
+        Decorator usage example:
+
+        .. code-block:: py
+
+            @canvas.add_event_handler("pointer_up", "pointer_down")
+            def my_handler(event):
+                print(event)
+        """
         decorating = not callable(args[0])
         callback = None if decorating else args[0]
         types = args if decorating else args[1:]
@@ -65,6 +94,12 @@ class JupyterWgpuCanvas(WgpuOffscreenCanvas, RemoteFrameBuffer):
         return decorator(callback)
 
     def remove_event_handler(self, callback, *types):
+        """Unregister an event hand ler.
+
+        Arguments:
+            callback (callable): The event handler.
+            *types (list of strings): A list of event types.
+        """
         for type in types:
             self._event_handlers[type].remove(callback)
 

--- a/wgpu/gui/jupyter.py
+++ b/wgpu/gui/jupyter.py
@@ -51,16 +51,16 @@ class JupyterWgpuCanvas(WgpuOffscreenCanvas, RemoteFrameBuffer):
             callback(event)
 
     def add_event_handler(self, *args):
-        decorating = callable(args[0])
-        callback = args[0] if decorating else None
-        types = args[1:] if decorating else args
+        decorating = not callable(args[0])
+        callback = None if decorating else args[0]
+        types = args if decorating else args[1:]
 
         def decorator(_callback):
             for type in types:
                 self._event_handlers[type].add(_callback)
             return _callback
 
-        if not decorating:
+        if decorating:
             return decorator
         return decorator(callback)
 

--- a/wgpu/gui/jupyter.py
+++ b/wgpu/gui/jupyter.py
@@ -50,11 +50,23 @@ class JupyterWgpuCanvas(WgpuOffscreenCanvas, RemoteFrameBuffer):
         for callback in self._event_handlers[event_type]:
             callback(event)
 
-    def add_event_handler(self, type, callback):
-        self._event_handlers[type].add(callback)
+    def add_event_handler(self, *args):
+        decorating = callable(args[0])
+        callback = args[0] if decorating else None
+        types = args[1:] if decorating else args
 
-    def remove_event_handler(self, type, callback):
-        self._event_handlers[type].remove(callback)
+        def decorator(_callback):
+            for type in types:
+                self._event_handlers[type].add(_callback)
+            return _callback
+
+        if not decorating:
+            return decorator
+        return decorator(callback)
+
+    def remove_event_handler(self, callback, *types):
+        for type in types:
+            self._event_handlers[type].remove(callback)
 
     def get_frame(self):
         self._request_draw_timer_running = False


### PR DESCRIPTION
See https://github.com/pygfx/pygfx/issues/223

New API implemented for glfw and jupyter canvases:

```python
canvas.add_event_handler(callback, *types)
canvas.remove_event_handler(callback, *types)

@canvas.add_event_handler(*types)
def callback(event):
    ...
```

Where `type` can be any event from [the spec](https://jupyter-rfb.readthedocs.io/en/latest/events.html) and callbacks should be callables receiving an event object.