### PR TITLE
Avoid unexpected numpy imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ on:
 jobs:
 
   lint-build:
-    name: Linting
+    name: Test Linting
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dev dependencies
@@ -31,15 +31,62 @@ jobs:
       run: |
           flake8 .
 
-  docs-build:
-    name: Docs
+  test-codegen-build:
+    name: Test Codegen
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+          python -m pip install --upgrade pip
+          pip install -U pytest numpy black cffi
+    - name: Test codegen
+      run: |
+          pytest -v codegen
+
+  test-minimal-import-build:
+    name: Test Imports
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+          python -m pip install --upgrade pip
+          pip install requests
+          python download-wgpu-native.py
+          pip uninstall -q -y requests
+          pip install -e .
+    - name: Test imports
+      env:
+        WGPU_FORCE_OFFSCREEN: true
+      run: |
+          python -c "print('wgpu'); import wgpu; print(wgpu)"
+          python -c "print('wgpu.backends.rs'); import wgpu.backends.rs"
+          python -c "print('wgpu.gui.offscreen'); import wgpu.gui.offscreen"
+          python -c "print('wgpu.utils'); import wgpu.utils"
+          python -c "print('wgpu.utils.shadertoy'); import wgpu.utils.shadertoy"
+
+  docs-build:
+    name: Test Docs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dev dependencies
@@ -51,71 +98,15 @@ jobs:
           cd docs
           make html SPHINXOPTS="-W --keep-going"
 
-  test-builds:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Test Linux py37
-            os: ubuntu-latest
-            pyversion: '3.7'
-          - name: Test Linux py38
-            os: ubuntu-latest
-            pyversion: '3.8'
-          - name: Test Linux py39
-            os: ubuntu-latest
-            pyversion: '3.9'
-            PYINSTALLER: 1
-          - name: Test Linux py310
-            os: ubuntu-latest
-            pyversion: '3.10'
-          # Pypy3 fails on installing a 3d party dependency
-          #- name: Test Linux pypy3
-          #  os: ubuntu-latest
-          #  pyversion: 'pypy3'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.pyversion }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.pyversion }}
-    - name: Install llvmpipe and lavapipe for offscreen canvas
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update -y -qq
-        sudo add-apt-repository ppa:oibaf/graphics-drivers -y
-        sudo apt-get update
-        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
-    - name: Install dev dependencies
-      run: |
-          python -m pip install --upgrade pip
-          pip install -U -r dev-requirements.txt
-          python download-wgpu-native.py
-          pip install -e .
-    - name: Test on repo
-      run: |
-          pytest -v tests
-    - name: Test codegen
-      run: |
-          pytest -v codegen
-    - name: Test PyInstaller
-      if: matrix.PYINSTALLER == 1
-      run: |
-          pip install psutil pyinstaller>=4.9
-          pyinstaller --version
-          pytest -v wgpu/__pyinstaller
-
   test-examples-build:
     name: Test Examples
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install llvmpipe and lavapipe for offscreen canvas
@@ -134,6 +125,78 @@ jobs:
       run: |
           pytest -v examples
 
+  test-pyinstaller-build:
+    name: Test PyInstaller
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+          python -m pip install --upgrade pip
+          pip install -U requests numpy pytest
+          python download-wgpu-native.py
+          pip install -e .
+          pip install psutil pyinstaller>=4.9
+    - name: Test PyInstaller
+      run: |
+          pyinstaller --version
+          pytest -v wgpu/__pyinstaller
+
+  test-builds:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Test Linux py37
+            os: ubuntu-latest
+            pyversion: '3.7'
+          - name: Test Linux py38
+            os: ubuntu-latest
+            pyversion: '3.8'
+          - name: Test Linux py39
+            os: ubuntu-latest
+            pyversion: '3.9'
+          - name: Test Linux py310
+            os: ubuntu-latest
+            pyversion: '3.10'
+          - name: Test Linux py311
+            os: ubuntu-latest
+            pyversion: '3.11'
+          # Pypy3 fails on installing a 3d party dependency
+          #- name: Test Linux pypy3
+          #  os: ubuntu-latest
+          #  pyversion: 'pypy3'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.pyversion }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.pyversion }}
+    - name: Install llvmpipe and lavapipe for offscreen canvas
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update -y -qq
+        sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+        sudo apt-get update
+        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+    - name: Install dev dependencies
+      run: |
+          python -m pip install --upgrade pip
+          pip install -U -r dev-requirements.txt
+          python download-wgpu-native.py
+          pip install -e .
+    - name: Test on repo
+      run: |
+          pytest -v tests
+
   # The release builds are done for the platforms that we want to build wheels for.
   # We build wheels, test them, and then upload the wheel as an artifact.
   release-builds:
