### PR TITLE
Add timestamp to events, and buttons to wheel events

### DIFF
--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -152,8 +152,8 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
         glfw.set_window_iconify_callback(self._window, weakbind(self._on_iconify))
 
         # User input
-        self._key_modifiers = set()
-        self._pointer_buttons = set()
+        self._key_modifiers = []
+        self._pointer_buttons = []
         self._pointer_pos = 0, 0
         self._double_click_state = {"clicks": 0}
         glfw.set_mouse_button_callback(self._window, weakbind(self._on_mouse_button))
@@ -323,10 +323,14 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
 
         if action == glfw.PRESS:
             event_type = "pointer_down"
-            self._pointer_buttons.add(button)
+            buttons = set(self._pointer_buttons)
+            buttons.add(button)
+            self._pointer_buttons = list(sorted(buttons))
         elif action == glfw.RELEASE:
             event_type = "pointer_up"
-            self._pointer_buttons.discard(button)
+            buttons = set(self._pointer_buttons)
+            buttons.discard(button)
+            self._pointer_buttons = list(sorted(buttons))
         else:
             return
 
@@ -426,6 +430,7 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
             "dy": -100.0 * dy,
             "x": self._pointer_pos[0],
             "y": self._pointer_pos[1],
+            "buttons": list(self._pointer_buttons),
             "modifiers": list(self._key_modifiers),
         }
         match_keys = {"modifiers"}
@@ -438,11 +443,15 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
         if action == glfw.PRESS:
             event_type = "key_down"
             if modifier:
-                self._key_modifiers.add(modifier)
+                modifiers = set(self._key_modifiers)
+                modifiers.add(modifier)
+                self._key_modifiers = list(sorted(modifiers))
         elif action == glfw.RELEASE:
             event_type = "key_up"
             if modifier:
-                self._key_modifiers.discard(modifier)
+                modifiers = set(self._key_modifiers)
+                modifiers.discard(modifier)
+                self._key_modifiers = list(sorted(modifiers))
         else:  # glfw.REPEAT
             return
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -285,6 +285,11 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
             for mod in MODIFIERS_MAP.keys()
             if mod & event.modifiers()
         ]
+        buttons = [
+            BUTTON_MAP[button]
+            for button in BUTTON_MAP.keys()
+            if button & event.buttons()
+        ]
 
         ev = {
             "event_type": "wheel",
@@ -292,6 +297,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
             "dy": -event.angleDelta().y(),
             "x": event.position().x(),
             "y": event.position().y(),
+            "buttons": buttons,
             "modifiers": modifiers,
         }
         match_keys = {"modifiers"}

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -253,8 +253,8 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         if touches:
             ev.update(
                 {
-                    "ntouches": 0,  # TODO
-                    "touches": {},  # TODO
+                    "ntouches": 0,
+                    "touches": {},  # TODO: Qt touch events
                 }
             )
 


### PR DESCRIPTION
See https://github.com/vispy/jupyter_rfb/pull/78 for the change that makes it work for jupyter_rfb (and the update to the event spec).