### PR TITLE
make offscreen canvas closable

### DIFF
--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -15,6 +15,7 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
         super().__init__(*args, **kwargs)
         self._logical_size = width, height
         self._pixel_ratio = pixel_ratio
+        self._closed = False
 
     def get_pixel_ratio(self):
         return self._pixel_ratio
@@ -31,10 +32,10 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
         self._logical_size = width, height
 
     def close(self):
-        pass
+        self._closed = True
 
     def is_closed(self):
-        return False
+        return self._closed
 
     def _request_draw(self):
         call_later(0, self.draw)


### PR DESCRIPTION
As discussed in https://github.com/pygfx/pygfx/pull/396 this PR adds a `_closed` flag that allows users to `.close()` an offscreen canvas. This makes the offscreen canvas behave a bit more like an offscreen canvas and allows unit-testing `gfx.Display` in pygfx.