### PR TITLE
Refactor docs a bit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,12 +22,25 @@ import wgpu.gui  # noqa: E402
 
 # -- Tweak wgpu's docs -------------------------------------------------------
 
-# Ensure that our API docs are complete
-with open(os.path.join(ROOT_DIR, "docs", "reference_wgpu.rst"), "rb") as f:
-    wgpu_api_docs_text = f.read().decode()
+# Ensure that all classes are in the docs
+with open(os.path.join(ROOT_DIR, "docs", "reference_classes.rst"), "rb") as f:
+    classes_text = f.read().decode()
 for cls_name in wgpu.base.__all__:
-    expected_line = f".. autoclass:: wgpu.{cls_name}"
-    assert expected_line in wgpu_api_docs_text, f"Missing docs for {cls_name}"
+    expected = f".. autoclass:: {cls_name}"
+    assert (
+        expected in classes_text
+    ), f"Missing doc entry {cls_name} in reference_classes.rst"
+
+# Ensure that all classes are references in the alphabetic list, and referenced at least one other time
+with open(os.path.join(ROOT_DIR, "docs", "reference_wgpu.rst"), "rb") as f:
+    wgpu_text = f.read().decode()
+for cls_name in wgpu.base.__all__:
+    expected1 = f":class:`{cls_name}`"
+    expected2 = f"* :class:`{cls_name}`"
+    assert expected2 in wgpu_text, f"Missing doc entry {cls_name} in reference_wgpu.rst"
+    assert (
+        wgpu_text.count(expected1) >= 2
+    ), f"Need at least one reference to {cls_name} in reference_wgpu.rst"
 
 # Make flags and enum appear better in docs
 wgpu.enums._use_sphinx_repr = True

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -9,4 +9,5 @@ Reference
    reference_enums
    reference_flags
    reference_wgpu
+   reference_classes
    reference_gui

--- a/docs/reference_classes.rst
+++ b/docs/reference_classes.rst
@@ -1,0 +1,137 @@
+WGPU classes
+============
+
+.. currentmodule:: wgpu
+
+
+Adapter and device
+------------------
+
+.. autoclass:: GPU
+
+.. autofunction:: request_adapter
+
+.. autofunction:: request_adapter_async
+
+.. autoclass:: GPUAdapter
+    :members:
+
+.. autoclass:: GPUObjectBase
+    :members:
+
+.. autoclass:: GPUDevice
+    :members:
+
+
+Buffers and textures
+--------------------
+
+.. autoclass:: GPUBuffer
+    :members:
+
+.. autoclass:: GPUTexture
+    :members:
+
+.. autoclass:: GPUTextureView
+    :members:
+
+.. autoclass:: GPUSampler
+    :members:
+
+
+Bind groups
+-----------
+
+.. autoclass:: GPUBindGroupLayout
+    :members:
+
+.. autoclass:: GPUBindGroup
+    :members:
+
+.. autoclass:: GPUPipelineLayout
+    :members:
+
+
+Shaders and pipelines
+---------------------
+
+.. autoclass:: GPUShaderModule
+    :members:
+
+.. autoclass:: GPUPipelineBase
+    :members:
+
+.. autoclass:: GPUComputePipeline
+    :members:
+
+.. autoclass:: GPURenderPipeline
+    :members:
+
+
+Command buffers and encoders
+----------------------------
+
+.. autoclass:: GPUCommandBuffer
+    :members:
+
+.. autoclass:: GPUCommandsMixin
+    :members:
+
+.. autoclass:: GPUBindingCommandsMixin
+    :members:
+
+.. autoclass:: GPUDebugCommandsMixin
+    :members:
+
+.. autoclass:: GPURenderCommandsMixin
+    :members:
+
+.. autoclass:: GPUCommandEncoder
+    :members:
+
+.. autoclass:: GPUComputePassEncoder
+    :members:
+
+.. autoclass:: GPURenderPassEncoder
+    :members:
+
+.. autoclass:: GPURenderBundle
+    :members:
+
+.. autoclass:: GPURenderBundleEncoder
+    :members:
+
+
+
+Other
+-----
+
+.. autoclass:: GPUCanvasContext
+    :members:
+
+.. autoclass:: GPUQueue
+    :members:
+
+.. autoclass:: GPUQuerySet
+    :members:
+
+.. autoclass:: GPUDeviceLostInfo
+    :members:
+
+.. autoclass:: GPUOutOfMemoryError
+    :members:
+
+.. autoclass:: GPUValidationError
+    :members:
+
+.. autoclass:: GPUCompilationInfo
+    :members:
+
+.. autoclass:: GPUCompilationMessage
+    :members:
+
+.. autoclass:: GPUUncapturedErrorEvent
+    :members:
+
+.. autoclass:: GPUExternalTexture
+    :members:

