### PR TITLE
Improve wgsl error reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-.Python
+.DS_Store
+Python
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ __pycache__/
 
 # Distribution / packaging
 .DS_Store
-Python
+.Python
 build/
 develop-eggs/
 dist/

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,14 @@
 """Global configuration for pytest"""
+
+import os
+import sys
+
 import numpy as np
 import pytest
+
+
+# Enable importing testutils from all test scripts
+sys.path.insert(0, os.path.abspath(os.path.join(__file__, "..", "tests")))
 
 
 def pytest_addoption(parser):

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -12,7 +12,8 @@ import imageio.v2 as imageio
 import numpy as np
 import pytest
 
-from tests.testutils import (
+
+from testutils import (
     can_use_wgpu_lib,
     is_lavapipe,
     find_examples,

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -25,9 +25,7 @@ def setup_module():
 
 
 def teardown_module():
-    import glfw
-
-    glfw.terminate()
+    pass  # Do not glfw.terminate() because other tests may still need glfw
 
 
 def test_is_autogui():

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,7 +1,10 @@
 import os
-from pathlib import Path
+import re
 import sys
+import logging
 import subprocess
+from io import StringIO
+from pathlib import Path
 
 import wgpu.backends.rs  # noqa
 from wgpu.utils import get_default_device  # noqa
@@ -13,13 +16,40 @@ screenshots_dir = examples_dir / "screenshots"
 diffs_dir = screenshots_dir / "diffs"
 
 
+class LogCaptureHandler(logging.StreamHandler):
+
+    _ANSI_ESCAPE_SEQ = re.compile(r"\x1b\[[\d;]+m")
+
+    def __init__(self):
+        super().__init__(StringIO())
+        self.records = []
+
+    def emit(self, record):
+        record.msg = self._ANSI_ESCAPE_SEQ.sub("", record.msg)
+        self.records.append(record)
+        super().emit(record)
+
+    def reset(self):
+        self.records = []
+        self.stream = StringIO()
+
+
 def run_tests(scope):
     """Run all test functions in the given scope."""
+    caplog = LogCaptureHandler()
     for func in list(scope.values()):
         if callable(func) and func.__name__.startswith("test_"):
-            if func.__code__.co_argcount == 0:
+            nargs = func.__code__.co_argcount
+            argnames = [func.__code__.co_varnames[i] for i in range(nargs)]
+            if not argnames:
                 print(f"Running {func.__name__} ...")
                 func()
+            elif argnames == ["caplog"]:
+                print(f"Running {func.__name__} ...")
+                logging.root.addHandler(caplog)
+                caplog.reset()
+                func(caplog)
+                logging.root.removeHandler(caplog)
             else:
                 print(f"SKIPPING {func.__name__} because it needs args")
     print("Done")

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -47,7 +47,7 @@ from .rs_helpers import (
     get_surface_id_from_canvas,
     get_memoryview_from_address,
     get_memoryview_and_address,
-    parse_wgpu_shader_error,
+    parse_wgsl_error,
     to_snake_case,
     to_camel_case,
     device_dropper,
@@ -573,7 +573,7 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
             message = ffi.string(c_message).decode(errors="ignore")
             message = message.replace("\\n", "\n")
 
-            shader_error = parse_wgpu_shader_error(message)
+            shader_error = parse_wgsl_error(message)
 
             if shader_error:
                 self._on_error(shader_error)

--- a/wgpu/backends/rs_helpers.py
+++ b/wgpu/backends/rs_helpers.py
@@ -285,10 +285,10 @@ class WgslErrorParser:
                         err_msg += self._extract_line(source, start, end, label, note)
                     else:
                         err_msg += [color_string(33, inner_error)]
-        else:
-            return None
 
-        return "\n".join(err_msg)
+                return "\n".join(err_msg)
+
+        return None  # Does not look like a shader error
 
     def _extract_line(self, source, start, end, label, note):
 


### PR DESCRIPTION
I ran into a case where the line info could not be found, and it printed the whole source. I fixed that, and refactored the code a bit along the way. I put the logic for parsing shader errorrs in a class to hold the different parts together. I also refactored the tests a bit, because the dedented code blocks made the tests very hard to read. 