### PR TITLE
Add note about example version in repo vs pypi

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -131,3 +131,5 @@ Examples
 Some examples with wgpu-py can be found here:
 
 * https://github.com/pygfx/wgpu-py/tree/main/examples
+
+Note: The examples in the main branch of the repository may not match the pip installable version.  Be sure to refer to the examples from the git tag that matches the version of wgpu you have installed.


### PR DESCRIPTION
Add a note so that people don't get confused (like [I did](https://github.com/pygfx/wgpu-py/issues/261)) by trying to use the current main branch examples with the pip installable release version.