--- a/docs/reference_wgpu.rst
+++ b/docs/reference_wgpu.rst
@@ -1,16 +1,17 @@
 WGPU API
 ========
 
+.. currentmodule:: wgpu
+
 This document describes the wgpu API. It is basically a Pythonic version of the
 `WebGPU API <https://gpuweb.github.io/gpuweb/>`_. It exposes an API
 for performing operations, such as rendering and computation, on a
 Graphics Processing Unit.
 
-.. warning::
-    The WebGPU API is still being developed and occasionally there are backwards
-    incompatible changes. Since we mostly follow the WebGPU API, there may be
-    backwards incompatible changes to wgpu-py too. This will be so until
-    the WebGPU API settles as a standard.
+*The WebGPU API is still being developed and occasionally there are backwards
+incompatible changes. Since we mostly follow the WebGPU API, there may be
+backwards incompatible changes to wgpu-py too. This will be so until
+the WebGPU API settles as a standard.*
 
 
 How to read this API
@@ -68,186 +69,152 @@ Each backend may also implement minor differences (usually additions)
 from the base API. For the ``rs`` backend check ``print(wgpu.backends.rs.apidiff.__doc__)``.
 
 
-Adapter
--------
+Alphabetic list of GPU classes
+------------------------------
 
-To start using the GPU for computations or rendering, a device object
-is required. One first requests an adapter, which represens a GPU
-implementation on the current system. The device can then be requested
-from the adapter.
+* :class:`GPU`
+* :class:`GPUAdapter`
+* :class:`GPUBindGroup`
+* :class:`GPUBindGroupLayout`
+* :class:`GPUBindingCommandsMixin`
+* :class:`GPUBuffer`
+* :class:`GPUCanvasContext`
+* :class:`GPUCommandBuffer`
+* :class:`GPUCommandEncoder`
+* :class:`GPUCommandsMixin`
+* :class:`GPUCompilationInfo`
+* :class:`GPUCompilationMessage`
+* :class:`GPUComputePassEncoder`
+* :class:`GPUComputePipeline`
+* :class:`GPUDebugCommandsMixin`
+* :class:`GPUDevice`
+* :class:`GPUDeviceLostInfo`
+* :class:`GPUExternalTexture`
+* :class:`GPUObjectBase`
+* :class:`GPUOutOfMemoryError`
+* :class:`GPUPipelineBase`
+* :class:`GPUPipelineLayout`
+* :class:`GPUQuerySet`
+* :class:`GPUQueue`
+* :class:`GPURenderBundle`
+* :class:`GPURenderBundleEncoder`
+* :class:`GPURenderCommandsMixin`
+* :class:`GPURenderPassEncoder`
+* :class:`GPURenderPipeline`
+* :class:`GPUSampler`
+* :class:`GPUShaderModule`
+* :class:`GPUTexture`
+* :class:`GPUTextureView`
+* :class:`GPUUncapturedErrorEvent`
+* :class:`GPUValidationError`
 
-WGPU supports a variety of wgpu-backends. By default one is selected automatically.
+
+Overview
+--------
+
+
+Adapter, device and canvas
+++++++++++++++++++++++++++
+
+The :class:`GPU` represents the root namespace that contains the entrypoint to request an adapter.
+
+The :class:`GPUAdapter` represents a hardware or software device, with specific
+features, limits and properties. To actually start using that harware for computations or rendering, a :class:`GPUDevice` object must be requisted from the adapter. This is a logical unit
+to control your hardware (or software).
+The device is the central object; most other GPU objects are created from it.
+Also see the convenience function :func:`wgpu.utils.get_default_device`.
+
+A device is controlled with a specific backend API. By default one is selected automatically.
 This can be overridden by setting the
 `WGPU_BACKEND_TYPE` environment variable to "Vulkan", "Metal", "D3D12", "D3D11", or "OpenGL".
 
