### PR TITLE
Update to wgpu-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ may need to install the Vulkan drivers. You may want to force "Vulkan" while "D3
 
 On Linux, it's advisable to install the proprietary drivers of your GPU
 (if you have a dedicated GPU). You may need to `apt install mesa-vulkan-drivers`.
-Wayland currently only works with the GLFW canvas (and is unstable).
+Wayland support is currently broken (we could use a hand to fix this).
 
 On MacOS you need at least 10.13 (High Sierra) to have Vulkan support.
 

--- a/codegen/rspatcher.py
+++ b/codegen/rspatcher.py
@@ -135,7 +135,7 @@ def write_mappings():
 
     # Write a few native-only mappings: int => key
     pylines.append("enum_int2str = {")
-    for name in ["BackendType", "AdapterType"]:
+    for name in ["BackendType", "AdapterType", "ErrorType", "DeviceLostReason"]:
         pylines.append(f'    "{name}":' + " {")
         for key, val in hp.enums[name].items():
             if key == "Force32":

--- a/codegen/rspatcher.py
+++ b/codegen/rspatcher.py
@@ -76,7 +76,8 @@ def write_mappings():
 
     # Create enummap, which allows the rs backend to resolve enum field names
     # to the corresponding integer value.
-    enummap = {}
+    # todo: remove when doing new wgsl
+    enummap = {"MipmapFilterMode.nearest": 0, "MipmapFilterMode.linear": 1}
     for name in idl.enums:
         hname = name_map.get(name, name)
         if hname not in hp.enums:
@@ -100,7 +101,10 @@ def write_mappings():
 
     # Some structs have fields that are enum values. The rs backend
     # must be able to resolve these too.
-    cstructfield2enum = {}
+    # todo: remove when doing new wgsl
+    cstructfield2enum = {
+        "SamplerDescriptor.mipmapFilter": "MipmapFilterMode",
+    }
     for structname, struct in hp.structs.items():
         for key, val in struct.items():
             if isinstance(val, str) and val.startswith("WGPU"):

--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -12,20 +12,17 @@ from wgpu.utils import compute_with_buffers  # Convenience function
 
 shader_source = """
 
-struct DataContainer {
-    data: [[stride(4)]] array<i32>;
-};
+@group(0) @binding(0)
+var<storage,read> data1: array<i32>;
 
-[[group(0), binding(0)]]
-var<storage,read> data1: DataContainer;
+@group(0) @binding(1)
+var<storage,read_write> data2: array<i32>;
 
-[[group(0), binding(1)]]
-var<storage,read_write> data2: DataContainer;
-
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+@stage(compute)
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) index: vec3<u32>) {
     let i: u32 = index.x;
-    data2.data[i] = data1.data[i];
+    data2[i] = data1[i];
 }
 """
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -151,19 +151,20 @@ shader_source = """
 struct Locals {
     transform: mat4x4<f32>;
 };
-[[group(0), binding(0)]]
+@group(0)
+@binding(0)
 var<uniform> r_locals: Locals;
 
 struct VertexInput {
-    [[location(0)]] pos : vec4<f32>;
-    [[location(1)]] texcoord: vec2<f32>;
+    @location(0) pos : vec4<f32>,
+    @location(1) texcoord: vec2<f32>,
 };
 struct VertexOutput {
-    [[location(0)]] texcoord: vec2<f32>;
-    [[builtin(position)]] pos: vec4<f32>;
+    @location(0) texcoord: vec2<f32>,
+    @builtin(position) pos: vec4<f32>,
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(in: VertexInput) -> VertexOutput {
     let ndc: vec4<f32> = r_locals.transform * in.pos;
     var out: VertexOutput;
@@ -172,14 +173,17 @@ fn vs_main(in: VertexInput) -> VertexOutput {
     return out;
 }
 
-[[group(0), binding(1)]]
+@group(0)
+@binding(1)
 var r_tex: texture_2d<f32>;
-[[group(0), binding(2)]]
+
+@group(0)
+@binding(2)
 var r_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    let value = textureSample(r_tex, r_sampler, in.texcoord).r;;
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let value = textureSample(r_tex, r_sampler, in.texcoord).r;
     return vec4<f32>(value, value, value, 1.0);
 }
 """

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -149,10 +149,9 @@ sampler = device.create_sampler()
 
 shader_source = """
 struct Locals {
-    transform: mat4x4<f32>;
+    transform: mat4x4<f32>,
 };
-@group(0)
-@binding(0)
+@group(0) @binding(0)
 var<uniform> r_locals: Locals;
 
 struct VertexInput {
@@ -173,12 +172,10 @@ fn vs_main(in: VertexInput) -> VertexOutput {
     return out;
 }
 
-@group(0)
-@binding(1)
+@group(0) @binding(1)
 var r_tex: texture_2d<f32>;
 
-@group(0)
-@binding(2)
+@group(0) @binding(2)
 var r_sampler: sampler;
 
 @stage(fragment)

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -23,14 +23,14 @@ import wgpu
 
 shader_source = """
 struct VertexInput {
-    [[builtin(vertex_index)]] vertex_index : u32;
+    @builtin(vertex_index) vertex_index : u32,
 };
 struct VertexOutput {
-    [[location(0)]] color : vec4<f32>;
-    [[builtin(position)]] pos: vec4<f32>;
+    @location(0) color : vec4<f32>,
+    @builtin(position) pos: vec4<f32>,
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vs_main(in: VertexInput) -> VertexOutput {
     var positions = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
     let index = i32(in.vertex_index);
@@ -42,8 +42,8 @@ fn vs_main(in: VertexInput) -> VertexOutput {
     return out;
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color;
 }
 """

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -16,15 +16,15 @@ if not can_use_wgpu_lib:
 
 
 simple_compute_shader = """
-    struct DataContainer { data: [[stride(4)]] array<i32>; };
+    @group(0)
+    @binding(0)
+    var<storage,read_write> data2: array<i32>;
 
-    [[group(0), binding(0)]]
-    var<storage,read_write> data2: DataContainer;
-
-    [[stage(compute), workgroup_size(1)]]
-    fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+    @stage(compute)
+    @workgroup_size(1)
+    fn main(@builtin(global_invocation_id) index: vec3<u32>) {
         let i: u32 = index.x;
-        data2.data[i] = i32(i);
+        data2[i] = i32(i);
     }
 """
 
@@ -119,22 +119,25 @@ def test_compute_0_1_spirv():
 def test_compute_1_3():
 
     compute_shader = """
-        struct DataContainer { data: [[stride(4)]] array<i32>; };
 
-        [[group(0), binding(0)]]
-        var<storage,read> data0: DataContainer;
+        @group(0)
+        @binding(0)
+        var<storage,read> data0: array<i32>;
 
-        [[group(0), binding(1)]]
-        var<storage,read_write> data1: DataContainer;
+        @group(0)
+        @binding(1)
+        var<storage,read_write> data1: array<i32>;
 
-        [[group(0), binding(2)]]
-        var<storage,read_write> data2: DataContainer;
+        @group(0)
+        @binding(2)
+        var<storage,read_write> data2: array<i32>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute)
+        @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = i32(index.x);
-            data1.data[i] = data0.data[i];
-            data2.data[i] = i;
+            data1[i] = data0[i];
+            data2[i] = i;
         }
     """
 
@@ -154,18 +157,19 @@ def test_compute_1_3():
 def test_compute_indirect():
 
     compute_shader = """
