### PR TITLE
Emit mouse_move events in Qt when no button is pressed

### DIFF
--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -123,6 +123,7 @@ class QWgpuWidget(WgpuCanvasBase, QtWidgets.QWidget):
         # Configure how Qt renders this widget
         self.setAttribute(WA_PaintOnScreen, True)
         self.setAutoFillBackground(False)
+        self.setMouseTracking(True)
 
         # A timer for limiting fps
         self._request_draw_timer = QtCore.QTimer()
@@ -210,6 +211,7 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
 
         self.set_logical_size(*(size or (640, 480)))
         self.setWindowTitle(title or "qt wgpu canvas")
+        self.setMouseTracking(True)
 
         self._subwidget = QWgpuWidget(self, max_fps=max_fps)
 


### PR DESCRIPTION
By default, Qt widgets do not receive mouse move events when no button is pressed. In order to make sure that mouse move events are tracked, I had to enable mouse tracking for both the `QWgpuWidget` *and* the `QWgpuCanvas`.