### PR TITLE
Execute examples in the test process

### DIFF
--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -2,7 +2,6 @@
 Test that the examples run without error.
 """
 
-import asyncio
 import os
 import importlib
 import runpy
@@ -12,7 +11,6 @@ from unittest.mock import patch
 import imageio.v2 as imageio
 import numpy as np
 import pytest
-import wgpu.gui.offscreen
 
 from tests.testutils import (
     can_use_wgpu_lib,
@@ -38,47 +36,11 @@ examples_to_test = find_examples(query="# test_example = true", return_stems=Tru
 
 
 @pytest.mark.parametrize("module", examples_to_run)
-def test_examples_run(module, force_offscreen, disable_call_later_after_run):
+def test_examples_run(module, force_offscreen):
     """Run every example marked to see if they can run without error."""
     # use runpy so the module is not actually imported (and can be gc'd)
     # but also to be able to run the code in the __main__ block
     runpy.run_module(f"examples.{module}", run_name="__main__")
-
-
-@pytest.fixture
-def disable_call_later_after_run():
-    """Disable call_later after run has been called."""
-    # we start by asserting no tasks are pending
-    # if this fails, we likely need to refactor this fixture
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    if len(asyncio.all_tasks(loop=loop)) != 0:
-        raise RuntimeError("no tasks should be pending")
-
-    orig_run = wgpu.gui.offscreen.run
-    orig_call_later = wgpu.gui.offscreen.call_later
-    allow_call_later = True
-
-    def wrapped_call_later(*args, **kwargs):
-        if allow_call_later:
-            orig_call_later(*args, **kwargs)
-
-    def wrapped_run(*args, **kwargs):
-        nonlocal allow_call_later
-        allow_call_later = False
-        orig_run(*args, **kwargs)
-
-    wgpu.gui.offscreen.call_later = wrapped_call_later
-    wgpu.gui.offscreen.run = wrapped_run
-    try:
-        yield
-
-        # again, after the test, no tasks should be pending
-        # if this fails, we likely need to refactor this fixture
-        if len(asyncio.all_tasks(loop=loop)) != 0:
-            raise RuntimeError("no tasks should be pending")
-    finally:
-        wgpu.gui.offscreen.call_later = orig_call_later
-        wgpu.gui.offscreen.run = orig_run
 
 
 @pytest.fixture

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -2,15 +2,17 @@
 Test that the examples run without error.
 """
 
+import asyncio
 import os
 import importlib
-from unittest.mock import patch
-import subprocess
+import runpy
 import sys
+from unittest.mock import patch
 
 import imageio.v2 as imageio
 import numpy as np
 import pytest
+import wgpu.gui.offscreen
 
 from tests.testutils import (
     can_use_wgpu_lib,
@@ -27,38 +29,56 @@ if not can_use_wgpu_lib:
 
 
 # run all tests unless they opt-out
-examples_to_run = find_examples(negative_query="# run_example = false")
+examples_to_run = find_examples(
+    negative_query="# run_example = false", return_stems=True
+)
 
 # only test output of examples that opt-in
 examples_to_test = find_examples(query="# test_example = true", return_stems=True)
 
 
-@pytest.mark.parametrize("module", examples_to_run, ids=lambda module: module.stem)
-def test_examples_run(module, pytestconfig):
+@pytest.mark.parametrize("module", examples_to_run)
+def test_examples_run(module, force_offscreen, disable_call_later_after_run):
     """Run every example marked to see if they can run without error."""
-    env = os.environ.copy()
-    env["WGPU_FORCE_OFFSCREEN"] = "true"
+    # use runpy so the module is not actually imported (and can be gc'd)
+    # but also to be able to run the code in the __main__ block
+    runpy.run_module(f"examples.{module}", run_name="__main__")
 
+
+@pytest.fixture
+def disable_call_later_after_run():
+    """Disable call_later after run has been called."""
+    # we start by asserting no tasks are pending
+    # if this fails, we likely need to refactor this fixture
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    if len(asyncio.all_tasks(loop=loop)) != 0:
+        raise RuntimeError("no tasks should be pending")
+
+    orig_run = wgpu.gui.offscreen.run
+    orig_call_later = wgpu.gui.offscreen.call_later
+    allow_call_later = True
+
+    def wrapped_call_later(*args, **kwargs):
+        if allow_call_later:
+            orig_call_later(*args, **kwargs)
+
+    def wrapped_run(*args, **kwargs):
+        nonlocal allow_call_later
+        allow_call_later = False
+        orig_run(*args, **kwargs)
+
+    wgpu.gui.offscreen.call_later = wrapped_call_later
+    wgpu.gui.offscreen.run = wrapped_run
     try:
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(module.relative_to(ROOT)),
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-            cwd=ROOT,
-            timeout=5,
-            env=env,
-        )
-    except subprocess.TimeoutExpired:
-        pytest.fail(
-            "opt-out by adding `# run_example = false` to the module docstring,"
-            "or use WgpuAutoGui to support WGPU_FORCE_OFFSCREEN"
-        )
+        yield
 
-    assert result.returncode == 0, f"failed to run:\n{result.stdout}"
+        # again, after the test, no tasks should be pending
+        # if this fails, we likely need to refactor this fixture
+        if len(asyncio.all_tasks(loop=loop)) != 0:
+            raise RuntimeError("no tasks should be pending")
+    finally:
+        wgpu.gui.offscreen.call_later = orig_call_later
+        wgpu.gui.offscreen.run = orig_run
 
 
 @pytest.fixture
@@ -81,11 +101,22 @@ def mock_time():
 
 
 @pytest.mark.parametrize("module", examples_to_test)
-def test_examples_screenshots(module, pytestconfig, force_offscreen, mock_time):
+def test_examples_screenshots(
+    module, pytestconfig, force_offscreen, mock_time, request
+):
     """Run every example marked for testing."""
 
-    # render
-    example = importlib.import_module(f"examples.{module}")
+    # import the example module
+    module_name = f"examples.{module}"
+    example = importlib.import_module(module_name)
+
+    # ensure it is unloaded after the test
+    def unload_module():
+        del sys.modules[module_name]
+
+    request.addfinalizer(unload_module)
+
+    # render a frame
     img = example.canvas.draw()
 
     # check if _something_ was rendered

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -85,3 +85,8 @@ def run():
     # calls to request_draw() in the animate function.
     loop = asyncio.get_event_loop_policy().get_event_loop()
     loop.run_until_complete(mainloop_iter())
+
+    # cancel any newly scheduled tasks
+    for t in asyncio.all_tasks(loop=loop):
+        t.cancel()
+    assert len(asyncio.all_tasks(loop=loop)) == 0


### PR DESCRIPTION
This avoids many types of overhead, like process creation, python interpreter startup, module importing, and wgpu device acquisition.

We use the runpy module here (and not exec) since it facilitates the use case quite well but also because it executes the code in a temporary module namespace.

With this change the full test suite runtime is improved as follows:

* Locally: 10.39s to 3.79s
* CI: 10.85s to 4.24s (but likely just a lucky shot, since software rendering is the bottleneck there, rather than initialization)

(Note: exactly the same change as https://github.com/pygfx/pygfx/pull/362)