### PR TITLE
Fix glfw window size on mac

### DIFF
--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -256,8 +256,8 @@ class GlfwWgpuCanvas(WgpuCanvasBase):
             screen_ratio = ssize[0] / psize[0]
             glfw.set_window_size(
                 self._window,
-                int(new_logical_size[0] * pixel_ratio / screen_ratio),
-                int(new_logical_size[1] * pixel_ratio / screen_ratio),
+                int(new_logical_size[0] * pixel_ratio * screen_ratio),
+                int(new_logical_size[1] * pixel_ratio * screen_ratio),
             )
         # If this causes the widget size to change, then _on_size_change will
         # be called, but we may want force redetermining the size.


### PR DESCRIPTION
The windows for GLFW are HUGE! Like 4x too big, which can be explained because we probably did a division where we should have done a multiplication. Also see the comment a few lines up.