### PR TITLE
Cancel callbacks in offscreen.run

### DIFF
--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -79,7 +79,7 @@ async def mainloop_iter():
     pass  # no op
 
 
-def run(cancel_new=True):
+def run():
     """Handle all tasks scheduled with call_later and return."""
     # This runs a stub coroutine. It will also run any pending things
     # on the loop, like the draw-event scheduled with request_draw. But
@@ -88,9 +88,8 @@ def run(cancel_new=True):
     loop = asyncio.get_event_loop_policy().get_event_loop()
     loop.run_until_complete(mainloop_iter())
 
-    if cancel_new:
-        while queued:
-            handle = queued.pop()
-            handle.cancel()
-        for t in asyncio.all_tasks(loop=loop):
-            t.cancel()
+    while queued:
+        handle = queued.pop()
+        handle.cancel()
+    for t in asyncio.all_tasks(loop=loop):
+        t.cancel()

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -66,7 +66,6 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
 
 
 WgpuCanvas = WgpuManualOffscreenCanvas
-WgpuCanvas = WgpuManualOffscreenCanvas
 queued = []
 
 


### PR DESCRIPTION
Cleanup in offscreen.run was not sufficient. Call_later does not create tasks in the asyncio loop immediately, but we can use the handles returned by call_later to cancel.