### PR TITLE
Stop forcing Vulkan on Windows

### DIFF
--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -183,7 +183,9 @@ libf = SafeLibCalls(lib, error_handler)
 
 @_register_backend
 class GPU(base.GPU):
-    def request_adapter(self, *, canvas, power_preference=None):
+    def request_adapter(
+        self, *, canvas, power_preference=None, force_fallback_adapter=False
+    ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 
@@ -194,7 +196,9 @@ class GPU(base.GPU):
                 render to (to create a swap chain for, to be precise). Can be None
                 if you're not rendering to screen (or if you're confident that the
                 returned adapter will work just fine).
-            powerPreference(PowerPreference): "high-performance" or "low-power"
+            power_preference(PowerPreference): "high-performance" or "low-power".
+            force_fallback_adapter (bool): whether to use a (probably CPU-based)
+                fallback adapter.
         """
 
         # ----- Surface ID
@@ -232,7 +236,7 @@ class GPU(base.GPU):
             "WGPURequestAdapterOptions *",
             compatibleSurface=surface_id,
             powerPreference=power_preference or "high-performance",
-            forceFallbackAdapter=False,
+            forceFallbackAdapter=bool(force_fallback_adapter),
             backendType=backend,
             # not used: nextInChain
         )
@@ -334,12 +338,16 @@ class GPU(base.GPU):
 
         return GPUAdapter(adapter_id, features, limits, adapter_info)
 
-    async def request_adapter_async(self, *, canvas, power_preference=None):
+    async def request_adapter_async(
+        self, *, canvas, power_preference=None, force_fallback_adapter=False
+    ):
         """Async version of ``request_adapter()``.
         This function uses the Rust WGPU library.
         """
         return self.request_adapter(
-            canvas=canvas, power_preference=power_preference
+            canvas=canvas,
+            power_preference=power_preference,
+            force_fallback_adapter=force_fallback_adapter,
         )  # no-cover
 
     def _generate_report(self):

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -212,32 +212,10 @@ class GPU(base.GPU):
         # ----- Select backend
 
         # Try to read the WGPU_BACKEND_TYPE environment variable to see
-        # if a backend should be forced. When you run into trouble with
-        # the automatic selection of wgpu, you can use this variable
-        # to force a specific backend. For instance, on Windows you
-        # might want to force Vulkan, to avoid DX12 which seems to ignore
-        # the NVidia control panel settings.
-        # See https://github.com/gfx-rs/wgpu/issues/1416
-        # todo: for the moment we default to forcing Vulkan on Windows
-        # -> AK (19-10-2023): Tried using D3D12.
-        #    With a clean Windows install (no Nvidia drivers installed yet):
-        #       Vulkan crashes when it tries to display a window.
-        #       Did not test D3D12.
-        #    With Nvidia drivers uninstalled:
-        #       Vulkan reports "no available adapter".
-        #       D3d12 kinda works. It runs some/most examples, but fails the 3D
-        #       tests in test_rs_compute_tex.py, produces an error for the
-        #       Naga-generated DX shader code on the volume rendering example,
-        #       and buffer mapping (e.g. in pygfx picking) seems iffy too.
-        #    With NVidia drivers:
-        #       Both Vulkan and D3D12 work as expected, passing all tests
-        #       (unit and examples) in wgpu-py and pygfx.
+        # if a backend should be forced.
         force_backend = os.getenv("WGPU_BACKEND_TYPE", None)
         backend = enum_str2int["BackendType"]["Undefined"]
-        if force_backend is None:  # Allow OUR defaults
-            if sys.platform.startswith("win"):
-                backend = enum_str2int["BackendType"]["Vulkan"]
-        elif force_backend:
+        if force_backend:
             try:
                 backend = enum_str2int["BackendType"][force_backend]
             except KeyError:

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -219,12 +219,19 @@ class GPU(base.GPU):
         # the NVidia control panel settings.
         # See https://github.com/gfx-rs/wgpu/issues/1416
         # todo: for the moment we default to forcing Vulkan on Windows
-        # -> AK (19-10-2023): Tried using D3D12. An advantage is that it works
-        #    on a clean Windows install where Nvidia drivers have not been
-        #    upgraded yet. It runs some/most examples, but fails the 3D
-        #    tests in test_rs_compute_tex.py, produces an error for the
-        #    Naga-generated DX shader code on the volume rendering example,
-        #    and buffer mapping seems iffy too.
+        # -> AK (19-10-2023): Tried using D3D12.
+        #    With a clean Windows install (no Nvidia drivers installed yet):
+        #       Vulkan crashes when it tries to display a window.
+        #       Did not test D3D12.
+        #    With Nvidia drivers uninstalled:
+        #       Vulkan reports "no available adapter".
+        #       D3d12 kinda works. It runs some/most examples, but fails the 3D
+        #       tests in test_rs_compute_tex.py, produces an error for the
+        #       Naga-generated DX shader code on the volume rendering example,
+        #       and buffer mapping (e.g. in pygfx picking) seems iffy too.
+        #    With NVidia drivers:
+        #       Both Vulkan and D3D12 work as expected, passing all tests
+        #       (unit and examples) in wgpu-py and pygfx.
         force_backend = os.getenv("WGPU_BACKEND_TYPE", None)
         backend = enum_str2int["BackendType"]["Undefined"]
         if force_backend is None:  # Allow OUR defaults

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -16,7 +16,6 @@ Read the codegen/readme.md for more information.
 
 
 import os
-import sys
 import ctypes
 import logging
 import ctypes.util

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -219,6 +219,12 @@ class GPU(base.GPU):
         # the NVidia control panel settings.
         # See https://github.com/gfx-rs/wgpu/issues/1416
         # todo: for the moment we default to forcing Vulkan on Windows
+        # -> AK (19-10-2023): Tried using D3D12. An advantage is that it works
+        #    on a clean Windows install where Nvidia drivers have not been
+        #    upgraded yet. It runs some/most examples, but fails the 3D
+        #    tests in test_rs_compute_tex.py, produces an error for the
+        #    Naga-generated DX shader code on the volume rendering example,
+        #    and buffer mapping seems iffy too.
         force_backend = os.getenv("WGPU_BACKEND_TYPE", None)
         backend = enum_str2int["BackendType"]["Undefined"]
         if force_backend is None:  # Allow OUR defaults

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -73,7 +73,9 @@ class GPU:
 
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     @apidiff.change("arguments include a canvas object")
-    def request_adapter(self, *, canvas, power_preference=None):
+    def request_adapter(
+        self, *, canvas, power_preference=None, force_fallback_adapter=False
+    ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 
@@ -82,16 +84,19 @@ class GPU:
                 be able to render to (to create a swap chain for, to be precise).
                 Can be None if you're not rendering to screen (or if you're
                 confident that the returned adapter will work just fine).
-            powerPreference (PowerPreference): "high-performance" or "low-power"
+            power_preference (PowerPreference): "high-performance" or "low-power".
+            force_fallback_adapter (bool): whether to use a (probably CPU-based)
+                fallback adapter.
         """
