### PR TITLE
Fix mouse press events not coming through on double clicks

### DIFF
--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -343,6 +343,7 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         self._mouse_event("pointer_up", event)
 
     def mouseDoubleClickEvent(self, event):  # noqa: N802
+        super().mouseDoubleClickEvent(event)
         self._mouse_event("double_click", event, touches=False)
 
     def wheelEvent(self, event):  # noqa: N802


### PR DESCRIPTION
Calling super in `mouseDoubleClickEvent` makes sure that the mousePressEvent is called as well.