### PR TITLE
package only the release binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import re
-import sys
+import platform
 
 from setuptools import find_packages, setup
 from wheel.bdist_wheel import get_platform, bdist_wheel as _bdist_wheel
@@ -19,12 +19,12 @@ class bdist_wheel(_bdist_wheel):  # noqa: N801
 
 
 resources_globs = ["*.h", "*.idl"]
-if sys.platform.startswith("win"):
-    resources_globs.append("*.dll")
-elif sys.platform.startswith("linux"):
-    resources_globs.append("*.so")
-elif sys.platform.startswith("darwin"):
-    resources_globs.append("*.dylib")
+if platform.system() == "Windows":
+    resources_globs.append("libwgpu-release.dll")
+elif platform.system() == "Linux":
+    resources_globs.append("libwgpu-release.so")
+elif platform.system() == "Darwin":
+    resources_globs.append("libwgpu-release.dylib")
 else:
     pass  # don't include binaries; user will have to arrange for the lib
 


### PR DESCRIPTION
Closes: https://github.com/pygfx/wgpu-py/issues/291

This PR adds a small improvement to `setup.py` which makes it only include the release binary instead of including both the debug and the release version. The main benefit of doing so is to reducing package size.

I've also changed the glob (e.g., `*.dll`) into an explicit filename. My angle here is security. We know what the filename will be in advance and this way we can avoid collecting other binaries that we didn't expect to find. If you prefer the glob, I'm happy to revert :)

@Korijn I've also changed the `sys.platform` call to `platform.system`. `platform` is the currently recommended way to deal with platform-specific logic in python so I figured I would use the chance to update. That said, I don't feel very strongly about this and if you'd rather have the old style I'm happy to revert.