### PR TITLE
fix: fix gui qt in ipython

### DIFF
--- a/wgpu/gui/auto.py
+++ b/wgpu/gui/auto.py
@@ -32,21 +32,26 @@ else:
     try:
         from .glfw import WgpuCanvas, run, call_later  # noqa
     except ImportError as glfw_err:
-        for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
-            try:
-                importlib.import_module(libname)
+        qt_backends = ("PySide6", "PyQt6", "PySide2", "PyQt5")
+        for backend in qt_backends:
+            if backend in sys.modules:
                 break
-            except ModuleNotFoundError:
-                pass
         else:
-            msg = str(glfw_err)
-            msg += "\n\n  Could not find either glfw or Qt framework."
-            msg += "\n  Install glfw using e.g. ``pip install -U glfw``,"
-            msg += (
-                "\n  or install a qt framework using e.g. ``pip install -U pyside6``."
-            )
-            if sys.platform.startswith("linux"):
-                msg += "\n  You may also need to run the equivalent of ``apt install libglfw3``."
-            raise ImportError(msg) from None
+            for libname in qt_backends:
+                try:
+                    importlib.import_module(libname)
+                    break
+                except ModuleNotFoundError:
+                    pass
+            else:
+                msg = str(glfw_err)
+                msg += "\n\n  Could not find either glfw or Qt framework."
+                msg += "\n  Install glfw using e.g. ``pip install -U glfw``,"
+                msg += (
+                    "\n  or install a qt framework using e.g. ``pip install -U pyside6``."
+                )
+                if sys.platform.startswith("linux"):
+                    msg += "\n  You may also need to run the equivalent of ``apt install libglfw3``."
+                raise ImportError(msg) from None
 
         from .qt import WgpuCanvas, run, call_later

--- a/wgpu/gui/auto.py
+++ b/wgpu/gui/auto.py
@@ -47,9 +47,7 @@ else:
                 msg = str(glfw_err)
                 msg += "\n\n  Could not find either glfw or Qt framework."
                 msg += "\n  Install glfw using e.g. ``pip install -U glfw``,"
-                msg += (
-                    "\n  or install a qt framework using e.g. ``pip install -U pyside6``."
-                )
+                msg += "\n  or install a qt framework using e.g. ``pip install -U pyside6``."
                 if sys.platform.startswith("linux"):
                     msg += "\n  You may also need to run the equivalent of ``apt install libglfw3``."
                 raise ImportError(msg) from None

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -189,7 +189,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
 
     def _request_draw(self):
         if not self._request_draw_timer.isActive():
-            self._request_draw_timer.start(self._get_draw_wait_time() * 1000)
+            self._request_draw_timer.start(int(self._get_draw_wait_time() * 1000))
 
     def close(self):
         super().close()


### PR DESCRIPTION
This fixes a conflic with IPython's [`%gui qt`](https://ipython.readthedocs.io/en/stable/config/eventloops.html) magic (which is often used when running an interactive event loop in IPython)

```python
In [1]: %gui qt

In [2]: from wgpu.gui.auto import WgpuCanvas
```

```pytb
File ~/mambaforge/envs/microvis/lib/python3.10/site-packages/wgpu/gui/auto.py:37
     35 for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
     36     try:
---> 37         importlib.import_module(libname)
     38         break
     39     except ModuleNotFoundError:

File ~/mambaforge/envs/microvis/lib/python3.10/importlib/__init__.py:126, in import_module(name, package)
    124             break
    125         level += 1
--> 126 return _bootstrap._gcd_import(name[level:], package, level)

File ~/mambaforge/envs/microvis/lib/python3.10/site-packages/IPython/external/qt_loaders.py:65, in ImportDenier.find_spec(self, fullname, path, target)
     63         return
     64     if fullname in self.__forbidden:
---> 65         raise ImportError(
     66             """
     67 Importing %s disabled by IPython, which has
     68 already imported an Incompatible QT Binding: %s
     69 """
     70             % (fullname, loaded_api())
     71         )

ImportError:
    Importing PySide6 disabled by IPython, which has
    already imported an Incompatible QT Binding: pyqt5
```

Looks like IPython straight up forbids even the *attempt* to import these packages by name (even if they are not installed).  so it's impossible to use `wgpu.gui.auto` once `%gui qt` has been invoked.

... this also fixes one small type casting issue I found with PyQt5