### PR TITLE
Fix offscreen size arg

### DIFF
--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -11,9 +11,9 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
     method to perform a draw and get the result.
     """
 
-    def __init__(self, *args, width=640, height=480, pixel_ratio=1, **kwargs):
+    def __init__(self, *args, size=None, pixel_ratio=1, **kwargs):
         super().__init__(*args, **kwargs)
-        self._logical_size = width, height
+        self._logical_size = (float(size[0]), float(size[1])) if size else (640, 480)
         self._pixel_ratio = pixel_ratio
         self._closed = False
 


### PR DESCRIPTION
We use `size` in all the GUI backends, but for some reason we used `width` and `height`  for the offscreen canvas 🤷 

This means that the validation examples in PyGfx have the default size instead of the custom one (if given). In particular the new validation example in https://github.com/pygfx/pygfx/pull/404 does not fit on the image :)