### PR TITLE
Refer to stable rtd links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,7 +255,7 @@ Added:
 * Official support for Windows 3.10.
 * The `max_fps` argument can be provided to a canvas.
 * The glfw gui backend supports user events in the same manner as the jupyter gui backend,
-  using the [jupyter_rfb event specification](https://jupyter-rfb.readthedocs.io/en/latest/events.html).
+  using the [jupyter_rfb event specification](https://jupyter-rfb.readthedocs.io/en/stable/events.html).
 * Introduce the `auto` gui backend, which selects either glfw or jupyter.
 
 Fixed:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/pygfx/wgpu-py/workflows/CI/badge.svg)](https://github.com/pygfx/wgpu-py/actions)
-[![Documentation Status](https://readthedocs.org/projects/wgpu-py/badge/?version=latest)](https://wgpu-py.readthedocs.io)
+[![Documentation Status](https://readthedocs.org/projects/wgpu-py/badge/?version=stable)](https://wgpu-py.readthedocs.io)
 [![PyPI version](https://badge.fury.io/py/wgpu.svg)](https://badge.fury.io/py/wgpu)
 
 # wgpu-py

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -40,7 +40,7 @@ either the GLFW, Qt, or Jupyter backend, depending on the environment.
 
 To implement interaction, the ``canvas`` has a :func:`WgpuAutoGui.handle_event()` method
 that can be overloaded. Alternatively you can use it's :func:`WgpuAutoGui.add_event_handler()`
-method. See the `event spec <https://jupyter-rfb.readthedocs.io/en/latest/events.html>`_
+method. See the `event spec <https://jupyter-rfb.readthedocs.io/en/stable/events.html>`_
 for details about the event objects.
 
 
@@ -158,7 +158,7 @@ Support for Jupyter lab and notebook
 
 WGPU can be used in Jupyter lab and the Jupyter notebook. This canvas
 is based on `jupyter_rfb <https://github.com/vispy/jupyter_rfb>`_, an ipywidget
-subclass implementing a remote frame-buffer. There are also some `wgpu examples <https://jupyter-rfb.readthedocs.io/en/latest/examples/>`_.
+subclass implementing a remote frame-buffer. There are also some `wgpu examples <https://jupyter-rfb.readthedocs.io/en/stable/examples/>`_.
 
 .. code-block:: py
 

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -27,7 +27,7 @@ GUI libraries
 Multiple GUI backends are supported, see :doc:`the GUI API <gui>` for details:
 
 * `glfw <https://github.com/FlorianRhiem/pyGLFW>`_: a lightweight GUI for the desktop
-* `jupyter_rfb <https://jupyter-rfb.readthedocs.io/en/latest/>`_: only needed if you plan on using wgpu in Jupyter
+* `jupyter_rfb <https://jupyter-rfb.readthedocs.io>`_: only needed if you plan on using wgpu in Jupyter
 * qt (PySide6, PyQt6, PySide2, PyQt5)
 * wx
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ runtime_deps = ["cffi>=1.15.0rc2", "rubicon-objc>=0.4.1; sys_platform == 'darwin
 extra_deps = {
     "jupyter": ["jupyter_rfb>=0.3.1"],
     "glfw": ["glfw>=1.9"],
-    "docs": ["sphinx"],
+    # sphinx<7 because https://github.com/readthedocs/readthedocs.org/issues/10279
+    "docs": ["sphinx<7", "sphinx_rtd_theme"],
 }
 
 setup(

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -287,7 +287,7 @@ class WgpuAutoGui:
         Subclasses can overload this method. Events include widget
         resize, mouse/touch interaction, key events, and more. An event
         is a dict with at least the key event_type. For details, see
-        https://jupyter-rfb.readthedocs.io/en/latest/events.html
+        https://jupyter-rfb.readthedocs.io/en/stable/events.html
 
         The default implementation dispatches the event to the
         registered event handlers.
@@ -309,7 +309,7 @@ class WgpuAutoGui:
             *types (list of strings): A list of event types.
 
         For the available events, see
-        https://jupyter-rfb.readthedocs.io/en/latest/events.html
+        https://jupyter-rfb.readthedocs.io/en/stable/events.html
 
         Can also be used as a decorator.
 


### PR DESCRIPTION
* Change RTD links to use the `stable` docs.
* Fix RTD.
* Also see https://github.com/vispy/jupyter_rfb/pull/72