-        # todo: include forceFallbackAdapter arg when this is also correctly applied in wgpu-native (currently its not)
         raise RuntimeError(
             "Select a backend (by importing wgpu.backends.rs) before requesting an adapter!"
         )
 
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     @apidiff.change("arguments include a canvas object")
-    async def request_adapter_async(self, *, canvas, power_preference=None):
+    async def request_adapter_async(
+        self, *, canvas, power_preference=None, force_fallback_adapter=False
+    ):
         """Async version of `request_adapter()`."""
         raise RuntimeError(
             "Select a backend (by importing wgpu.rs) before requesting an adapter!"


### PR DESCRIPTION
Until now we forced using the Vulkan adapter backend on Windows, because DX12 was less well support in the early days of wgpu-core.

* [x] Remove code that explicitly selects Vulkan for Windows.
* [x] Avoid raising exceptions in ffi callbacks.
* [x] Add ability to select fallback adapter in `wgpu.request_adapter()`.

## Motivation for selecting Vulkan

* Without drivers installed, Vulkan cannot be used.
* I found that without drivers installed, not forcing the Vukan adapter runs (using D3D12), but not without flaws. At least better than Vulkan.
* At wgpu-core D3D12 is listed as having first class support, but ...
* The D3D12 backend (also with drivers installed) still has flaws, but that's ok, because ...
* I found that *with* drivers installed, auto-selection picks Vulkan.
* Eventually wgpu can also use D3D11 on older Windows versions that don't support Vulkan or Dx12.
* The situation around honoring the Nvidia panel settings are the same for all backends.

In summary, I think its fine to let wgpu select the backend on Windows from hereon.

## Experiments on a clean Windows install

* With a clean Windows install (no Nvidia drivers installed yet):
       * Vulkan (forced) crashes when it tries to display a window.
       * Did not test D3D12 (missed that opportunity)
* With Nvidia drivers uninstalled:
       * Vulkan reports "no available adapter".
       * D3d12 kinda works. It runs some/most examples, but fails the 3D tests in test_rs_compute_tex.py, produces an error for the Naga-generated DX shader code on the volume rendering example, and buffer mapping (e.g. in pygfx picking) seems iffy too.
       * Tried D312 with both Integrated Graphics and GPU, seems the same errors come up, which is in (extra) indication that the problem is in the part where wgpu is converted to D3D12.
* With NVidia drivers:
    * When letting wgpu select a backend, it picks Vulkan.
    * Vulkan work as expected, passing all tests (unit and examples) in wgpu-py and pygfx.
    * Forcing D3D12 creates the same glitches as mentioned above.
    * Forcing D3D11 reports no available adapter.
    * Forcing the fallback adapter (software rendering, with D3D12) is not flawless, but seems to have less issues than D3D12 on hardware.

## Experiments on reacting to Nvidia control panel

* Both with Vulkan and D3D12 (and also with auto-select, i.e. Vulkan), the Nvidia control panel setting is ignored.
* It simply selects the Nvidia GPU or Integrated Graphics only based on the value of `power_reference` in `wgpu.request_adapter()`.
