### PR TITLE
Fix docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+# If we ever want to run wgpu stuff in the doc build
+#  apt_packages:
+#    - libegl1-mesa
+#    - libgl1-mesa-dri
+#    - libxcb-xfixes0-dev
+#    - mesa-vulkan-drivers
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -1,4 +1,4 @@
-GUI API
+gui API
 =======
 
 .. currentmodule:: wgpu.gui

--- a/docs/wgpu.rst
+++ b/docs/wgpu.rst
@@ -1,5 +1,5 @@
-WGPU
-====
+wgpu API
+========
 
 .. currentmodule:: wgpu
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ runtime_deps = ["cffi>=1.15.0rc2", "rubicon-objc>=0.4.1; sys_platform == 'darwin
 extra_deps = {
     "jupyter": ["jupyter_rfb>=0.3.1"],
     "glfw": ["glfw>=1.9"],
+    "docs": ["sphinx"],
 }
 
 setup(


### PR DESCRIPTION
Docs where refactored in #338, using autosummary and introduced linking to classes, structs etc.

Sadly, the links in the docs are broken. Interestingly, they work fine if I build the docs locally. It appears that RTD uses a relatively old version of Sphinx. Maybe this causes it?

--> I switched to using a rtd config file and now it works 🚀 