+The device and all objects created from it inherit from :class:`GPUObjectBase` - they represent something on the GPU.
 
-.. autoclass:: wgpu.GPU
-
-.. autofunction:: wgpu.request_adapter
-
-.. autofunction:: wgpu.request_adapter_async
-
-.. autoclass:: wgpu.GPUAdapter
-    :members:
-
-
-Device
-------
-
-The device is the central object; most other GPU objects are created from it.
-It is recommended to request a device object once, or perhaps twice.
-But not for every operation (e.g. in unit tests).
-Also see :func:`wgpu.utils.get_default_device`.
-
-
-.. autoclass:: wgpu.GPUObjectBase
-    :members:
-
-
-.. autoclass:: wgpu.GPUDevice
-    :members:
-
+In most render use-cases you want the result to be presented to a canvas on the screen.
+The :class:`GPUCanvasContext` is the bridge between wgpu and the underlying GUI backend.
 
 Buffers and textures
---------------------
+++++++++++++++++++++
 
-Buffers and textures are used to provide your shaders with data.
+A :class:`GPUBuffer` can be created from a device. It is used to hold data, that can
+be uploaded using it's API. From the shader's point of view, the buffer can be accessed
+as a typed array.
 
-.. autoclass:: wgpu.GPUBuffer
-    :members:
+A :class:`GPUTexture` is similar to a buffer, but has some image-specific features.
+A texture can be 1D, 2D or 3D, can have multiple levels of detail (i.e. lod or mipmaps).
+The texture itself represents the raw data, you can create one or more :class:`GPUTextureView` objects
+for it, that can be attached to a shader.
 
-.. autoclass:: wgpu.GPUTexture
-    :members:
+To let a shader sample from a texture, you also need a :class:`GPUSampler` that
+defines the filtering and sampling behavior beyond the edges.
 
-.. autoclass:: wgpu.GPUTextureView
-    :members:
-
-.. autoclass:: wgpu.GPUSampler
-    :members:
-
+WebGPU also defines the :class:`GPUExternalTexture`, but this is not (yet?) used in wgpu-py.
 
 Bind groups
------------
++++++++++++
 
 Shaders need access to resources like buffers, texture views, and samplers.
 The access to these resources occurs via so called bindings. There are
-integer slots, which you specify both via the API and in the shader, to
-bind the resources to the shader.
+integer slots, which must be specifie both via the API, and in the shader.
 
-Bindings are organized into bind groups, which are essentially a list
-of bindings. E.g. in Python shaders the slot of each resource is specified
-as a two-tuple (e.g. ``(1, 3)``) specifying the bind group and binding
-slot respectively.
+Bindings are organized into :class:`GPUBindGroup` s, which are essentially a list
+of :class:`GPUBinding` s.
 
-Further, in wgpu you need to specify a binding *layout*, providing
+Further, in wgpu you need to specify a :class:`GPUBindGroupLayout`, providing
 meta-information about the binding (type, texture dimension etc.).
 
-One uses
-:func:`device.create_bind_group() <wgpu.GPUDevice.create_bind_group>`
-to create a group of bindings using the actual buffers/textures/samplers.
-
-One uses
-:func:`device.create_bind_group_layout() <wgpu.GPUDevice.create_bind_group_layout>`
-to specify more information about these bindings, and
-:func:`device.create_pipeline_layout() <wgpu.GPUDevice.create_pipeline_layout>`
-to pack one or more bind group layouts together, into a complete layout
-description for a pipeline.
-
-
-.. autoclass:: wgpu.GPUBindGroupLayout
-    :members:
-
-.. autoclass:: wgpu.GPUBindGroup
-    :members:
-
-.. autoclass:: wgpu.GPUPipelineLayout
-    :members:
-
+Multiple bind groups layouts are collected in a :class:`GPUPipelineLayout`,
+which represents a complete layout description for a pipeline.
 
 Shaders and pipelines
----------------------
++++++++++++++++++++++
 
 The wgpu API knows three kinds of shaders: compute, vertex and fragment.
 Pipelines define how the shader is run, and with what resources.
 
+Shaders are represented by a :class:`GPUShaderModule`.
 