-        struct DataContainer { data: [[stride(4)]] array<i32>; };
+        @group(0)
+        @binding(0)
+        var<storage,read> data1: array<i32>;
 
-        [[group(0), binding(0)]]
-        var<storage,read> data1: DataContainer;
+        @group(0)
+        @binding(1)
+        var<storage,read_write> data2: array<i32>;
 
-        [[group(0), binding(1)]]
-        var<storage,read_write> data2: DataContainer;
-
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute)
+        @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = i32(index.x);
-            data2.data[i] = data1.data[i] + 1;
+            data2[i] = data1[i] + 1;
         }
     """
 
@@ -260,18 +264,19 @@ def test_compute_indirect():
 
 def test_compute_fails():
     compute_shader = """
-        struct DataContainer { data: [[stride(4)]] array<i32>; };
+        @group(0)
+        @binding(0)
+        var<storage,read> data1: array<i32>;
 
-        [[group(0), binding(0)]]
-        var<storage,read> data1: DataContainer;
+        @group(0)
+        @binding(1)
+        var<storage,read_write> data2: array<i32>;
 
-        [[group(0), binding(1)]]
-        var<storage,read_write> data2: DataContainer;
-
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute)
+        @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = i32(index.x);
-            data2.data[i] = data1.data[i];
+            data2[i] = data1[i];
         }
     """
 

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -66,15 +66,15 @@ def test_glfw_canvas_basics():
 
 
 shader_source = """
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4<f32> {
     var positions: array<vec2<f32>, 3> = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
     let p: vec2<f32> = positions[vertex_index];
     return vec4<f32>(p, 0.0, 1.0);
 }
 
-[[stage(fragment)]]
-fn fs_main() -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fs_main() -> @location(0) vec4<f32> {
     return vec4<f32>(1.0, 0.5, 0.0, 1.0);
 }
 """

--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -79,15 +79,15 @@ def test_tuple_from_tuple_or_dict():
 
 
 compute_shader_wgsl = """
-struct ArrayContainer { data: [[stride(4)]] array<i32>; };
+@group(0)
+@binding(0)
+var<storage,read_write> out1: array<i32>;
 
