### PR TITLE
Improve error reporting on WGSL again

### DIFF
--- a/tests/test_rs_basics.py
+++ b/tests/test_rs_basics.py
@@ -5,10 +5,10 @@ import random
 import ctypes
 import sys
 import tempfile
+import re
 
 import wgpu.utils
 import wgpu.backends.rs
-import wgpu.backends.rs_helpers
 import numpy as np
 
 from testutils import run_tests, can_use_wgpu_lib, is_ci, iters_equal
@@ -659,7 +659,13 @@ def test_write_texture2():
 
 def test_parse_shader_error(caplog):
 
-    # invalid attribute access
+    device = wgpu.utils.get_default_device()
+
+    ansi_color_escape = re.compile(
+        r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]"
+    )  # ANSI color codes
+
+    # test1: invalid attribute access
     error_source = """
     struct VertexOutput {
         @location(0) texcoord : vec2<f32>,
@@ -672,14 +678,12 @@ def test_parse_shader_error(caplog):
         out.invalid_attr = vec4<f32>(0.0, 0.0, 1.0);
         return out;
     }
-    """
-
-    device = wgpu.utils.get_default_device()
+    """  # noqa
 
     with raises(RuntimeError):
         device.create_shader_module(code=error_source)
 
-    shader_error = caplog.records[0].msg
+    shader_error = ansi_color_escape.sub("", caplog.records[0].msg)
 
     assert (
         shader_error.strip()
@@ -688,24 +692,24 @@ Shader error: label:  Some("")
 error: invalid field accessor `invalid_attr`
 
 
-     ┌─ wgsl:10:12
-     │
-  10 │         out.invalid_attr = vec4<f32>(0.0, 0.0, 1.0);
-     │             ^^^^^^^^^^^^ invalid accessor
-
-""".strip()
+   ┌─ wgsl:10:12
+   │
+10 │         out.invalid_attr = vec4<f32>(0.0, 0.0, 1.0);
+   │             ^^^^^^^^^^^^ invalid accessor
+   = note: 
+""".strip()  # noqa
     )
 
-    # grammar error, expected ',', not ';'
+    # test2: grammar error, expected ',', not ';'
     error_source = """struct VertexOutput {
         @location(0) texcoord : vec2<f32>;
         @builtin(position) position: vec4<f32>,
     };
-    """
+    """  # noqa
     with raises(RuntimeError):
         device.create_shader_module(code=error_source)
 
-    shader_error = caplog.records[1].msg
+    shader_error = ansi_color_escape.sub("", caplog.records[1].msg)
 
     assert (
         shader_error.strip()
@@ -714,12 +718,40 @@ Shader error: label:  Some("")
 error: expected ',', found ';'
 
 
-     ┌─ wgsl:2:41
-     │
-   2 │         @location(0) texcoord : vec2<f32>;
-     │                                          ^ expected ','
+  ┌─ wgsl:2:41
+  │
+2 │         @location(0) texcoord : vec2<f32>;
+  │                                          ^ expected ','
+  = note: 
+""".strip()  # noqa
+    )
 
-""".strip()
+    # test3: grammar error, contains '\t' and (tab),  unknown scalar type: 'f3'
+    error_source = """
+    struct VertexOutput {
+    \t@location(0) texcoord : vec2<f32>,
+    	@builtin(position) position: vec4<f3>,
+    };
+    """  # noqa
+    with raises(RuntimeError):
+        device.create_shader_module(code=error_source)
+
+    shader_error = ansi_color_escape.sub("", caplog.records[2].msg)
+
+    assert (
+        shader_error.strip()
+        == """
+Shader error: label:  Some("")
+error: unknown scalar type: 'f3'
+
+
+  ┌─ wgsl:4:39
+  │
+4 │      @builtin(position) position: vec4<f3>,
+  │                                        ^^ unknown scalar type
+  = note: "Valid scalar types are f16, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64, bool"
+
+""".strip()  # noqa
     )
 
 

--- a/wgpu/backends/rs_helpers.py
+++ b/wgpu/backends/rs_helpers.py
@@ -171,12 +171,13 @@ def parse_wgpu_shader_error(message):
     match = __shader_error_tmpl.match(message)
     if match:
         source = match.group(1)
+        source = source.replace("\\t", " ")
         label = match.group(2)
         inner_error = match.group(3)
-        err_msg.append(f"Shader error: label: {label}")
+        err_msg.append(f"\033[33mShader error: label: {label}")
         match2 = __inner_error_tmpl.match(inner_error)
         if match2:
-            err_msg.append(f"error: {match2.group(1)}")
+            err_msg.append(f"error: {match2.group(1)}\033[0m")
             start = int(match2.group(2))
             end = int(match2.group(3))
             label = match2.group(4)
@@ -187,11 +188,17 @@ def parse_wgpu_shader_error(message):
             line = lines[-1]
             line_pos = start - (next_n - len(line))
 
+            note = match2.group(5)
+
+            pad = len(str(line_num))
             err_msg.append("\n")
-            err_msg.append(f"{' '*4} ┌─ wgsl:{line_num}:{line_pos}")
-            err_msg.append(f"{' '*4} │")
-            err_msg.append(f"{line_num:4d} │ {line}")
-            err_msg.append(f"{' '*4} │ {' '*line_pos + '^'*(end-start)} {label}")
+            err_msg.append(f"\033[36m{' '*pad} ┌─\033[0m wgsl:{line_num}:{line_pos}")
+            err_msg.append(f"\033[36m{' '*pad} │\033[0m")
+            err_msg.append(f"\033[36m{line_num} │\033[0m {line}")
+            err_msg.append(
+                f"\033[36m{' '*pad} │\033[0m \033[33m{' '*line_pos + '^'*(end-start)} {label}\033[0m"
+            )
+            err_msg.append(f"\033[36m{' '*pad} = note: {note}\033[0m")
             err_msg.append("\n\n")
 
             return "\n".join(err_msg)


### PR DESCRIPTION
Related: #278 

This PR fixes the problem that the error position indication is not accurate when the shader code contains a tab or \t symbol.

Add possible error notes

Add ANSI colors to make the results more readable.

Now, it looks something like this:
![image](https://user-images.githubusercontent.com/8044566/171581933-fb79c803-7b3c-43f6-9fdb-4b7de1647914.png)

The test case has also been updated.
