### PR TITLE
Fix minor doc oversight

### DIFF
--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -1640,7 +1640,7 @@ class GPUQueue(GPUObjectBase):
     """
     A queue can be used to submit command buffers to.
 
-    You can obtain a queue object via the :attr:`GPUDevice.default_queue` property.
+    You can obtain a queue object via the :attr:`GPUDevice.queue` property.
     """
 
     # IDL: undefined submit(sequence<GPUCommandBuffer> commandBuffers);


### PR DESCRIPTION
`default_queue` was changed to `queue` in v0.4