-[[group(0), binding(0)]]
-var<storage,read_write> out1: ArrayContainer;
-
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+@stage(compute)
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) index: vec3<u32>) {
     let i: u32 = index.x;
-    out1.data[i] = i32(i);
+    out1[i] = i32(i);
 }
 """
 

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -22,14 +22,14 @@ elif is_ci and sys.platform == "win32":
 def test_compute_tex_1d_rgba8uint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_1d<u32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_1d<rgba8uint,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i: i32 = i32(index.x);
             let color1 = vec4<i32>(textureLoad(r_tex1, i, 0));
             let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
@@ -57,14 +57,14 @@ def test_compute_tex_1d_rgba8uint():
 def test_compute_tex_1d_rgba16sint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_1d<i32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_1d<rgba16sint,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i: i32 = i32(index.x);
             let color1 : vec4<i32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
@@ -92,14 +92,14 @@ def test_compute_tex_1d_rgba16sint():
 def test_compute_tex_1d_r32sint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_1d<i32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_1d<r32sint, write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i: i32 = i32(index.x);
             let color1 : vec4<i32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
@@ -127,14 +127,14 @@ def test_compute_tex_1d_r32sint():
 def test_compute_tex_1d_r32float():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_1d<f32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_1d<r32float,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i: i32 = i32(index.x);
             let color1 : vec4<f32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<f32>(color1.x + f32(i), color1.y + 1.0, color1.z * 2.0, color1.a);
@@ -165,14 +165,14 @@ def test_compute_tex_1d_r32float():
 def test_compute_tex_2d_rgba8uint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_2d<u32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_2d<rgba8uint,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec2<i32>(index.xy);
             let color1 = vec4<i32>(textureLoad(r_tex1, i, 0));
             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
@@ -201,14 +201,14 @@ def test_compute_tex_2d_rgba8uint():
 def test_compute_tex_2d_rgba16sint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_2d<i32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_2d<rgba16sint, write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec2<i32>(index.xy);
             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
@@ -236,14 +236,14 @@ def test_compute_tex_2d_rgba16sint():
 
 def test_compute_tex_2d_r32sint():
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_2d<i32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_2d<r32sint, write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec2<i32>(index.xy);
             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
@@ -272,14 +272,14 @@ def test_compute_tex_2d_r32sint():
 def test_compute_tex_2d_r32float():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1:texture_2d<f32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_2d<r32float, write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec2<i32>(index.xy);
             let color1: vec4<f32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<f32>(color1.x + f32(i.x), color1.y + 1.0, color1.z * 2.0, color1.a);
@@ -311,14 +311,14 @@ def test_compute_tex_2d_r32float():
 def test_compute_tex_3d_rgba8uint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_3d<u32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_3d<rgba8uint,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec3<i32>(index);
             let color1 = vec4<i32>(textureLoad(r_tex1, i, 0));
             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
@@ -348,14 +348,14 @@ def test_compute_tex_3d_rgba8uint():
 def test_compute_tex_3d_rgba16sint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_3d<i32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_3d<rgba16sint,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec3<i32>(index);
             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
@@ -385,14 +385,14 @@ def test_compute_tex_3d_rgba16sint():
 def test_compute_tex_3d_r32sint():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_3d<i32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_3d<r32sint,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec3<i32>(index);
             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
@@ -422,14 +422,14 @@ def test_compute_tex_3d_r32sint():
 def test_compute_tex_3d_r32float():
 
     compute_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex1: texture_3d<f32>;
 
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_tex2: texture_storage_3d<r32float,write>;
 
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+        @stage(compute) @workgroup_size(1)
+        fn main(@builtin(global_invocation_id) index: vec3<u32>) {
             let i = vec3<i32>(index);
             let color1: vec4<f32> = textureLoad(r_tex1, i, 0);
             let color2 = vec4<f32>(color1.x + f32(i.x), color1.y + 1.0, color1.z * 2.0, color1.a);

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -89,39 +89,39 @@ def test_compute_tex_1d_rgba16sint():
     )
 
 
-# def test_compute_tex_1d_r32sint():
-#
-#     compute_shader = """
-#         [[group(0), binding(0)]]
-#         var r_tex1: texture_1d<i32>;
-#
-#         [[group(0), binding(1)]]
-#         var r_tex2: texture_storage_1d<r32sint, write>;
-#
-#         [[stage(compute), workgroup_size(1)]]
-#         fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
-#             let i: i32 = i32(index.x);
-#             let color1 : vec4<i32> = textureLoad(r_tex1, i, 0);
-#             let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
-#             textureStore(r_tex2, i, color2);
-#         }
-#     """
-#
-#     # Generate data
-#     nx, ny, nz, nc = 256, 1, 1, 1
-#     data1 = (ctypes.c_int32 * nc * nx)()
-#     for x in range(nx):
-#         for c in range(nc):
-#             data1[x][c] = random.randint(0, 20)
-#
-#     # Compute and validate
-#     _compute_texture(
-#         compute_shader,
-#         wgpu.TextureFormat.r32sint,
-#         wgpu.TextureDimension.d1,
-#         (nx, ny, nz, nc),
-#         data1,
-#     )
+def test_compute_tex_1d_r32sint():
+
+    compute_shader = """
+        [[group(0), binding(0)]]
+        var r_tex1: texture_1d<i32>;
+
+        [[group(0), binding(1)]]
+        var r_tex2: texture_storage_1d<r32sint, write>;
+
+        [[stage(compute), workgroup_size(1)]]
+        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+            let i: i32 = i32(index.x);
+            let color1 : vec4<i32> = textureLoad(r_tex1, i, 0);
+            let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
+            textureStore(r_tex2, i, color2);
+        }
+    """
+
+    # Generate data
+    nx, ny, nz, nc = 256, 1, 1, 1
+    data1 = (ctypes.c_int32 * nc * nx)()
+    for x in range(nx):
+        for c in range(nc):
+            data1[x][c] = random.randint(0, 20)
+
+    # Compute and validate
+    _compute_texture(
+        compute_shader,
+        wgpu.TextureFormat.r32sint,
+        wgpu.TextureDimension.d1,
+        (nx, ny, nz, nc),
+        data1,
+    )
 
 
 def test_compute_tex_1d_r32float():
@@ -234,39 +234,39 @@ def test_compute_tex_2d_rgba16sint():
     )
 
 
-# def test_compute_tex_2d_r32sint():
-#     compute_shader = """
-#         [[group(0), binding(0)]]
-#         var r_tex1: texture_2d<i32>;
-#
-#         [[group(0), binding(1)]]
-#         var r_tex2: texture_storage_2d<r32sint, write>;
-#
-#         [[stage(compute), workgroup_size(1)]]
-#         fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
-#             let i = vec2<i32>(index.xy);
-#             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
-#             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
-#             textureStore(r_tex2, i, color2);
-#         }
-#     """
-#
-#     # Generate data
-#     nx, ny, nz, nc = 256, 8, 1, 1
-#     data1 = (ctypes.c_int32 * nc * nx * ny)()
-#     for y in range(ny):
-#         for x in range(nx):
-#             for c in range(nc):
-#                 data1[y][x][c] = random.randint(0, 20)
-#
-#     # Compute and validate
-#     _compute_texture(
-#         compute_shader,
-#         wgpu.TextureFormat.r32sint,
-#         wgpu.TextureDimension.d2,
-#         (nx, ny, nz, nc),
-#         data1,
-#     )
+def test_compute_tex_2d_r32sint():
+    compute_shader = """
+        [[group(0), binding(0)]]
+        var r_tex1: texture_2d<i32>;
+
+        [[group(0), binding(1)]]
+        var r_tex2: texture_storage_2d<r32sint, write>;
+
+        [[stage(compute), workgroup_size(1)]]
+        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+            let i = vec2<i32>(index.xy);
+            let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
+            let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
+            textureStore(r_tex2, i, color2);
+        }
+    """
+
+    # Generate data
+    nx, ny, nz, nc = 256, 8, 1, 1
+    data1 = (ctypes.c_int32 * nc * nx * ny)()
+    for y in range(ny):
+        for x in range(nx):
+            for c in range(nc):
+                data1[y][x][c] = random.randint(0, 20)
+
+    # Compute and validate
+    _compute_texture(
+        compute_shader,
+        wgpu.TextureFormat.r32sint,
+        wgpu.TextureDimension.d2,
+        (nx, ny, nz, nc),
+        data1,
+    )
 
 
 def test_compute_tex_2d_r32float():
@@ -382,41 +382,41 @@ def test_compute_tex_3d_rgba16sint():
     )
 
 
