### PR TITLE
Add missing dev dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,8 @@ flake8-black
 pep8-naming
 sphinx
 imageio
+pyinstaller
+psutil
 
 # Building wheels
 wheel


### PR DESCRIPTION
Closes: https://github.com/pygfx/wgpu-py/issues/293

This PR adds two missing dependencies to `dev-requirements.txt`