-.. autoclass:: wgpu.GPUShaderModule
-    :members:
-
-.. autoclass:: wgpu.GPUPipelineBase
-    :members:
-
-.. autoclass:: wgpu.GPUComputePipeline
-    :members:
-
-.. autoclass:: wgpu.GPURenderPipeline
-    :members:
-
+Compute shaders are combined with a pipelinelayout into a :class:`GPUComputePipeline`.
+Similarly, a vertex and (optional) fragment shader are combined with a pipelinelayout
+into a :class:`GPURenderPipeline`. Both of these inherit from :class:`GPUPipelineBase`.
 
 Command buffers and encoders
-----------------------------
+++++++++++++++++++++++++++++
 
-.. autoclass:: wgpu.GPUCommandBuffer
-    :members:
+The actual rendering occurs by recording a series of commands and then submitting these commands.
 
-.. autoclass:: wgpu.GPUCommandsMixin
-    :members:
+The root object to generate commands with is the :class:`GPUCommandEncoder`.
+This class inherits from :class:`GPUCommandsMixin` (because it generates commands),
+and :class:`GPUDebugCommandsMixin` (because it supports debugging).
 
-.. autoclass:: wgpu.GPUBindingCommandsMixin
-    :members:
+Commands specific to compute and rendering are generated with a :class:`GPUComputePassEncoder` and :class:`GPURenderPassEncoder` respectively. You get these from the command encoder by the
+corresponding ``begin_x_pass()`` method. These pass encoders inherit from
+:class:`GPUBindingCommandsMixin` (because you associate a pipeline)
+and the latter also from :class:`GPURenderCommandsMixin`.
 
-.. autoclass:: wgpu.GPUDebugCommandsMixin
-    :members:
+When you're done generating commands, you call ``finish()`` and get the list of
+commands as an opaque object: the :class:`GPUCommandBuffer`. You don't really use this object
+except for submitting it to the :class:`GPUQueue`.
 
-.. autoclass:: wgpu.GPURenderCommandsMixin
-    :members:
+The command buffers are one-time use. The :class:`GPURenderBundle` and :class:`GPURenderBundleEncoder` can
+be used to record commands to be used multiple times, but this is not yet
+implememted in wgpu-py.
 
-.. autoclass:: wgpu.GPUCommandEncoder
-    :members:
+Error handling
+++++++++++++++
 
-.. autoclass:: wgpu.GPUComputePassEncoder
-    :members:
+Errors are caught and logged using the ``wgpu`` logger.
 
-.. autoclass:: wgpu.GPURenderPassEncoder
-    :members:
+Todo: document the role of these classes:
+:class:`GPUUncapturedErrorEvent`
+:class:`GPUValidationError`
+:class:`GPUOutOfMemoryError`
+:class:`GPUDeviceLostInfo`
 
-.. autoclass:: wgpu.GPURenderBundle
-    :members:
+TODO
+++++
 
-.. autoclass:: wgpu.GPURenderBundleEncoder
-    :members:
-
-
-
-Other
------
-
-.. autoclass:: wgpu.GPUCanvasContext
-    :members:
-
-.. autoclass:: wgpu.GPUQueue
-    :members:
-
-.. autoclass:: wgpu.GPUQuerySet
-    :members:
-
-.. autoclass:: wgpu.GPUDeviceLostInfo
-    :members:
-
-.. autoclass:: wgpu.GPUOutOfMemoryError
-    :members:
-
-.. autoclass:: wgpu.GPUValidationError
-    :members:
-
-.. autoclass:: wgpu.GPUCompilationInfo
-    :members:
-
-.. autoclass:: wgpu.GPUCompilationMessage
-    :members:
-
-.. autoclass:: wgpu.GPUUncapturedErrorEvent
-    :members:
-
-.. autoclass:: wgpu.GPUExternalTexture
-    :members:
+These classes are not supported and/or documented yet.
+:class:`GPUCompilationMessage`
+:class:`GPUCompilationInfo`
+:class:`GPUQuerySet`


### PR DESCRIPTION
This splits the wgpu API docs into two parts:
* A somewhat more guided document, that contains a list of all classes (sorted alphabetically) as well as an attempt to explain how things fit together, mentioning each class at leas once.
* All classes via autodoc.

Previously the "guide"  was mixed with the autodoc, but that did not really work, I think.

There is (a lot) of room for improvement, but it's a start.