-# def test_compute_tex_3d_r32sint():
-#
-#     compute_shader = """
-#         [[group(0), binding(0)]]
-#         var r_tex1: texture_3d<i32>;
-#
-#         [[group(0), binding(1)]]
-#         var r_tex2: texture_storage_3d<r32sint,write>;
-#
-#         [[stage(compute), workgroup_size(1)]]
-#         fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
-#             let i = vec3<i32>(index);
-#             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
-#             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
-#             textureStore(r_tex2, i, color2);
-#         }
-#     """
-#
-#     # Generate data
-#     nx, ny, nz, nc = 256, 8, 6, 1
-#     data1 = (ctypes.c_int32 * nc * nx * ny * nz)()
-#     for z in range(nz):
-#         for y in range(ny):
-#             for x in range(nx):
-#                 for c in range(nc):
-#                     data1[z][y][x][c] = random.randint(0, 20)
-#
-#     # Compute and validate
-#     _compute_texture(
-#         compute_shader,
-#         wgpu.TextureFormat.r32sint,
-#         wgpu.TextureDimension.d3,
-#         (nx, ny, nz, nc),
-#         data1,
-#     )
+def test_compute_tex_3d_r32sint():
+
+    compute_shader = """
+        [[group(0), binding(0)]]
+        var r_tex1: texture_3d<i32>;
+
+        [[group(0), binding(1)]]
+        var r_tex2: texture_storage_3d<r32sint,write>;
+
+        [[stage(compute), workgroup_size(1)]]
+        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+            let i = vec3<i32>(index);
+            let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
+            let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
+            textureStore(r_tex2, i, color2);
+        }
+    """
+
+    # Generate data
+    nx, ny, nz, nc = 256, 8, 6, 1
+    data1 = (ctypes.c_int32 * nc * nx * ny * nz)()
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                for c in range(nc):
+                    data1[z][y][x][c] = random.randint(0, 20)
+
+    # Compute and validate
+    _compute_texture(
+        compute_shader,
+        wgpu.TextureFormat.r32sint,
+        wgpu.TextureDimension.d3,
+        (nx, ny, nz, nc),
+        data1,
+    )
 
 
 def test_compute_tex_3d_r32float():

--- a/tests/test_rs_compute_tex.py
+++ b/tests/test_rs_compute_tex.py
@@ -89,39 +89,39 @@ def test_compute_tex_1d_rgba16sint():
     )
 
 
-def test_compute_tex_1d_r32sint():
-
-    compute_shader = """
-        [[group(0), binding(0)]]
-        var r_tex1: texture_1d<i32>;
-
-        [[group(0), binding(1)]]
-        var r_tex2: texture_storage_1d<r32sint, write>;
-
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
-            let i: i32 = i32(index.x);
-            let color1 : vec4<i32> = textureLoad(r_tex1, i, 0);
-            let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
-            textureStore(r_tex2, i, color2);
-        }
-    """
-
-    # Generate data
-    nx, ny, nz, nc = 256, 1, 1, 1
-    data1 = (ctypes.c_int32 * nc * nx)()
-    for x in range(nx):
-        for c in range(nc):
-            data1[x][c] = random.randint(0, 20)
-
-    # Compute and validate
-    _compute_texture(
-        compute_shader,
-        wgpu.TextureFormat.r32sint,
-        wgpu.TextureDimension.d1,
-        (nx, ny, nz, nc),
-        data1,
-    )
+# def test_compute_tex_1d_r32sint():
+#
+#     compute_shader = """
+#         [[group(0), binding(0)]]
+#         var r_tex1: texture_1d<i32>;
+#
+#         [[group(0), binding(1)]]
+#         var r_tex2: texture_storage_1d<r32sint, write>;
+#
+#         [[stage(compute), workgroup_size(1)]]
+#         fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+#             let i: i32 = i32(index.x);
+#             let color1 : vec4<i32> = textureLoad(r_tex1, i, 0);
+#             let color2 = vec4<i32>(color1.x + i, color1.y + 1, color1.z * 2, color1.a);
+#             textureStore(r_tex2, i, color2);
+#         }
+#     """
+#
+#     # Generate data
+#     nx, ny, nz, nc = 256, 1, 1, 1
+#     data1 = (ctypes.c_int32 * nc * nx)()
+#     for x in range(nx):
+#         for c in range(nc):
+#             data1[x][c] = random.randint(0, 20)
+#
+#     # Compute and validate
+#     _compute_texture(
+#         compute_shader,
+#         wgpu.TextureFormat.r32sint,
+#         wgpu.TextureDimension.d1,
+#         (nx, ny, nz, nc),
+#         data1,
+#     )
 
 
 def test_compute_tex_1d_r32float():
@@ -234,39 +234,39 @@ def test_compute_tex_2d_rgba16sint():
     )
 
 
-def test_compute_tex_2d_r32sint():
-    compute_shader = """
-        [[group(0), binding(0)]]
-        var r_tex1: texture_2d<i32>;
-
-        [[group(0), binding(1)]]
-        var r_tex2: texture_storage_2d<r32sint, write>;
-
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
-            let i = vec2<i32>(index.xy);
-            let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
-            let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
-            textureStore(r_tex2, i, color2);
-        }
-    """
-
-    # Generate data
-    nx, ny, nz, nc = 256, 8, 1, 1
-    data1 = (ctypes.c_int32 * nc * nx * ny)()
-    for y in range(ny):
-        for x in range(nx):
-            for c in range(nc):
-                data1[y][x][c] = random.randint(0, 20)
-
-    # Compute and validate
-    _compute_texture(
-        compute_shader,
-        wgpu.TextureFormat.r32sint,
-        wgpu.TextureDimension.d2,
-        (nx, ny, nz, nc),
-        data1,
-    )
+# def test_compute_tex_2d_r32sint():
+#     compute_shader = """
+#         [[group(0), binding(0)]]
+#         var r_tex1: texture_2d<i32>;
+#
+#         [[group(0), binding(1)]]
+#         var r_tex2: texture_storage_2d<r32sint, write>;
+#
+#         [[stage(compute), workgroup_size(1)]]
+#         fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+#             let i = vec2<i32>(index.xy);
+#             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
+#             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
+#             textureStore(r_tex2, i, color2);
+#         }
+#     """
+#
+#     # Generate data
+#     nx, ny, nz, nc = 256, 8, 1, 1
+#     data1 = (ctypes.c_int32 * nc * nx * ny)()
+#     for y in range(ny):
+#         for x in range(nx):
+#             for c in range(nc):
+#                 data1[y][x][c] = random.randint(0, 20)
+#
+#     # Compute and validate
+#     _compute_texture(
+#         compute_shader,
+#         wgpu.TextureFormat.r32sint,
+#         wgpu.TextureDimension.d2,
+#         (nx, ny, nz, nc),
+#         data1,
+#     )
 
 
 def test_compute_tex_2d_r32float():
