### PR TITLE
Make canvases close when they get deleted

### DIFF
--- a/tests/test_gui_auto_offscreen.py
+++ b/tests/test_gui_auto_offscreen.py
@@ -3,6 +3,7 @@ Test the force offscreen auto gui mechanism.
 """
 
 import os
+import weakref
 
 import wgpu.backends.rs  # noqa
 from pytest import fixture, skip
@@ -49,3 +50,15 @@ def test_event_loop():
     run()
 
     assert ran
+
+
+def test_offscreen_canvas_del():
+
+    from wgpu.gui.offscreen import WgpuCanvas
+
+    canvas = WgpuCanvas()
+    ref = weakref.ref(canvas)
+
+    assert ref() is not None
+    del canvas
+    assert ref() is None

--- a/tests/test_gui_base.py
+++ b/tests/test_gui_base.py
@@ -170,5 +170,40 @@ def test_autogui_mixin():
     assert events == [1, 2, 5]
 
 
+def test_weakbind():
+
+    weakbind = wgpu.gui.base.weakbind
+
+    xx = []
+
+    class Foo:
+        def bar(self):
+            xx.append(1)
+
+    f1 = Foo()
+    f2 = Foo()
+
+    b1 = f1.bar
+    b2 = weakbind(f2.bar)
+
+    assert len(xx) == 0
+    b1()
+    assert len(xx) == 1
+    b2()
+    assert len(xx) == 2
+
+    del f1
+    del f2
+
+    # May be needed (on pypy?) to force a collection
+    # gc.collect()
+
+    assert len(xx) == 2
+    b1()
+    assert len(xx) == 3  # f1 still exists
+    b2()
+    assert len(xx) == 3  # f2 is gone!
+
+
 if __name__ == "__main__":
     run_tests(globals())

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -53,6 +53,7 @@ def weakbind(method):
         if self is not None:
             return class_func(self, *args, **kwargs)
 
+    proxy.__name__ = class_func.__name__
     return proxy
 
 

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -43,7 +43,7 @@ def log_exception(kind):
 
 
 def weakbind(method):
-    """Wrap a method so that the instance is held in a weakref."""
+    """Replace a bound method with a callable object that stores the `self` using a weakref."""
     ref = weakref.ref(method.__self__)
     class_func = method.__func__
     del method

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -3,11 +3,11 @@ Support for rendering in a Qt widget. Provides a widget subclass that
 can be used as a standalone window or in a larger GUI.
 """
 
+import sys
 import ctypes
 import importlib
-import sys
 
-from .base import WgpuCanvasBase, WgpuAutoGui
+from .base import WgpuCanvasBase, WgpuAutoGui, weakbind
 
 
 # Select GUI toolkit
@@ -192,7 +192,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
             self._request_draw_timer.start(int(self._get_draw_wait_time() * 1000))
 
     def close(self):
-        super().close()
+        QtWidgets.QWidget.close(self)
 
     def is_closed(self):
         return not self.isVisible()
@@ -323,7 +323,7 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         self.setMouseTracking(True)
 
         self._subwidget = QWgpuWidget(self, max_fps=max_fps)
-        self._subwidget.add_event_handler(self.handle_event, "*")
+        self._subwidget.add_event_handler(weakbind(self.handle_event), "*")
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -372,7 +372,8 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         return self._subwidget._request_draw()
 
     def close(self):
-        super().close()
+        self._subwidget.close()
+        QtWidgets.QWidget.close(self)
 
     def is_closed(self):
         return not self.isVisible()

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -5,7 +5,7 @@ can be used as a standalone window or in a larger GUI.
 
 import ctypes
 
-from .base import WgpuCanvasBase
+from .base import WgpuCanvasBase, weakbind
 
 import wx
 
@@ -120,7 +120,7 @@ class WxWgpuCanvas(WgpuCanvasBase, wx.Frame):
         self.SetTitle(title or "wx wgpu canvas")
 
         self._subwidget = WxWgpuWindow(parent=self, max_fps=max_fps)
-        self._subwidget.add_event_handler(self.handle_event, "*")
+        self._subwidget.add_event_handler(weakbind(self.handle_event), "*")
         self.Bind(wx.EVT_CLOSE, lambda e: self.Destroy())
 
         self.Show()


### PR DESCRIPTION
Closes #305.

* [x] Implement `WgpuCanvasBase.__del__` to call `self.close()`.
* [x] Avoid refs holding onto the canvas in Qt.
* [x] Avoid refs holding onto the canvas in glfw. Plus tests.
* [x] Avoid refs holding onto the canvas in wx.
* [x] Avoid refs holding onto the canvas in offscreen.
* [x] Avoid refs holding onto the canvas in Jupyter.
* [x] Improved support for interactive sessions with glfw (when asyncio is already running).
