### PR TITLE
Ability to turn vsync off

### DIFF
--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -376,18 +376,14 @@ class GPUCanvasContext(base.GPUCanvasContext):
         # 2 Fifo: Wait for vsync.
         #
         # In general 2 gives the best result, but sometimes people want to
-        # benchmark something and get the highest FPS possible. We can
-        # sortof detect this by looking at the max_fps attribute of the
-        # canvas. Note that we've observed rate limiting regardless of
-        # setting this to 0, depending on OS or being on battery power.
+        # benchmark something and get the highest FPS possible. Note
+        # that we've observed rate limiting regardless of setting this
+        # to 0, depending on OS or being on battery power.
         #
         # Also see:
         # * https://github.com/gfx-rs/wgpu/blob/e54a36ee/wgpu-types/src/lib.rs#L2663-L2678
         # * https://github.com/pygfx/wgpu-py/issues/256
-
-        present_mode = 2
-        if getattr(canvas, "_max_fps", 0) > 100:
-            present_mode = 0
+        present_mode = 2 if getattr(canvas, "_vsync", True) else 0
 
         # H: nextInChain: WGPUChainedStruct *, label: char *, usage: WGPUTextureUsageFlags/int, format: WGPUTextureFormat, width: int, height: int, presentMode: WGPUPresentMode
         struct = new_struct_p(

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -369,6 +369,26 @@ class GPUCanvasContext(base.GPUCanvasContext):
 
         # logger.info(str((psize, canvas.get_logical_size(), canvas.get_pixel_ratio())))
 
+        # Set the present mode to determine vsync behavior.
+        #
+        # 0 Immediate: no waiting, with risk of tearing.
+        # 1 Mailbox: submit without delay, but present on vsync. Not always available.
+        # 2 Fifo: Wait for vsync.
+        #
+        # In general 2 gives the best result, but sometimes people want to
+        # benchmark something and get the highest FPS possible. We can
+        # sortof detect this by looking at the max_fps attribute of the
+        # canvas. Note that we've observed rate limiting regardless of
+        # setting this to 0, depending on OS or being on battery power.
+        #
+        # Also see:
+        # * https://github.com/gfx-rs/wgpu/blob/e54a36ee/wgpu-types/src/lib.rs#L2663-L2678
+        # * https://github.com/pygfx/wgpu-py/issues/256
+
+        present_mode = 2
+        if getattr(canvas, "_max_fps", 0) > 100:
+            present_mode = 0
+
         # H: nextInChain: WGPUChainedStruct *, label: char *, usage: WGPUTextureUsageFlags/int, format: WGPUTextureFormat, width: int, height: int, presentMode: WGPUPresentMode
         struct = new_struct_p(
             "WGPUSwapChainDescriptor *",
@@ -376,11 +396,10 @@ class GPUCanvasContext(base.GPUCanvasContext):
             format=self._format,
             width=max(1, psize[0]),
             height=max(1, psize[1]),
-            presentMode=2,
+            presentMode=present_mode,
             # not used: nextInChain
             # not used: label
         )
-        # present_mode -> 0: Immediate, 1: Mailbox, 2: Fifo
 
         if self._surface_id is None:
             self._surface_id = get_surface_id_from_canvas(canvas)

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -112,14 +112,15 @@ class WgpuCanvasBase(WgpuCanvasInterface):
     subclasses) to use wgpu-py.
 
     This class applies draw rate limiting, which can be set with the
-    ``max_fps`` attribute (default 30). If the ``max_fps`` is set larger
-    than 100, VSync will be turned off.
+    ``max_fps`` attribute (default 30). For benchmarks you may also want
+    to set ``vsync`` to False.
     """
 
-    def __init__(self, *args, max_fps=30, **kwargs):
+    def __init__(self, *args, max_fps=30, vsync=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._last_draw_time = 0
         self._max_fps = float(max_fps)
+        self._vsync = bool(vsync)
         self._err_hashes = {}
 
     def draw_frame(self):

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -112,7 +112,7 @@ class WgpuCanvasBase(WgpuCanvasInterface):
     subclasses) to use wgpu-py.
 
     This class applies draw rate limiting, which can be set with the
-    `max_fps` attribute (default 30). If the `max_fps` is set larger
+    ``max_fps`` attribute (default 30). If the ``max_fps`` is set larger
     than 100, VSync will be turned off.
     """
 

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -110,6 +110,10 @@ class WgpuCanvasBase(WgpuCanvasInterface):
 
     It is convenient - but not required - to use this class (or any of its
     subclasses) to use wgpu-py.
+
+    This class applies draw rate limiting, which can be set with the
+    `max_fps` attribute (default 30). If the `max_fps` is set larger
+    than 100, VSync will be turned off.
     """
 
     def __init__(self, *args, max_fps=30, **kwargs):


### PR DESCRIPTION
Closes #256.

Turn vsync off when max_fps is high. This could also be a separate prop, but I suppose they sort of go hand in hand.