@@ -144,36 +207,36 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - name: Install dev dependencies
-        run: |
-            python -m pip install --upgrade pip wheel setuptools twine
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.3
-        with:
-          output-dir: dist
-      - name: Twine check
-        run: |
-            twine check dist/*
-      - name: Upload distributions
-        uses: actions/upload-artifact@v2
-        with:
-          path: dist
-          name: dist
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install dev dependencies
+      run: |
+          python -m pip install --upgrade pip wheel setuptools twine
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.1.3
+      with:
+        output-dir: dist
+    - name: Twine check
+      run: |
+          twine check dist/*
+    - name: Upload distributions
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+        name: dist
 
   sdist-build:
-    name: Build sdist on ubuntu-latest
+    name: Build sdist
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install dev dependencies
@@ -203,14 +266,14 @@ jobs:
         name: dist
 
   publish:
-    name: Publish release to Github and Pypi
+    name: Publish to Github and Pypi
     runs-on: ubuntu-latest
     needs: [test-builds, release-builds, sdist-build]
     if: success() && startsWith(github.ref, 'refs/tags/v')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Download assets

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -11,9 +11,9 @@ jobs:
     name: Regenerate
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install llvmpipe and lavapipe for offscreen canvas

--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -1,11 +1,12 @@
-import argparse
 import os
 import re
-import requests
 import sys
+import argparse
 import tempfile
 import platform
 from zipfile import ZipFile
+
+import requests
 
 
 # The directory containing non-python resources that are included in packaging

--- a/examples/shadertoy_glsl_mouse_event.py
+++ b/examples/shadertoy_glsl_mouse_event.py
@@ -24,7 +24,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     vec2 p = fragCoord / iResolution.x;
     vec2 cen = 0.5*iResolution.xy/iResolution.x;
     vec4 m = iMouse / iResolution.x;
-   
+
    vec3 col = vec3(0.0);
 
    if( m.z>0.0 ) // button is down

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -80,7 +80,7 @@ def test_examples_screenshots(
     request.addfinalizer(unload_module)
 
     # render a frame
-    img = example.canvas.draw()
+    img = np.asarray(example.canvas.draw())
 
     # check if _something_ was rendered
     assert img is not None and img.size > 0

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import numpy as np
-
 from ._offscreen import WgpuOffscreenCanvas
 from .base import WgpuAutoGui
 
@@ -60,10 +58,16 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
             },
             size,
         )
-        return np.frombuffer(data, np.uint8).reshape(size[1], size[0], 4)
+
+        # Return as memory object to avoid numpy dependency
+        # Equivalent: np.frombuffer(data, np.uint8).reshape(size[1], size[0], 4)
+        return data.cast("B", (size[1], size[0], 4))
 
     def draw(self):
-        """Perform a draw and return the numpy array as a result."""
+        """Perform a draw and return the resulting array as an NxMx4 memoryview object.
+        This object can be converted to a numpy array (without copying data)
+        using ``np.asarray(arr)``.
+        """
         return self._draw_frame_and_present()
 
 

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -161,6 +161,7 @@ binding_layout = [
 
 class UniformArray:
     """Convenience class to create a uniform array.
+
     Maybe we can make it a public util at some point.
     """
 


### PR DESCRIPTION
In #345 I ran into the doc build env not having installed numpy, and therefore failing the build. Numpy is not a dependency. So let's fix that.

* [x] Remove numpy usage from `gui/offscreen.py`. Easy, because a memory object is easy enough to turn into a numpy array by the caller. 
* [x] Remove numpy usage from `utils/shadertoy.py`. Had to refactor the uniform array stuff a bit.
* [x] Added a CI testbuild to avoid regressions. It simply imports wgpu and some of its subpackages in a minimal env.
* [x] Refactoring the CI code a bit, moving the codegen and pyinstaller tests out of the matrix-test-build. This makes the yaml easier to read and the tests run faster.