@@ -382,41 +382,41 @@ def test_compute_tex_3d_rgba16sint():
     )
 
 
-def test_compute_tex_3d_r32sint():
-
-    compute_shader = """
-        [[group(0), binding(0)]]
-        var r_tex1: texture_3d<i32>;
-
-        [[group(0), binding(1)]]
-        var r_tex2: texture_storage_3d<r32sint,write>;
-
-        [[stage(compute), workgroup_size(1)]]
-        fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
-            let i = vec3<i32>(index);
-            let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
-            let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
-            textureStore(r_tex2, i, color2);
-        }
-    """
-
-    # Generate data
-    nx, ny, nz, nc = 256, 8, 6, 1
-    data1 = (ctypes.c_int32 * nc * nx * ny * nz)()
-    for z in range(nz):
-        for y in range(ny):
-            for x in range(nx):
-                for c in range(nc):
-                    data1[z][y][x][c] = random.randint(0, 20)
-
-    # Compute and validate
-    _compute_texture(
-        compute_shader,
-        wgpu.TextureFormat.r32sint,
-        wgpu.TextureDimension.d3,
-        (nx, ny, nz, nc),
-        data1,
-    )
+# def test_compute_tex_3d_r32sint():
+#
+#     compute_shader = """
+#         [[group(0), binding(0)]]
+#         var r_tex1: texture_3d<i32>;
+#
+#         [[group(0), binding(1)]]
+#         var r_tex2: texture_storage_3d<r32sint,write>;
+#
+#         [[stage(compute), workgroup_size(1)]]
+#         fn main([[builtin(global_invocation_id)]] index: vec3<u32>) {
+#             let i = vec3<i32>(index);
+#             let color1: vec4<i32> = textureLoad(r_tex1, i, 0);
+#             let color2 = vec4<i32>(color1.x + i.x, color1.y + 1, color1.z * 2, color1.a);
+#             textureStore(r_tex2, i, color2);
+#         }
+#     """
+#
+#     # Generate data
+#     nx, ny, nz, nc = 256, 8, 6, 1
+#     data1 = (ctypes.c_int32 * nc * nx * ny * nz)()
+#     for z in range(nz):
+#         for y in range(ny):
+#             for x in range(nx):
+#                 for c in range(nc):
+#                     data1[z][y][x][c] = random.randint(0, 20)
+#
+#     # Compute and validate
+#     _compute_texture(
+#         compute_shader,
+#         wgpu.TextureFormat.r32sint,
+#         wgpu.TextureDimension.d3,
+#         (nx, ny, nz, nc),
+#         data1,
+#     )
 
 
 def test_compute_tex_3d_r32float():

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -548,8 +548,8 @@ def test_render_orange_square_depth():
 def test_render_orange_dots():
     """Render four orange dots and check that there are four orange square dots."""
 
-    if sys.platform == "darwin":
-        skip("The render-dots tests fails on Metal")
+    # if sys.platform == "darwin":
+    #     skip("The render-dots tests fails on Metal")
 
     device = get_default_device()
 

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -19,8 +19,8 @@ elif is_ci and sys.platform == "win32":
 
 
 default_vertex_shader = """
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> [[builtin(position)]] vec4<f32> {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4<f32> {
     var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
         vec3<f32>(-0.5, -0.5, 0.1),
         vec3<f32>(-0.5,  0.5, 0.1),
@@ -45,8 +45,8 @@ def test_render_orange_square():
     # With 0.5 some drivers would produce 127 and others 128.
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -83,8 +83,8 @@ def test_render_orange_square_indexed():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -130,8 +130,8 @@ def test_render_orange_square_indirect():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -172,8 +172,8 @@ def test_render_orange_square_indexed_indirect():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -227,13 +227,13 @@ def test_render_orange_square_vbo():
     device = get_default_device()
 
     shader_source = """
