### PR TITLE
ensure at least one frame is drawn when using offscreen canvas

### DIFF
--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -37,7 +37,7 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
         return False
 
     def _request_draw(self):
-        call_later(self.draw)
+        call_later(0, self.draw)
 
     def present(self, texture_view):
         # This gets called at the end of a draw pass via GPUCanvasContextOffline

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -37,7 +37,7 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
         return False
 
     def _request_draw(self):
-        pass
+        call_later(self.draw)
 
     def present(self, texture_view):
         # This gets called at the end of a draw pass via GPUCanvasContextOffline


### PR DESCRIPTION
It seems the example tests don't actually draw a frame. This change should fix that.