### PR TITLE
Fix qt 6.3 keyboard events

### DIFF
--- a/examples/triangle_qt.py
+++ b/examples/triangle_qt.py
@@ -9,7 +9,7 @@ import importlib
 # For the sake of making this example Just Work, we try multiple QT libs
 for lib in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
     try:
-        QtWidgets = importlib.import_module(f"{lib}.QtWidgets")
+        QtWidgets = importlib.import_module(".QtWidgets", lib)
         break
     except ModuleNotFoundError:
         pass

--- a/examples/triangle_qt_embed.py
+++ b/examples/triangle_qt_embed.py
@@ -9,7 +9,7 @@ import importlib
 # For the sake of making this example Just Work, we try multiple QT libs
 for lib in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
     try:
-        QtWidgets = importlib.import_module(f"{lib}.QtWidgets")
+        QtWidgets = importlib.import_module(".QtWidgets", lib)
         break
     except ModuleNotFoundError:
         pass

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -20,11 +20,13 @@ for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
             WA_PaintOnScreen = QtCore.Qt.WidgetAttribute.WA_PaintOnScreen
             PreciseTimer = QtCore.Qt.TimerType.PreciseTimer
             KeyboardModifiers = QtCore.Qt.KeyboardModifier
+            FocusPolicy = QtCore.Qt.FocusPolicy
             Keys = QtCore.Qt.Key
         except AttributeError:
             WA_PaintOnScreen = QtCore.Qt.WA_PaintOnScreen
             PreciseTimer = QtCore.Qt.PreciseTimer
             KeyboardModifiers = QtCore.Qt
+            FocusPolicy = QtCore.Qt
             Keys = QtCore.Qt
         break
 else:
@@ -126,6 +128,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         self.setAttribute(WA_PaintOnScreen, True)
         self.setAutoFillBackground(False)
         self.setMouseTracking(True)
+        self.setFocusPolicy(FocusPolicy.StrongFocus)
 
         # A timer for limiting fps
         self._request_draw_timer = QtCore.QTimer()

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -13,9 +13,8 @@ from .base import WgpuCanvasBase, WgpuAutoGui
 # Select GUI toolkit
 for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
     if libname in sys.modules:
-        QtCore = importlib.import_module(libname + ".QtCore")
-        widgets_modname = "QtGui" if QtCore.qVersion()[0] == "4" else "QtWidgets"
-        QtWidgets = importlib.import_module(libname + "." + widgets_modname)
+        QtCore = importlib.import_module(".QtCore", libname)
+        QtWidgets = importlib.import_module(".QtWidgets", libname)
         try:
             WA_PaintOnScreen = QtCore.Qt.WidgetAttribute.WA_PaintOnScreen
             PreciseTimer = QtCore.Qt.TimerType.PreciseTimer


### PR DESCRIPTION
Something changed with PySide/Qt 6.3 and keyboard events weren't coming in. Setting the focus policy to something else than `Qt.NoFocus` seems to do the trick. See more here: https://doc.qt.io/qtforpython/PySide6/QtCore/Qt.html#PySide6.QtCore.PySide6.QtCore.Qt.FocusPolicy

Also, there seems to be a problem with overwriting the `handle_event` method in a subclass in combination with PySide/Qt (also 6.2.*), so the [examples/events.py]() is still broken for PySide/Qt. Might have something to do with #271 ?