-        [[stage(vertex)]]
-        fn vs_main([[location(0)]] pos : vec2<f32>) -> [[builtin(position)]] vec4<f32> {
+        @stage(vertex)
+        fn vs_main(@location(0) pos : vec2<f32>) -> @builtin(position) vec4<f32> {
             return vec4<f32>(pos, 0.0, 1.0);
         }
 
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -286,8 +286,8 @@ def test_render_orange_square_color_attachment1():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -330,8 +330,8 @@ def test_render_orange_square_color_attachment2():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -375,8 +375,8 @@ def test_render_orange_square_viewport():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -413,8 +413,8 @@ def test_render_orange_square_scissor():
     device = get_default_device()
 
     fragment_shader = """
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -453,8 +453,8 @@ def test_render_orange_square_depth():
     device = get_default_device()
 
     shader_source = """
-        [[stage(vertex)]]
-        fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> [[builtin(position)]] vec4<f32> {
+        @stage(vertex)
+        fn vs_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4<f32> {
             var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
                 vec3<f32>(-0.5, -0.5, 0.0),
                 vec3<f32>(-0.5,  0.5, 0.0),
@@ -465,8 +465,8 @@ def test_render_orange_square_depth():
             return vec4<f32>(p, 1.0);
         }
 
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """
@@ -548,19 +548,16 @@ def test_render_orange_square_depth():
 def test_render_orange_dots():
     """Render four orange dots and check that there are four orange square dots."""
 
-    # if sys.platform == "darwin":
-    #     skip("The render-dots tests fails on Metal")
-
     device = get_default_device()
 
     shader_source = """
         struct VertexOutput {
-            [[builtin(position)]] position: vec4<f32>;
-            //[[builtin(pointSize]] point_size: f32;
+            @builtin(position) position: vec4<f32>,
+            //@builtin(pointSize) point_size: f32,
         };
 
-        [[stage(vertex)]]
-        fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> VertexOutput {
+        @stage(vertex)
+        fn vs_main(@builtin(vertex_index) vertex_index : u32) -> VertexOutput {
             var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
                 vec3<f32>(-0.5, -0.5, 0.0),
                 vec3<f32>(-0.5,  0.5, 0.0),
@@ -573,8 +570,8 @@ def test_render_orange_dots():
             return out;
         }
 
-        [[stage(fragment)]]
-        fn fs_main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main() -> @location(0) vec4<f32> {
             return vec4<f32>(1.0, 0.499, 0.0, 1.0);
         }
     """

--- a/tests/test_rs_render.py
+++ b/tests/test_rs_render.py
@@ -548,6 +548,9 @@ def test_render_orange_square_depth():
 def test_render_orange_dots():
     """Render four orange dots and check that there are four orange square dots."""
 
+    if sys.platform == "darwin":
+        skip("The render-dots tests fails on Metal")
+
     device = get_default_device()
 
     shader_source = """

--- a/tests/test_rs_render_tex.py
+++ b/tests/test_rs_render_tex.py
@@ -21,12 +21,12 @@ elif is_ci and sys.platform == "win32":
 
 default_vertex_shader = """
 struct VertexOutput {
-    [[location(0)]] texcoord : vec2<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    @location(0) texcoord : vec2<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index : u32) -> VertexOutput {
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) vertex_index : u32) -> VertexOutput {
     var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
         vec2<f32>(-0.5, -0.5),
         vec2<f32>(-0.5,  0.5),
@@ -63,13 +63,13 @@ def test_render_textured_square_rgba8unorm():
     """Test a texture with format rgba8unorm."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<f32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let sample = textureSample(r_tex, r_sampler, in.texcoord);
             return sample;
         }
@@ -92,13 +92,13 @@ def test_render_textured_square_rgba8uint():
     """Test a texture with format rgba8uint."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<u32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             // let sample = textureSample(r_tex, r_sampler, in.texcoord);
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
@@ -123,13 +123,13 @@ def test_render_textured_square_rgba16sint():
     """Test a texture with format rgba16sint."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<i32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             // let sample = textureSample(r_tex, r_sampler, in.texcoord);
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
@@ -154,13 +154,13 @@ def test_render_textured_square_rgba32float():
     """Test a texture with format rgba32float."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<f32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let sample = textureSample(r_tex, r_sampler, in.texcoord);
             return sample / 255.0;
         }
@@ -188,13 +188,13 @@ def test_render_textured_square_rg8unorm():
     """
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<f32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let sample = textureSample(r_tex, r_sampler, in.texcoord);
             return sample;
         }
@@ -217,13 +217,13 @@ def test_render_textured_square_rg8uint():
     """
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<u32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             // let sample = textureSample(r_tex, r_sampler, in.texcoord);
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
@@ -248,13 +248,13 @@ def test_render_textured_square_rg16sint():
     """
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<i32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             // let sample = textureSample(r_tex, r_sampler, in.texcoord);
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
@@ -279,13 +279,13 @@ def test_render_textured_square_rg32float():
     """
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<f32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let sample = textureSample(r_tex, r_sampler, in.texcoord);
             return vec4<f32>(sample.rg / 255.0, 0.0, 1.0);
         }
@@ -309,13 +309,13 @@ def test_render_textured_square_r8unorm():
     """Test a texture with format r8unorm."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<f32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let sample = textureSample(r_tex, r_sampler, in.texcoord);
             let val = sample.r;
             return vec4<f32>(val, val, 0.0, 1.0);
@@ -337,13 +337,13 @@ def test_render_textured_square_r8uint():
     """Test a texture with format r8uint."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<u32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
             let val = f32(sample.r) / 255.0;
@@ -366,13 +366,13 @@ def test_render_textured_square_r16sint():
     """Test a texture with format r16sint. Because e.g. CT data."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<i32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
             let val = f32(sample.r) / 255.0;
@@ -395,13 +395,13 @@ def test_render_textured_square_r32sint():
     """Test a texture with format r32sint. Because e.g. CT data."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<i32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let texcoords_u = vec2<i32>(in.texcoord * vec2<f32>(textureDimensions(r_tex)));
             let sample = textureLoad(r_tex, texcoords_u, 0);
             let val = f32(sample.r) / 255.0;
@@ -424,13 +424,13 @@ def test_render_textured_square_r32float():
     """Test a texture with format r32float."""
 
     fragment_shader = """
-        [[group(0), binding(0)]]
+        @group(0) @binding(0)
         var r_tex: texture_2d<f32>;
-        [[group(0), binding(1)]]
+        @group(0) @binding(1)
         var r_sampler: sampler;
 
-        [[stage(fragment)]]
-        fn fs_main(in: VertexOutput, ) -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn fs_main(in: VertexOutput, ) -> @location(0) vec4<f32> {
             let sample = textureSample(r_tex, r_sampler, in.texcoord);
             let val = sample.r / 255.0;
             return vec4<f32>(val, val, 0.0, 1.0);

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -468,6 +468,13 @@ class GPUAdapter(base.GPUAdapter):
         for key, val in required_limits.items():
             setattr(c_limits, to_camel_case(key), val)
 
+        # H: nextInChain: WGPUChainedStruct *, label: char *
+        queue_struct = new_struct(
+            "WGPUQueueDescriptor",
+            label=to_c_label("default_queue"),
+            # not used: nextInChain
+        )
+
         # H: nextInChain: WGPUChainedStruct *, label: char *, requiredFeaturesCount: int, requiredFeatures: WGPUFeatureName *, requiredLimits: WGPURequiredLimits *, defaultQueue: WGPUQueueDescriptor
         struct = new_struct_p(
             "WGPUDeviceDescriptor *",
@@ -476,9 +483,8 @@ class GPUAdapter(base.GPUAdapter):
             requiredFeaturesCount=0,
             requiredFeatures=ffi.new("WGPUFeatureName []", []),
             requiredLimits=c_required_limits,
-            # not used: defaultQueue
+            defaultQueue=queue_struct,
         )
-        # todo: defaultQueue = WGPUQueueDescriptor
         device_id = None
 
         @ffi.callback("void(WGPURequestDeviceStatus, WGPUDevice, char *, void *)")
@@ -636,7 +642,6 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
         }
         return GPUTexture(label, id, self, tex_info)
 
-    # FIXME: was create_sampler(self, *, label="", address_mode_u: "enums.AddressMode" = "clamp-to-edge", address_mode_v: "enums.AddressMode" = "clamp-to-edge", address_mode_w: "enums.AddressMode" = "clamp-to-edge", mag_filter: "enums.FilterMode" = "nearest", min_filter: "enums.FilterMode" = "nearest", mipmap_filter: "enums.MimapFilterMode" = "nearest", lod_min_clamp: float = 0, lod_max_clamp: float = 32, compare: "enums.CompareFunction" = None, max_anisotropy: int = 1):
     def create_sampler(
         self,
         *,

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -49,6 +49,7 @@ from .rs_helpers import (
     get_memoryview_and_address,
     to_snake_case,
     to_camel_case,
+    device_dropper,
 )
 
 
@@ -186,32 +187,6 @@ def check_struct(struct_name, d):
     invalid_keys = set(d.keys()).difference(valid_keys)
     if invalid_keys:
         raise ValueError(f"Invalid keys in {struct_name}: {invalid_keys}")
-
-
-class DeviceDropper:
-    """Helps drop devices at a good time."""
-
-    # I found that when wgpuDeviceDrop() was called in Device._destroy,
-    # the tests would hang. I found that the drop call was done around
-    # the time when another device was used (e.g. to create a buffer
-    # or shader module). For some reason, the delay in destruction (by
-    # Python's CG) causes a deadlock or something. We seem to be able
-    # to fix this by doing the actual dropping later - e.g. when the
-    # user creates a new device.
-    def __init__(self):
-        self._devices_to_drop = []
-
-    def drop_soon(self, internal):
-        self._devices_to_drop.append(internal)
-
-    def drop_all_pending(self):
-        while self._devices_to_drop:
-            internal = self._devices_to_drop.pop(0)
-            # H: void f(WGPUDevice device)
-            lib.wgpuDeviceDrop(internal)
-
-
-device_dropper = DeviceDropper()
 
 
 # %% The API

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -56,8 +56,8 @@ logger = logging.getLogger("wgpu")  # noqa
 apidiff = ApiDiff()
 
 # The wgpu-native version that we target/expect
-__version__ = "0.11.0.1"
-__commit_sha__ = "9d962ef667ef6006cca7bac7489d5bf303a2a244"
+__version__ = "0.12.0.1"
+__commit_sha__ = "0ff888a666e6e787af9bc9c9afc35a5055547b5a"
 version_info = tuple(map(int, __version__.split(".")))
 check_expected_version(version_info)  # produces a warning on mismatch
 

--- a/wgpu/backends/rs_helpers.py
+++ b/wgpu/backends/rs_helpers.py
@@ -122,17 +122,24 @@ def get_surface_id_from_canvas(canvas):
     elif sys.platform.startswith("linux"):  # no-cover
         display_id = canvas.get_display_id()
         is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+        is_xcb = False
         if is_wayland:
-            # todo: probably does not work since we dont have WGPUSurfaceDescriptorFromWayland
-            struct = ffi.new("WGPUSurfaceDescriptorFromXlib *")
+            # todo: wayland untested
+            struct = ffi.new("WGPUSurfaceDescriptorFromWaylandSurface *")
             struct.display = ffi.cast("void *", display_id)
+            struct.surface = int(win_id)  # must be void *
+            struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromWaylandSurface
+        elif is_xcb:
+            # todo: xcb untested
+            struct = ffi.new("WGPUSurfaceDescriptorFromXcbWindow *")
+            struct.connection = ffi.NULL  # ?? ffi.cast("void *", display_id)
             struct.window = int(win_id)
-            struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromXlib
+            struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromXlibWindow
         else:
-            struct = ffi.new("WGPUSurfaceDescriptorFromXlib *")
+            struct = ffi.new("WGPUSurfaceDescriptorFromXlibWindow *")
             struct.display = ffi.cast("void *", display_id)
             struct.window = int(win_id)
-            struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromXlib
+            struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromXlibWindow
 
     else:  # no-cover
         raise RuntimeError("Cannot get surface id: unsupported platform.")

--- a/wgpu/backends/rs_helpers.py
+++ b/wgpu/backends/rs_helpers.py
@@ -124,10 +124,10 @@ def get_surface_id_from_canvas(canvas):
         is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
         is_xcb = False
         if is_wayland:
-            # todo: wayland untested
+            # todo: wayland seems to be broken right now
             struct = ffi.new("WGPUSurfaceDescriptorFromWaylandSurface *")
             struct.display = ffi.cast("void *", display_id)
-            struct.surface = int(win_id)  # must be void *
+            struct.surface = ffi.cast("void *", win_id)
             struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromWaylandSurface
         elif is_xcb:
             # todo: xcb untested

--- a/wgpu/backends/rs_mappings.py
+++ b/wgpu/backends/rs_mappings.py
@@ -4,7 +4,7 @@
 
 # flake8: noqa
 
-# There are 227 enum mappings
+# There are 230 enum mappings
 
 enummap = {
     "AddressMode.clamp-to-edge": 2,
@@ -48,8 +48,8 @@ enummap = {
     "CullMode.front": 1,
     "CullMode.none": 0,
     "DeviceLostReason.destroyed": 1,
-    "ErrorFilter.out-of-memory": 2,
-    "ErrorFilter.validation": 1,
+    "ErrorFilter.out-of-memory": 1,
+    "ErrorFilter.validation": 0,
     "FeatureName.depth-clip-control": 1,
     "FeatureName.depth24unorm-stencil8": 2,
     "FeatureName.depth32float-stencil8": 3,
@@ -64,9 +64,12 @@ enummap = {
     "FrontFace.cw": 1,
     "IndexFormat.uint16": 1,
     "IndexFormat.uint32": 2,
-    "LoadOp.load": 1,
+    "LoadOp.load": 2,
+    "MipmapFilterMode.linear": 1,
+    "MipmapFilterMode.nearest": 0,
     "PowerPreference.high-performance": 2,
     "PowerPreference.low-power": 1,
+    "PredefinedColorSpace.srgb": 1,
     "PrimitiveTopology.line-list": 1,
     "PrimitiveTopology.line-strip": 2,
     "PrimitiveTopology.point-list": 0,
@@ -88,8 +91,8 @@ enummap = {
     "StencilOperation.replace": 2,
     "StencilOperation.zero": 1,
     "StorageTextureAccess.write-only": 1,
-    "StoreOp.discard": 1,
-    "StoreOp.store": 0,
+    "StoreOp.discard": 2,
+    "StoreOp.store": 1,
     "TextureAspect.all": 0,
     "TextureAspect.depth-only": 2,
     "TextureAspect.stencil-only": 1,
@@ -270,7 +273,7 @@ cstructfield2enum = {
     "SamplerDescriptor.compare": "CompareFunction",
     "SamplerDescriptor.magFilter": "FilterMode",
     "SamplerDescriptor.minFilter": "FilterMode",
-    "SamplerDescriptor.mipmapFilter": "FilterMode",
+    "SamplerDescriptor.mipmapFilter": "MipmapFilterMode",
     "StencilFaceState.compare": "CompareFunction",
     "StencilFaceState.depthFailOp": "StencilOperation",
     "StencilFaceState.failOp": "StencilOperation",

--- a/wgpu/backends/rs_mappings.py
+++ b/wgpu/backends/rs_mappings.py
@@ -322,4 +322,15 @@ enum_int2str = {
         2: "CPU",
         3: "Unknown",
     },
+    "ErrorType": {
+        0: "NoError",
+        1: "Validation",
+        2: "OutOfMemory",
+        3: "Unknown",
+        4: "DeviceLost",
+    },
+    "DeviceLostReason": {
+        0: "Undefined",
+        1: "Destroyed",
+    },
 }

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -1170,6 +1170,9 @@ class GPUCommandBuffer(GPUObjectBase):
     :class:`GPUCommandEncoder`, to be submitted to a :class:`GPUQueue`.
 
     Create a command buffer using :func:`GPUCommandEncoder.finish`.
+
+    Command buffers are single use, you must only submit them once and
+    submitting them destroys them. Use render bundles to re-use commands.
     """
 
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -3,7 +3,7 @@
 * The webgpu.idl defines 33 classes with 78 functions
 * The webgpu.idl defines 5 flags, 32 enums, 57 structs
 * The wgpu.h defines 131 functions
-* The wgpu.h defines 5 flags, 46 enums, 69 structs
+* The wgpu.h defines 5 flags, 48 enums, 74 structs
 ## Updating API
 * Wrote 5 flags to flags.py
 * Wrote 32 enums to enums.py
@@ -22,9 +22,8 @@
 * Diffs for GPUAdapter: add request_device_tracing
 * Validated 33 classes, 94 methods, 0 properties
 ## Validating rs.py
-* Enum PredefinedColorSpace missing in wgpu.h
 * Enum CanvasCompositingAlphaMode missing in wgpu.h
-* Wrote 227 enum mappings and 49 struct-field mappings to rs_mappings.py
+* Wrote 230 enum mappings and 49 struct-field mappings to rs_mappings.py
 * Validated 79 C function calls
 * Not using 57 C functions
 * Validated 69 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -24,6 +24,6 @@
 ## Validating rs.py
 * Enum CanvasCompositingAlphaMode missing in wgpu.h
 * Wrote 230 enum mappings and 49 struct-field mappings to rs_mappings.py
-* Validated 81 C function calls
-* Not using 55 C functions
+* Validated 80 C function calls
+* Not using 56 C functions
 * Validated 70 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,10 +20,10 @@
 * Validated 33 classes, 105 methods, 34 properties
 ### Patching API for backends/rs.py
 * Diffs for GPUAdapter: add request_device_tracing
-* Validated 33 classes, 94 methods, 0 properties
+* Validated 33 classes, 96 methods, 0 properties
 ## Validating rs.py
 * Enum CanvasCompositingAlphaMode missing in wgpu.h
 * Wrote 230 enum mappings and 49 struct-field mappings to rs_mappings.py
-* Validated 79 C function calls
-* Not using 57 C functions
+* Validated 81 C function calls
+* Not using 55 C functions
 * Validated 70 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -26,4 +26,4 @@
 * Wrote 230 enum mappings and 49 struct-field mappings to rs_mappings.py
 * Validated 79 C function calls
 * Not using 57 C functions
-* Validated 69 C structs
+* Validated 70 C structs

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,7 +1,7 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu-headers/webgpu.h"
+#include "webgpu.h"
 
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -1,7 +1,7 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu.h"
+#include "webgpu-headers/webgpu.h"
 
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes
@@ -38,6 +38,10 @@ typedef struct WGPUDeviceExtras {
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void wgpuDevicePoll(WGPUDevice device, bool force_wait);
 
 void wgpuSetLogCallback(WGPULogCallback callback);
@@ -46,7 +50,7 @@ void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
 
-void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStage stages, uint32_t offset, uint32_t sizeBytes, void* const data);
+void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void* const data);
 
 void wgpuBufferDrop(WGPUBuffer buffer);
 void wgpuCommandEncoderDrop(WGPUCommandEncoder commandEncoder);
@@ -63,5 +67,9 @@ void wgpuShaderModuleDrop(WGPUShaderModule shaderModule);
 void wgpuCommandBufferDrop(WGPUCommandBuffer commandBuffer);
 void wgpuRenderBundleDrop(WGPURenderBundle renderBundle);
 void wgpuComputePipelineDrop(WGPUComputePipeline computePipeline);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif


### PR DESCRIPTION
Todo:
* [x] Update to current wgpu-native tip, and make sure tests pass
* [x] https://github.com/gfx-rs/wgpu-native/pull/184
* [x] Update wgpu-native to latest headers (already on latest)
* [x] Update this PR again
* [x] Release wgpu-native
* [x] Some tests fail on Metal currently. See if they pass after the wgpu-core update. Yes, they do!
* [x] See if we can enable more of the destructors. 
* [x] Test new Wayland support.

Then:
* [x] Do a pygfx release (build against the previous wgpu-py)
* [ ] Merge this.
* [ ] Do a PR to update to the latest IDL. -> Remove the MipmapFilterMode stuff in the codegen!
* [ ] Prepare a PR to make pygfx work on latest wgpu-py.
* [ ] Release wgpu-py.
* [ ] Release pygfx.

## Notable changes

* Some tests that previously failed on Metal now run fine.
* Better error logging using the new callbacks in wgpu-native.
* WGSL syntax changes (see below). Prettier, but some work to change all our shaders.
* All destructors (drop methods) are now working as they should.
* I tried to revive Wayland support, no luck yet.

## API changes

* Shaders now use `@xx(yy)` instead of `[[xx(yy)]]`, e.g. `@stage(vertex)`.
* Structs now separate items using `,` instead of `;`.
* Buffers bound as arrays don't need to be defined via a struct anymore! 🥳 
