### PR TITLE
Only get initial windid on qt for canvas widgets

### DIFF
--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -141,9 +141,6 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         self._request_draw_timer.setSingleShot(True)
         self._request_draw_timer.timeout.connect(self.update)
 
-        # Get the window id one time. For some reason this is needed
-        # to "activate" the canvas. Otherwise the viz is not shown if
-        # one does not provide canvas to request_adapter().
         self.get_window_id()
 
     def paintEngine(self):  # noqa: N802 - this is a Qt method
@@ -330,6 +327,12 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
 
         self._subwidget = QWgpuWidget(self, max_fps=max_fps)
         self._subwidget.add_event_handler(weakbind(self.handle_event), "*")
+
+        # Get the window id one time. For some reason this is needed
+        # to "activate" the canvas. Otherwise the viz is not shown if
+        # one does not provide canvas to request_adapter().
+        # (AK: Cannot reproduce this now, what qtlib/os/versions was this on?)
+        self._subwidget.get_window_id()
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -141,8 +141,6 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         self._request_draw_timer.setSingleShot(True)
         self._request_draw_timer.timeout.connect(self.update)
 
-        self.get_window_id()
-
     def paintEngine(self):  # noqa: N802 - this is a Qt method
         # https://doc.qt.io/qt-5/qt.html#WidgetAttribute-enum  WA_PaintOnScreen
         return None


### PR DESCRIPTION
So when a WgpuWidget is embedded in a GUI, the winid is only obtained when needed (on the first draw). It looks like obtaining it initially puts the widget in a certain state (makes it native), and this results in problems when the widget is first created without a parent and then placed in the GUI.

----

```py

import PySide6
from PySide6 import QtWidgets
from PySide6.QtWidgets import QGridLayout, QBoxLayout
import pygfx as gfx
from wgpu.gui.qt import WgpuWidget

def main(canvas):
    renderer = gfx.WgpuRenderer(canvas)
    camera = gfx.NDCCamera()
    scene = gfx.Scene()
    scene.add(
        gfx.Background(None, gfx.BackgroundMaterial((0.2, 0.0, 0, 1), (0, 0.0, 0.2, 1)))
    )
    triangle = gfx.Mesh(
        gfx.Geometry(
            indices=[(0, 1, 2)],
            positions=[(0.0, -0.5, 0), (0.5, 0.5, 0), (-0.5, 0.75, 0)],
            colors=[(1, 1, 0, 1), (1, 0, 1, 1), (0, 1, 1, 1)],
        ),
        gfx.MeshBasicMaterial(vertex_colors=True),
    )
    scene.add(triangle)
    # canvas.custom_renderer = renderer
    canvas.request_draw(lambda: renderer.render(scene, camera))

class ExampleWidget(QtWidgets.QMainWindow):
    def __init__(self):
        super().__init__()
        self.resize(640, 480)
        self.setWindowTitle("wgpu triangle embedded in a qt app")
        main_widget = QtWidgets.QWidget()
        qframe0 = QtWidgets.QFrame()
        qframe1 = QtWidgets.QFrame()
        qframe2 = QtWidgets.QFrame()
        qframe3 = QtWidgets.QFrame()
        render0 = WgpuWidget()
        render1 = WgpuWidget()
        render2 = WgpuWidget()
        render3 = WgpuWidget()
        main_widget.setLayout(QGridLayout())
        qframe0.setFrameStyle(PySide6.QtWidgets.QFrame.Shape.Panel)
        qframe0.setLayout(
            QBoxLayout(PySide6.QtWidgets.QBoxLayout.Direction.TopToBottom)
        )
        qframe1.setFrameStyle(PySide6.QtWidgets.QFrame.Shape.Panel)
        qframe1.setLayout(
            QBoxLayout(PySide6.QtWidgets.QBoxLayout.Direction.TopToBottom)
        )
        qframe2.setFrameStyle(PySide6.QtWidgets.QFrame.Shape.Panel)
        qframe2.setLayout(
            QBoxLayout(PySide6.QtWidgets.QBoxLayout.Direction.TopToBottom)
        )
        qframe3.setLayout(
            QBoxLayout(PySide6.QtWidgets.QBoxLayout.Direction.TopToBottom)
        )
        qframe0.setParent(main_widget)
        main_widget.layout().addWidget(qframe0, 0, 0)
        qframe1.setParent(main_widget)
        main_widget.layout().addWidget(qframe1, 1, 0)
        render0.setParent(qframe0)
        qframe0.layout().insertWidget(-1, render0)
        qframe2.setParent(main_widget)
        main_widget.layout().addWidget(qframe2, 1, 1)
        render1.setParent(qframe1)
        qframe1.layout().insertWidget(-1, render1)
        qframe3.setParent(main_widget)
        main_widget.layout().addWidget(qframe3, 0, 1)
        render2.setParent(qframe2)
        qframe2.layout().insertWidget(-1, render2)
        render3.setParent(qframe3)
        qframe3.layout().insertWidget(-1, render3)
        self.render0 = render0
        self.render1 = render1
        self.render2 = render2
        self.render3 = render3
        self.setCentralWidget(main_widget)
        self.show()

app = QtWidgets.QApplication([])
example = ExampleWidget()
main(example.render0)
main(example.render1)
main(example.render2)
main(example.render3)

# Enter Qt event loop (compatible with qt5/qt6)
app.exec() if hasattr(app, "exec") else app.exec_()
```