### PR TITLE
Add tests for object releasing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,12 @@ jobs:
           pip install -U -r dev-requirements.txt
           python download-wgpu-native.py
           pip install -e .
-    - name: Test on repo
+    - name: Unit tests
       run: |
           pytest -v tests
+    - name: Memory tests
+      run: |
+          pytest -v tests_mem
 
   # The release builds are done for the platforms that we want to build wheels for.
   # We build wheels, test them, and then upload the wheel as an artifact.

--- a/tests_mem/test_mem.py
+++ b/tests_mem/test_mem.py
@@ -207,9 +207,6 @@ def test_release_canvas_context_1(n):
 
     from wgpu.gui.offscreen import WgpuCanvas
 
-    if hasattr(wgpu.gui.offscreen, "asyncio"):
-        pytest.skip("#404 is not yet merged")  # todo: remove this
-
     yield {
         "expected_counts_after_create": {
             "CanvasContext": (n, 0),

--- a/tests_mem/test_mem.py
+++ b/tests_mem/test_mem.py
@@ -5,7 +5,7 @@ import wgpu.backends.rs
 
 import pytest
 from testutils import can_use_glfw, can_use_wgpu_lib, can_use_pyside6
-
+from testutils import create_and_release, get_counts, ob_name_from_test_func
 
 if not can_use_wgpu_lib:
     pytest.skip(
@@ -17,61 +17,8 @@ if not can_use_wgpu_lib:
 DEVICE = wgpu.utils.get_default_device()
 
 
-# %% The logic
-
-
-def get_counts():
-    """Get a dict that maps object names to a 2-tuple represening
-    the counts in py and wgpu-native.
-    """
-    counts_py = wgpu.diagnostics.object_counts.get_dict()
-    counts_native = wgpu.diagnostics.rs_counts.get_dict()
-
-    all_keys = set(counts_py) | set(counts_native)
-
-    default = {"count": -1}
-
-    counts = {}
-    for key in sorted(all_keys):
-        counts[key] = (
-            counts_py.get(key, default)["count"],
-            counts_native.get(key, default)["count"],
-        )
-    counts.pop("total")
-
-    return counts
-
-
-def get_excess_counts(counts1, counts2):
-    """Compare two counts dicts, and return a new dict with the fields
-    that have increased counts.
-    """
-    more = {}
-    for name in counts1:
-        c1 = counts1[name][0]
-        c2 = counts2[name][0]
-        more_py = 0
-        if c2 > c1:
-            more_py = c2 - c1
-        c1 = counts1[name][1]
-        c2 = counts2[name][1]
-        more_native = 0
-        if c2 > c1:
-            more_native = c2 - c1
-        if more_py or more_native:
-            more[name] = more_py, more_native
-    return more
-
-
-def ob_name_from_test_func(func):
-    """Translate test_release_bind_group() to "BindGroup"."""
-    func_name = func.__name__
-    prefix = "test_release_"
-    assert func_name.startswith(prefix)
-    words = func_name[len(prefix) :].split("_")
-    if words[-1].isnumeric():
-        words.pop(-1)
-    return "".join(word.capitalize() for word in words)
+async def stub_event_loop():
+    pass
 
 
 def make_draw_func_for_canvas(canvas):
@@ -101,80 +48,6 @@ def make_draw_func_for_canvas(canvas):
         ctx.present()
 
     return draw
-
-
-def create_and_release(create_objects_func):
-    """Decorator."""
-
-    def core_test_func():
-        """The core function that does the testing."""
-
-        n = 32
-
-        generator = create_objects_func(n)
-        ob_name = ob_name_from_test_func(create_objects_func)
-
-        # ----- Collect options
-
-        options = {
-            "expected_counts_after_create": {ob_name: (32, 32)},
-            "expected_counts_after_release": {},
-        }
-
-        func_options = next(generator)
-        assert isinstance(func_options, dict), "First yield must be an options dict"
-        options.update(func_options)
-
-        # Measure baseline object counts
-        counts1 = get_counts()
-
-        # ----- Create
-
-        # Create objects
-        objects = list(generator)
-
-        # Test the count
-        assert len(objects) == n
-
-        # Test that all objects are of the same class.
-        # (this for-loop is a bit weird, but its to avoid leaking refs to objects)
-        cls = objects[0].__class__
-        assert all(isinstance(objects[i], cls) for i in range(len(objects)))
-
-        # Test that class matches function name (should prevent a group of copy-paste errors)
-        assert ob_name == cls.__name__[3:]
-
-        # Measure peak object counts
-        counts2 = get_counts()
-        more2 = get_excess_counts(counts1, counts2)
-        print("  more after create:", more2)
-
-        # Make sure the actual object has increased
-        assert more2  # not empty
-        assert more2 == options["expected_counts_after_create"]
-
-        # It's ok if other objects are created too ...
-
-        # ----- Release
-
-        # Delete objects
-        del objects
-        gc.collect()
-
-        # Measure after-release object counts
-        counts3 = get_counts()
-        more3 = get_excess_counts(counts1, counts3)
-        print("  more after release:", more3)
-
-        # Check!
-        assert more3 == options["expected_counts_after_release"]
-
-    core_test_func.__name__ = create_objects_func.__name__
-    return core_test_func
-
-
-async def stub_event_loop():
-    pass
 
 
 # %% Meta tests

--- a/tests_mem/test_mem.py
+++ b/tests_mem/test_mem.py
@@ -1,0 +1,329 @@
+import gc
+
+import wgpu.backends.rs
+import pytest
+
+
+# Create the default device beforehand
+wgpu.utils.get_default_device()
+
+
+# %% The logic
+
+
+def get_counts():
+    counts_py = wgpu.diagnostics.object_counts.get_dict()
+    counts_native = wgpu.diagnostics.rs_counts.get_dict()
+
+    all_keys = set(counts_py) | set(counts_native)
+
+    default = {"count": -1}
+
+    counts = {}
+    for key in sorted(all_keys):
+        counts[key] = (
+            counts_py.get(key, default)["count"],
+            counts_native.get(key, default)["count"],
+        )
+    counts.pop("total")
+
+    return counts
+
+
+def compare_counts(counts1, counts2):
+    more_py = {}
+    more_native = {}
+    for name in counts1:
+        c1 = counts1[name][0]
+        c2 = counts2[name][0]
+        if c2 > c1:
+            more_py[name] = c2 - c1
+        c1 = counts1[name][1]
+        c2 = counts2[name][1]
+        if c2 > c1:
+            more_native[name] = c2 - c1
+    return more_py, more_native
+
+
+def obname_from_test_func_name(func):
+    obname = func.__name__
+    prefix = "test_release_"
+    assert obname.startswith(prefix)
+    return obname[len(prefix) :].replace("_", "").lower()
+
+
+def create_and_release(create_objects_func):
+    def _create_and_release():
+        n = 32
+
+        # Before ...
+        counts1 = get_counts()
+
+        # Create objects
+        objects = list(create_objects_func(n))
+
+        # Test the count and that all are of the same class
+        assert len(objects) == n
+        assert all(
+            isinstance(objects[i], objects[0].__class__) for i in range(len(objects))
+        )
+        class_name = objects[0].__class__.__name__[3:].lower()
+
+        # Test that cass matches function name (should prevent a group of copy-paste errors)
+        obname = obname_from_test_func_name(create_objects_func)
+        assert obname == class_name
+
+        counts2 = get_counts()
+        more_py, more_native = compare_counts(counts1, counts2)
+
+        print("  more_py", more_py)
+        print("  more_native", more_native)
+
+        # Make sure we do indeed have n more
+        max_excess_py, max_excess_native = max(more_py.values()), max(
+            more_native.values()
+        )
+        assert max_excess_py == n
+        assert max_excess_native == n
+
+        # Delete objects
+        print("  release")
+        del objects
+        gc.collect()
+
+        counts3 = get_counts()
+        more_py, more_native = compare_counts(counts1, counts3)
+        max_excess_py, max_excess_native = max(more_py.values(), default=0), max(
+            more_native.values(), default=0
+        )
+
+        print("  more_py", more_py)
+        print("  more_native", more_native)
+
+        assert max_excess_py == 0
+        assert max_excess_native <= 1
+        # assert not more_py
+        # assert not more_native
+
+    _create_and_release.__name__ = create_objects_func.__name__
+    return _create_and_release
+
+
+# %% Meta tests
+
+
+# todo: enable this when done
+def xfail_test_all_objects_covered():
+    """Test that we have a test_release test function for each known object."""
+
+    ref_obnames = set(key.lower() for key in get_counts().keys())
+    func_obnames = set(obname_from_test_func_name(func) for func in RELEASE_TEST_FUNCS)
+
+    missing = ref_obnames - func_obnames
+    extra = func_obnames - ref_obnames
+    assert not missing
+    assert not extra
+
+
+def test_all_functions_solid():
+    """Test that all funcs starting with test_release are decorated appropriately."""
+    for func in RELEASE_TEST_FUNCS:
+        is_decorated = func.__code__.co_name == "_create_and_release"
+        assert is_decorated, func.__name__ + " not decorated"
+
+
+def test_buffers_meta1():
+    """Making sure that the test indeed fails, when holding onto the objects."""
+
+    lock = []
+
+    @create_and_release
+    def test_buffer(n):
+        device = wgpu.utils.get_default_device()
+        for i in range(n):
+            b = device.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
+            lock.append(b)
+            yield b
+
+    with pytest.raises(AssertionError):
+        test_buffer()
+
+
+def test_buffers_meta2():
+    """Making sure that the test indeed fails, by disabling the release call."""
+
+    ori = wgpu.backends.rs.GPUBuffer._destroy
+    wgpu.backends.rs.GPUBuffer._destroy = lambda self: None
+
+    try:
+        with pytest.raises(AssertionError):
+            test_release_buffer()
+
+    finally:
+        wgpu.backends.rs.GPUBuffer._destroy = ori
+
+
+# %% The actual tests
+
+
+@create_and_release
+def test_release_adapter(n):
+    for i in range(n):
+        yield wgpu.request_adapter(canvas=None, power_preference="high-performance")
+
+
+@create_and_release
+def xfail_test_release_device(n):
+    # Device object seem not to be cleaned up at wgpu-native. Wazzup with that?
+
+    adapter = wgpu.utils.get_default_device().adapter
+    for i in range(n):
+        yield adapter.request_device()
+
+
+@create_and_release
+def test_release_bind_group(n):
+    device = wgpu.utils.get_default_device()
+
+    buffer1 = device.create_buffer(size=128, usage=wgpu.BufferUsage.STORAGE)
+
+    binding_layouts = [
+        {
+            "binding": 0,
+            "visibility": wgpu.ShaderStage.COMPUTE,
+            "buffer": {
+                "type": wgpu.BufferBindingType.read_only_storage,
+            },
+        },
+    ]
+
+    bindings = [
+        {
+            "binding": 0,
+            "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
+        },
+    ]
+
+    bind_group_layout = device.create_bind_group_layout(entries=binding_layouts)
+
+    for i in range(n):
+        yield device.create_bind_group(layout=bind_group_layout, entries=bindings)
+
+
+@create_and_release
+def xfail_test_release_bind_group_layout(n):
+    # When we use the same binding layout descriptor, wgpu-native
+    # re-uses the BindGroupLayout object. On the other hand, it also
+    # does not seem to clean them up. Perhaps it just caches them? There
+    # are only so many possible combinations, and its just 152 bytes
+    # (on Metal) per object.
+    #
+    # * We should somehow allow this case in the test.
+    # * Should we do something similar with *our* BindGroupLayout object?
+
+    device = wgpu.utils.get_default_device()
+
+    binding_layouts = [
+        {
+            "binding": 0,
+            "visibility": wgpu.ShaderStage.COMPUTE,
+            "buffer": {
+                "type": wgpu.BufferBindingType.read_only_storage,
+            },
+        },
+    ]
+
+    for i in range(n):
+        binding_layouts[0]["binding"] = i
+        yield device.create_bind_group_layout(entries=binding_layouts)
+
+
+@create_and_release
+def test_release_buffer(n):
+    device = wgpu.utils.get_default_device()
+    for i in range(n):
+        yield device.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
+
+
+def test_CanvasContext(n):
+    pass
+
+
+def test_CommandBuffer(n):
+    pass
+
+
+def test_CommandEncoder(n):
+    pass
+
+
+def test_ComputePassEncoder(n):
+    pass
+
+
+def test_ComputePipeline(n):
+    pass
+
+
+def test_PipelineLayout(n):
+    pass
+
+
+def test_QuerySet(n):
+    pass
+
+
+def test_Queue(n):
+    pass
+
+
+def test_RenderBundle(n):
+    pass
+
+
+def test_RenderBundleEncoder(n):
+    pass
+
+
+def test_RenderPassEncoder(n):
+    pass
+
+
+def test_RenderPipeline(n):
+    pass
+
+
+def test_Sampler(n):
+    pass
+
+
+def test_ShaderModule(n):
+    pass
+
+
+def test_Texture(n):
+    pass
+
+
+def test_TextureView(n):
+    pass
+
+
+# %% The end
+
+
+ALL_TEST_FUNCS = [
+    ob
+    for name, ob in list(globals().items())
+    if name.startswith("test_") and callable(ob)
+]
+RELEASE_TEST_FUNCS = [
+    func for func in ALL_TEST_FUNCS if func.__name__.startswith("test_release_")
+]
+
+
+if __name__ == "__main__":
+    for func in ALL_TEST_FUNCS:
+        print(func.__name__ + " ...")
+        func()
+    print("done")

--- a/tests_mem/test_mem.py
+++ b/tests_mem/test_mem.py
@@ -120,6 +120,9 @@ def test_release_device(n):
     pytest.skip("XFAIL")
     # todo: XFAIL: Device object seem not to be cleaned up at wgpu-native.
 
+    # Note: the WebGPU spec says:
+    # [request_device()] is a one-time action: if a device is returned successfully, the adapter becomes invalid.
+
     yield {
         "expected_counts_after_create": {"Device": (n, n), "Queue": (n, 0)},
     }

--- a/tests_mem/test_mem.py
+++ b/tests_mem/test_mem.py
@@ -1,17 +1,29 @@
 import gc
 
 import wgpu.backends.rs
+import wgpu.gui.offscreen
+
 import pytest
+from testutils import can_use_glfw, can_use_wgpu_lib
+
+
+if not can_use_wgpu_lib:
+    pytest.skip(
+        "Skipping tests that need a window or the wgpu lib", allow_module_level=True
+    )
 
 
 # Create the default device beforehand
-wgpu.utils.get_default_device()
+DEVICE = wgpu.utils.get_default_device()
 
 
 # %% The logic
 
 
 def get_counts():
+    """Get a dict that maps object names to a 2-tuple represening
+    the counts in py and wgpu-native.
+    """
     counts_py = wgpu.diagnostics.object_counts.get_dict()
     counts_native = wgpu.diagnostics.rs_counts.get_dict()
 
@@ -30,94 +42,129 @@ def get_counts():
     return counts
 
 
-def compare_counts(counts1, counts2):
-    more_py = {}
-    more_native = {}
+def get_excess_counts(counts1, counts2):
+    """Compare two counts dicts, and return a new dict with the fields
+    that have increased counts.
+    """
+    more = {}
     for name in counts1:
         c1 = counts1[name][0]
         c2 = counts2[name][0]
+        more_py = 0
         if c2 > c1:
-            more_py[name] = c2 - c1
+            more_py = c2 - c1
         c1 = counts1[name][1]
         c2 = counts2[name][1]
+        more_native = 0
         if c2 > c1:
-            more_native[name] = c2 - c1
-    return more_py, more_native
+            more_native = c2 - c1
+        if more_py or more_native:
+            more[name] = more_py, more_native
+    return more
 
 
-def obname_from_test_func_name(func):
-    obname = func.__name__
+def ob_name_from_test_func(func):
+    """Translate test_release_bind_group() to "BindGroup"."""
+    func_name = func.__name__
     prefix = "test_release_"
-    assert obname.startswith(prefix)
-    return obname[len(prefix) :].replace("_", "").lower()
+    assert func_name.startswith(prefix)
+    words = func_name[len(prefix) :].split("_")
+    if words[-1].isnumeric():
+        words.pop(-1)
+    return "".join(word.capitalize() for word in words)
 
 
 def create_and_release(create_objects_func):
-    def _create_and_release():
+    """Decorator."""
+
+    def core_test_func():
+        """The core function that does the testing."""
+
         n = 32
 
-        # Before ...
+        generator = create_objects_func(n)
+
+        # ----- Collect options
+
+        options = {
+            "expected_native_high_count": n,
+            "allowed_native_low_count": 0,
+        }
+
+        func_options = next(generator)
+        assert isinstance(func_options, dict), "First yield must be an options dict"
+        options.update(func_options)
+
+        # Measure baseline object counts
         counts1 = get_counts()
 
+        # ----- Create
+
         # Create objects
-        objects = list(create_objects_func(n))
+        objects = list(generator)
 
-        # Test the count and that all are of the same class
+        # Test the count
         assert len(objects) == n
-        assert all(
-            isinstance(objects[i], objects[0].__class__) for i in range(len(objects))
-        )
-        class_name = objects[0].__class__.__name__[3:].lower()
 
-        # Test that cass matches function name (should prevent a group of copy-paste errors)
-        obname = obname_from_test_func_name(create_objects_func)
-        assert obname == class_name
+        # Test that all objects are of the same class.
+        # (this for-loop is a bit weird, but its to avoid leaking refs to objects)
+        cls = objects[0].__class__
+        assert all(isinstance(objects[i], cls) for i in range(len(objects)))
 
+        # Test that class matches function name (should prevent a group of copy-paste errors)
+        ob_name = ob_name_from_test_func(create_objects_func)
+        assert ob_name == cls.__name__[3:]
+
+        # Measure peak object counts
         counts2 = get_counts()
-        more_py, more_native = compare_counts(counts1, counts2)
+        more2 = get_excess_counts(counts1, counts2)
+        print("  more after create:", more2)
 
-        print("  more_py", more_py)
-        print("  more_native", more_native)
+        # Make sure the actual object has increased
+        expected_high_count = n, options["expected_native_high_count"]
+        assert ob_name in more2
+        assert more2[ob_name] == expected_high_count
 
-        # Make sure we do indeed have n more
-        max_excess_py, max_excess_native = max(more_py.values()), max(
-            more_native.values()
-        )
-        assert max_excess_py == n
-        assert max_excess_native == n
+        # It's ok if other objects are created too ...
+
+        # ----- Release
 
         # Delete objects
-        print("  release")
         del objects
         gc.collect()
 
+        # Measure after-release object counts
         counts3 = get_counts()
-        more_py, more_native = compare_counts(counts1, counts3)
-        max_excess_py, max_excess_native = max(more_py.values(), default=0), max(
-            more_native.values(), default=0
-        )
+        more3 = get_excess_counts(counts1, counts3)
+        print("  more after release:", more3)
 
-        print("  more_py", more_py)
-        print("  more_native", more_native)
+        # If no excess objects, all is well!
+        if not more3:
+            return
 
-        assert max_excess_py == 0
-        assert max_excess_native <= 1
-        # assert not more_py
-        # assert not more_native
+        # Otherwise, look deeper
+        expected_low_count = 0, options["allowed_native_low_count"]
+        more3.setdefault(ob_name, (0, 0))
+        assert more3[ob_name] == expected_low_count
 
-    _create_and_release.__name__ = create_objects_func.__name__
-    return _create_and_release
+        # Nothing left other than that?
+        more4 = more3.copy()
+        more4.pop(ob_name)
+        assert not more4
+
+    core_test_func.__name__ = create_objects_func.__name__
+    return core_test_func
 
 
 # %% Meta tests
 
 
 # todo: enable this when done
-def xfail_test_all_objects_covered():
+def xfail_test_meta_all_objects_covered():
     """Test that we have a test_release test function for each known object."""
 
     ref_obnames = set(key.lower() for key in get_counts().keys())
-    func_obnames = set(obname_from_test_func_name(func) for func in RELEASE_TEST_FUNCS)
+    func_obnames = set(ob_name_from_test_func(func) for func in RELEASE_TEST_FUNCS)
 
     missing = ref_obnames - func_obnames
     extra = func_obnames - ref_obnames
@@ -125,31 +172,31 @@ def xfail_test_all_objects_covered():
     assert not extra
 
 
-def test_all_functions_solid():
-    """Test that all funcs starting with test_release are decorated appropriately."""
+def test_meta_all_functions_solid():
+    """Test that all funcs starting with "test_release_" are decorated appropriately."""
     for func in RELEASE_TEST_FUNCS:
-        is_decorated = func.__code__.co_name == "_create_and_release"
+        is_decorated = func.__code__.co_name == "core_test_func"
         assert is_decorated, func.__name__ + " not decorated"
 
 
-def test_buffers_meta1():
+def test_meta_buffers_1():
     """Making sure that the test indeed fails, when holding onto the objects."""
 
     lock = []
 
     @create_and_release
-    def test_buffer(n):
-        device = wgpu.utils.get_default_device()
+    def test_release_buffer(n):
+        yield {}
         for i in range(n):
-            b = device.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
+            b = DEVICE.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
             lock.append(b)
             yield b
 
     with pytest.raises(AssertionError):
-        test_buffer()
+        test_release_buffer()
 
 
-def test_buffers_meta2():
+def test_meta_buffers_2():
     """Making sure that the test indeed fails, by disabling the release call."""
 
     ori = wgpu.backends.rs.GPUBuffer._destroy
@@ -165,27 +212,31 @@ def test_buffers_meta2():
 
 # %% The actual tests
 
+# These tests need to do one thing: generate n objects of the correct type.
+
 
 @create_and_release
 def test_release_adapter(n):
+    yield {}
     for i in range(n):
         yield wgpu.request_adapter(canvas=None, power_preference="high-performance")
 
 
 @create_and_release
 def xfail_test_release_device(n):
-    # Device object seem not to be cleaned up at wgpu-native. Wazzup with that?
+    # XFAIL: Device object seem not to be cleaned up at wgpu-native
 
-    adapter = wgpu.utils.get_default_device().adapter
+    yield {}
+    adapter = DEVICE.adapter
     for i in range(n):
         yield adapter.request_device()
 
 
 @create_and_release
 def test_release_bind_group(n):
-    device = wgpu.utils.get_default_device()
+    yield {}
 
-    buffer1 = device.create_buffer(size=128, usage=wgpu.BufferUsage.STORAGE)
+    buffer1 = DEVICE.create_buffer(size=128, usage=wgpu.BufferUsage.STORAGE)
 
     binding_layouts = [
         {
@@ -204,24 +255,23 @@ def test_release_bind_group(n):
         },
     ]
 
-    bind_group_layout = device.create_bind_group_layout(entries=binding_layouts)
+    bind_group_layout = DEVICE.create_bind_group_layout(entries=binding_layouts)
 
     for i in range(n):
-        yield device.create_bind_group(layout=bind_group_layout, entries=bindings)
+        yield DEVICE.create_bind_group(layout=bind_group_layout, entries=bindings)
 
 
 @create_and_release
-def xfail_test_release_bind_group_layout(n):
-    # When we use the same binding layout descriptor, wgpu-native
+def test_release_bind_group_layout(n):
+    # Note: when we use the same binding layout descriptor, wgpu-native
     # re-uses the BindGroupLayout object. On the other hand, it also
     # does not seem to clean them up. Perhaps it just caches them? There
     # are only so many possible combinations, and its just 152 bytes
     # (on Metal) per object.
-    #
-    # * We should somehow allow this case in the test.
-    # * Should we do something similar with *our* BindGroupLayout object?
 
-    device = wgpu.utils.get_default_device()
+    # todo: do we want similar behavior for *our* BindGroupLayout object?
+
+    yield {"expected_native_high_count": 1, "allowed_native_low_count": 1}
 
     binding_layouts = [
         {
@@ -234,79 +284,141 @@ def xfail_test_release_bind_group_layout(n):
     ]
 
     for i in range(n):
-        binding_layouts[0]["binding"] = i
-        yield device.create_bind_group_layout(entries=binding_layouts)
+        # binding_layouts[0]["binding"] = i  # force unique objects
+        yield DEVICE.create_bind_group_layout(entries=binding_layouts)
 
 
 @create_and_release
 def test_release_buffer(n):
-    device = wgpu.utils.get_default_device()
+    yield {}
     for i in range(n):
-        yield device.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
+        yield DEVICE.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
 
 
-def test_CanvasContext(n):
-    pass
+@create_and_release
+def test_release_canvas_context_1(n):
+    # Test with offscreen canvases. A context is created, but not a wgpu-native surface.
+
+    yield {"expected_native_high_count": 0}
+
+    for i in range(n):
+        c = wgpu.gui.offscreen.WgpuCanvas()
+        ctx = c.get_context()
+        ctx.configure(device=DEVICE, format="bgra8unorm-srgb")
+        ctx.get_current_texture()  # forces creating a surface
+        yield ctx
 
 
-def test_CommandBuffer(n):
-    pass
+@create_and_release
+def xfail_test_release_canvas_context_2(n):
+    # Test with GLFW canvases.
+
+    # XFAIL: The CanvasContext objects (both the Py side and the native surface) are not properly released,
+    # but they are when I check right afterwards, maybe it needs an event loop iter or glfw poll?
+
+    # todo: revisit this with the new upcoming APIs?
+
+    if not can_use_glfw:
+        pytest.skip("Need glfw for this test")
+
+    from wgpu.gui.glfw import WgpuCanvas, glfw  # noqa
+
+    yield {}
+
+    for i in range(n):
+        c = WgpuCanvas()
+        ctx = c.get_context()
+        ctx.configure(device=DEVICE, format="bgra8unorm-srgb")
+        ctx.get_current_texture()  # forces creating a surface
+        yield ctx
 
 
-def test_CommandEncoder(n):
-    pass
+# @create_and_release
+# def test_release_command_buffer(n):
+#     pass
 
 
-def test_ComputePassEncoder(n):
-    pass
+# @create_and_release
+# def test_release_command_encoder(n):
+#     pass
 
 
-def test_ComputePipeline(n):
-    pass
+# @create_and_release
+# def test_release_compute_pass_encoder(n):
+#     pass
 
 
-def test_PipelineLayout(n):
-    pass
+# @create_and_release
+# def test_release_compute_pipeline(n):
+#     pass
 
 
-def test_QuerySet(n):
-    pass
+# @create_and_release
+# def test_release_pipeline_layout(n):
+#     pass
 
 
-def test_Queue(n):
-    pass
+# @create_and_release
+# def test_release_query_set(n):
+#     pass
 
 
-def test_RenderBundle(n):
-    pass
+# @create_and_release
+# def test_release_queue(n):
+#     pass
 
 
-def test_RenderBundleEncoder(n):
-    pass
+# @create_and_release
+# def test_release_render_bundle(n):
+#     pass
 
 
-def test_RenderPassEncoder(n):
-    pass
+# @create_and_release
+# def test_release_render_bundle_encoder(n):
+#     pass
 
 
-def test_RenderPipeline(n):
-    pass
+# @create_and_release
+# def test_release_render_pass_encoder(n):
+#     pass
 
 
-def test_Sampler(n):
-    pass
+# @create_and_release
+# def test_release_render_pipeline(n):
+#     pass
 
 
-def test_ShaderModule(n):
-    pass
+@create_and_release
+def test_release_sampler(n):
+    yield {}
+    for i in range(n):
+        yield DEVICE.create_sampler()
 
 
-def test_Texture(n):
-    pass
+# @create_and_release
+# def test_release_shader_module(n):
+#     pass
 
 
-def test_TextureView(n):
-    pass
+@create_and_release
+def test_release_texture(n):
+    yield {}
+    for i in range(n):
+        yield DEVICE.create_texture(
+            size=(16, 16, 16),
+            usage=wgpu.TextureUsage.TEXTURE_BINDING,
+            format="rgba8unorm",
+        )
+
+
+@create_and_release
+def test_release_texture_view(n):
+    yield {}
+    texture = DEVICE.create_texture(
+        size=(16, 16, 16), usage=wgpu.TextureUsage.TEXTURE_BINDING, format="rgba8unorm"
+    )
+    for i in range(n):
+        yield texture.create_view()
 
 
 # %% The end

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -34,6 +34,17 @@ def _determine_can_use_glfw():
         return True
 
 
+def _determine_can_use_pyside6():
+    code = "import PySide6.QtGui"
+    try:
+        subprocess.check_output([sys.executable, "-c", code])
+    except Exception:
+        return False
+    else:
+        return True
+
+
 can_use_wgpu_lib = _determine_can_use_wgpu_lib()
 can_use_glfw = _determine_can_use_glfw()
+can_use_pyside6 = _determine_can_use_pyside6()
 is_ci = bool(os.getenv("CI", None))

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -1,6 +1,9 @@
+import gc
 import os
 import sys
 import subprocess
+
+import wgpu
 
 
 def _determine_can_use_wgpu_lib():
@@ -48,3 +51,127 @@ can_use_wgpu_lib = _determine_can_use_wgpu_lib()
 can_use_glfw = _determine_can_use_glfw()
 can_use_pyside6 = _determine_can_use_pyside6()
 is_ci = bool(os.getenv("CI", None))
+
+
+def get_counts():
+    """Get a dict that maps object names to a 2-tuple represening
+    the counts in py and wgpu-native.
+    """
+    counts_py = wgpu.diagnostics.object_counts.get_dict()
+    counts_native = wgpu.diagnostics.rs_counts.get_dict()
+
+    all_keys = set(counts_py) | set(counts_native)
+
+    default = {"count": -1}
+
+    counts = {}
+    for key in sorted(all_keys):
+        counts[key] = (
+            counts_py.get(key, default)["count"],
+            counts_native.get(key, default)["count"],
+        )
+    counts.pop("total")
+
+    return counts
+
+
+def get_excess_counts(counts1, counts2):
+    """Compare two counts dicts, and return a new dict with the fields
+    that have increased counts.
+    """
+    more = {}
+    for name in counts1:
+        c1 = counts1[name][0]
+        c2 = counts2[name][0]
+        more_py = 0
+        if c2 > c1:
+            more_py = c2 - c1
+        c1 = counts1[name][1]
+        c2 = counts2[name][1]
+        more_native = 0
+        if c2 > c1:
+            more_native = c2 - c1
+        if more_py or more_native:
+            more[name] = more_py, more_native
+    return more
+
+
+def ob_name_from_test_func(func):
+    """Translate test_release_bind_group() to "BindGroup"."""
+    func_name = func.__name__
+    prefix = "test_release_"
+    assert func_name.startswith(prefix)
+    words = func_name[len(prefix) :].split("_")
+    if words[-1].isnumeric():
+        words.pop(-1)
+    return "".join(word.capitalize() for word in words)
+
+
+def create_and_release(create_objects_func):
+    """Decorator."""
+
+    def core_test_func():
+        """The core function that does the testing."""
+
+        n = 32
+
+        generator = create_objects_func(n)
+        ob_name = ob_name_from_test_func(create_objects_func)
+
+        # ----- Collect options
+
+        options = {
+            "expected_counts_after_create": {ob_name: (32, 32)},
+            "expected_counts_after_release": {},
+        }
+
+        func_options = next(generator)
+        assert isinstance(func_options, dict), "First yield must be an options dict"
+        options.update(func_options)
+
+        # Measure baseline object counts
+        counts1 = get_counts()
+
+        # ----- Create
+
+        # Create objects
+        objects = list(generator)
+
+        # Test the count
+        assert len(objects) == n
+
+        # Test that all objects are of the same class.
+        # (this for-loop is a bit weird, but its to avoid leaking refs to objects)
+        cls = objects[0].__class__
+        assert all(isinstance(objects[i], cls) for i in range(len(objects)))
+
+        # Test that class matches function name (should prevent a group of copy-paste errors)
+        assert ob_name == cls.__name__[3:]
+
+        # Measure peak object counts
+        counts2 = get_counts()
+        more2 = get_excess_counts(counts1, counts2)
+        print("  more after create:", more2)
+
+        # Make sure the actual object has increased
+        assert more2  # not empty
+        assert more2 == options["expected_counts_after_create"]
+
+        # It's ok if other objects are created too ...
+
+        # ----- Release
+
+        # Delete objects
+        del objects
+        gc.collect()
+
+        # Measure after-release object counts
+        counts3 = get_counts()
+        more3 = get_excess_counts(counts1, counts3)
+        print("  more after release:", more3)
+
+        # Check!
+        assert more3 == options["expected_counts_after_release"]
+
+    core_test_func.__name__ = create_objects_func.__name__
+    return core_test_func

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import subprocess
+
+
+def _determine_can_use_wgpu_lib():
+    # For some reason, since wgpu-native 5c304b5ea1b933574edb52d5de2d49ea04a053db
+    # the process' exit code is not zero, so we test more pragmatically.
+    code = "import wgpu.utils; wgpu.utils.get_default_device(); print('ok')"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            code,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    print("_determine_can_use_wgpu_lib() status code:", result.returncode)
+    return (
+        result.stdout.strip().endswith("ok")
+        and "traceback" not in result.stderr.lower()
+    )
+
+
+def _determine_can_use_glfw():
+    code = "import glfw;exit(0) if glfw.init() else exit(1)"
+    try:
+        subprocess.check_output([sys.executable, "-c", code])
+    except Exception:
+        return False
+    else:
+        return True
+
+
+can_use_wgpu_lib = _determine_can_use_wgpu_lib()
+can_use_glfw = _determine_can_use_glfw()
+is_ci = bool(os.getenv("CI", None))

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -2366,7 +2366,7 @@ class GPUComputePassEncoder(
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePassEncoder computePassEncoder)
-            internal  # panics: libf.wgpuComputePassEncoderRelease(internal)
+            libf.wgpuComputePassEncoderRelease(internal)
 
 
 class GPURenderPassEncoder(
@@ -2429,7 +2429,7 @@ class GPURenderPassEncoder(
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPassEncoder renderPassEncoder)
-            internal  # panics: libf.wgpuRenderPassEncoderRelease(internal)
+            libf.wgpuRenderPassEncoderRelease(internal)
 
 
 class GPURenderBundleEncoder(

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -35,7 +35,6 @@ from .rs_helpers import (
     get_memoryview_and_address,
     to_snake_case,
     to_camel_case,
-    DelayedReleaser,
     ErrorHandler,
     SafeLibCalls,
 )
@@ -173,7 +172,6 @@ def check_struct(struct_name, d):
         raise ValueError(f"Invalid keys in {struct_name}: {invalid_keys}")
 
 
-delayed_releaser = DelayedReleaser()
 error_handler = ErrorHandler(logger)
 libf = SafeLibCalls(lib, error_handler)
 
@@ -546,9 +544,6 @@ class GPUAdapter(base.GPUAdapter):
     def _request_device(
         self, label, required_features, required_limits, default_queue, trace_path
     ):
-        # This is a good moment to release destroyed objects
-        delayed_releaser.release_all_pending()
-
         # ---- Handle features
 
         assert isinstance(required_features, (tuple, list, set))
@@ -720,7 +715,6 @@ class GPUAdapter(base.GPUAdapter):
             self._internal, internal = None, self._internal
             # H: void f(WGPUAdapter adapter)
             libf.wgpuAdapterRelease(internal)
-            # delayed_releaser.release_soon("wgpuAdapterRelease", internal)
 
 
 class GPUDevice(base.GPUDevice, GPUObjectBase):
@@ -1462,7 +1456,6 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUDevice device)
             libf.wgpuDeviceRelease(internal)
-            # delayed_releaser.release_soon("wgpuDeviceRelease", internal)
 
 
 class GPUBuffer(base.GPUBuffer, GPUObjectBase):

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -2662,6 +2662,7 @@ class GPUQueue(base.GPUQueue, GPUObjectBase):
     def _destroy(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
+            # H: void f(WGPUQueue queue)
             libf.wgpuQueueRelease(internal)
 
 

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -354,6 +354,7 @@ class GPU(base.GPU):
 class GPUCanvasContext(base.GPUCanvasContext):
     def __init__(self, canvas):
         super().__init__(canvas)
+        self._device = None
         self._surface_size = (-1, -1)
         self._surface_id = None
         self._internal = None

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1751,6 +1751,7 @@ class GPUPipelineLayout(base.GPUPipelineLayout, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUPipelineLayout pipelineLayout)
             libf.wgpuPipelineLayoutRelease(internal)
+            self._device._poll()
 
 
 class GPUShaderModule(base.GPUShaderModule, GPUObjectBase):
@@ -1802,6 +1803,7 @@ class GPUComputePipeline(base.GPUComputePipeline, GPUPipelineBase, GPUObjectBase
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePipeline computePipeline)
             libf.wgpuComputePipelineRelease(internal)
+            self._device._poll()
 
 
 class GPURenderPipeline(base.GPURenderPipeline, GPUPipelineBase, GPUObjectBase):

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -971,9 +971,17 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
             # not used: nextInChain
         )
 
+        # Note: wgpu-core re-uses BindGroupLayouts with the same (or similar
+        # enough) descriptor. You would think that this means that the id is
+        # the same when you call wgpuDeviceCreateBindGroupLayout with the same
+        # input, but it's not. So we cannot let wgpu-native/core decide when
+        # to re-use a BindGroupLayout. I don't feel confident checking here
+        # whether a BindGroupLayout can be re-used, so we simply don't. Higher
+        # level code can sometimes make this decision because it knows the app
+        # logic.
+
         # H: WGPUBindGroupLayout f(WGPUDevice device, WGPUBindGroupLayoutDescriptor const * descriptor)
         id = libf.wgpuDeviceCreateBindGroupLayout(self._internal, struct)
-
         return GPUBindGroupLayout(label, id, self, entries)
 
     def create_bind_group(

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1657,6 +1657,13 @@ class GPUBuffer(base.GPUBuffer, GPUObjectBase):
             # H: void f(WGPUBuffer buffer)
             libf.wgpuBufferRelease(internal)
             self._device._poll()
+            # Note: from the memtests it looks like we need to poll the device
+            # after releasing an object for some objects (buffer, texture,
+            # texture view, sampler, pipeline layout, compute pipeline, and
+            # render pipeline). But not others. Would be nice to at some point
+            # have more clarity on this. In the mean time, we now poll the
+            # device quite a bit, so leaks by not polling the device after
+            # releasing something are highly unlikely.
 
 
 class GPUTexture(base.GPUTexture, GPUObjectBase):
@@ -1818,6 +1825,7 @@ class GPURenderPipeline(base.GPURenderPipeline, GPUPipelineBase, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPipeline renderPipeline)
             libf.wgpuRenderPipelineRelease(internal)
+            self._device._poll()
 
 
 class GPUCommandBuffer(base.GPUCommandBuffer, GPUObjectBase):

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -717,7 +717,8 @@ class GPUAdapter(base.GPUAdapter):
     def _destroy(self):
         if self._internal is not None and lib is not None:
             self._internal, internal = None, self._internal
-            delayed_releaser.release_soon("wgpuAdapterRelease", internal)
+            libf.wgpuAdapterRelease(internal)
+            # delayed_releaser.release_soon("wgpuAdapterRelease", internal)
 
 
 class GPUDevice(base.GPUDevice, GPUObjectBase):
@@ -1446,7 +1447,8 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
     def _destroy(self):
         if self._internal is not None and lib is not None:
             self._internal, internal = None, self._internal
-            delayed_releaser.release_soon("wgpuDeviceRelease", internal)
+            libf.wgpuDeviceRelease(internal)
+            # delayed_releaser.release_soon("wgpuDeviceRelease", internal)
 
 
 class GPUBuffer(base.GPUBuffer, GPUObjectBase):
@@ -1637,6 +1639,7 @@ class GPUBuffer(base.GPUBuffer, GPUObjectBase):
         self._release_memoryviews()
         if self._internal is not None and lib is not None:
             self._internal, internal = None, self._internal
+            libf.wgpuDevicePoll(self._device._internal, True, ffi.NULL)
             # H: void f(WGPUBuffer buffer)
             libf.wgpuBufferRelease(internal)
 

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1456,6 +1456,7 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUDevice device)
             libf.wgpuDeviceRelease(internal)
+            # wgpuDeviceDestroy(internal) is also an option
 
 
 class GPUBuffer(base.GPUBuffer, GPUObjectBase):

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -1819,7 +1819,7 @@ class GPUCommandBuffer(base.GPUCommandBuffer, GPUObjectBase):
         # 'Cannot remove a vacant resource'. Got this info from the
         # wgpu chat. Also see
         # https://docs.rs/wgpu-core/latest/src/wgpu_core/device/mod.rs.html#4180-4194
-        # That's why _internal is set to None in submit()
+        # --> That's why _internal is set to None in Queue.submit()
         if self._internal is not None and lib is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUCommandBuffer commandBuffer)
@@ -2322,7 +2322,7 @@ class GPUCommandEncoder(
         raise NotImplementedError()
 
     def _destroy(self):
-        # Note that the natove object gets destroyed on finish.
+        # Note that the native object gets destroyed on finish.
         # Also see GPUCommandBuffer._destroy()
         if self._internal is not None and lib is not None:
             self._internal, internal = None, self._internal

--- a/wgpu/backends/rs.py
+++ b/wgpu/backends/rs.py
@@ -487,7 +487,7 @@ class GPUCanvasContext(base.GPUCanvasContext):
             return default
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUSwapChain swapChain)
             libf.wgpuSwapChainRelease(internal)
@@ -716,7 +716,7 @@ class GPUAdapter(base.GPUAdapter):
         )  # no-cover
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUAdapter adapter)
             libf.wgpuAdapterRelease(internal)
@@ -1448,14 +1448,18 @@ class GPUDevice(base.GPUDevice, GPUObjectBase):
         stencil_read_only: bool = False,
     ):
         raise NotImplementedError()
+        # Note: also enable the coresponing memtest when implementing this!
 
     def create_query_set(self, *, label="", type: "enums.QueryType", count: int):
         raise NotImplementedError()
+        # Note: also enable the coresponing memtest when implementing this!
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._queue is not None:
+            self._queue._destroy()
+            self._queue = None
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
-            self._poll()
             # H: void f(WGPUDevice device)
             libf.wgpuDeviceRelease(internal)
             # delayed_releaser.release_soon("wgpuDeviceRelease", internal)
@@ -1646,7 +1650,7 @@ class GPUBuffer(base.GPUBuffer, GPUObjectBase):
 
     def _destroy(self):
         self._release_memoryviews()
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUBuffer buffer)
             libf.wgpuBufferRelease(internal)
@@ -1704,7 +1708,7 @@ class GPUTexture(base.GPUTexture, GPUObjectBase):
         self._destroy()  # no-cover
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUTexture texture)
             libf.wgpuTextureRelease(internal)
@@ -1713,7 +1717,7 @@ class GPUTexture(base.GPUTexture, GPUObjectBase):
 
 class GPUTextureView(base.GPUTextureView, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUTextureView textureView)
             libf.wgpuTextureViewRelease(internal)
@@ -1722,7 +1726,7 @@ class GPUTextureView(base.GPUTextureView, GPUObjectBase):
 
 class GPUSampler(base.GPUSampler, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUSampler sampler)
             libf.wgpuSamplerRelease(internal)
@@ -1731,7 +1735,7 @@ class GPUSampler(base.GPUSampler, GPUObjectBase):
 
 class GPUBindGroupLayout(base.GPUBindGroupLayout, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUBindGroupLayout bindGroupLayout)
             libf.wgpuBindGroupLayoutRelease(internal)
@@ -1739,7 +1743,7 @@ class GPUBindGroupLayout(base.GPUBindGroupLayout, GPUObjectBase):
 
 class GPUBindGroup(base.GPUBindGroup, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUBindGroup bindGroup)
             libf.wgpuBindGroupRelease(internal)
@@ -1747,7 +1751,7 @@ class GPUBindGroup(base.GPUBindGroup, GPUObjectBase):
 
 class GPUPipelineLayout(base.GPUPipelineLayout, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUPipelineLayout pipelineLayout)
             libf.wgpuPipelineLayoutRelease(internal)
@@ -1787,7 +1791,7 @@ class GPUShaderModule(base.GPUShaderModule, GPUObjectBase):
         return []
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUShaderModule shaderModule)
             libf.wgpuShaderModuleRelease(internal)
@@ -1799,7 +1803,7 @@ class GPUPipelineBase(base.GPUPipelineBase):
 
 class GPUComputePipeline(base.GPUComputePipeline, GPUPipelineBase, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePipeline computePipeline)
             libf.wgpuComputePipelineRelease(internal)
@@ -1808,7 +1812,7 @@ class GPUComputePipeline(base.GPUComputePipeline, GPUPipelineBase, GPUObjectBase
 
 class GPURenderPipeline(base.GPURenderPipeline, GPUPipelineBase, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPipeline renderPipeline)
             libf.wgpuRenderPipelineRelease(internal)
@@ -1822,7 +1826,7 @@ class GPUCommandBuffer(base.GPUCommandBuffer, GPUObjectBase):
         # wgpu chat. Also see
         # https://docs.rs/wgpu-core/latest/src/wgpu_core/device/mod.rs.html#4180-4194
         # --> That's why _internal is set to None in Queue.submit()
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUCommandBuffer commandBuffer)
             libf.wgpuCommandBufferRelease(internal)
@@ -2326,7 +2330,7 @@ class GPUCommandEncoder(
     def _destroy(self):
         # Note that the native object gets destroyed on finish.
         # Also see GPUCommandBuffer._destroy()
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUCommandEncoder commandEncoder)
             libf.wgpuCommandEncoderRelease(internal)
@@ -2366,7 +2370,7 @@ class GPUComputePassEncoder(
         libf.wgpuComputePassEncoderEnd(self._internal)
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePassEncoder computePassEncoder)
             internal  # panics: libf.wgpuComputePassEncoderRelease(internal)
@@ -2429,7 +2433,7 @@ class GPURenderPassEncoder(
         raise NotImplementedError()
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPassEncoder renderPassEncoder)
             internal  # panics: libf.wgpuRenderPassEncoderRelease(internal)
@@ -2447,7 +2451,7 @@ class GPURenderBundleEncoder(
         raise NotImplementedError()
 
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderBundleEncoder renderBundleEncoder)
             libf.wgpuRenderBundleEncoderRelease(internal)
@@ -2655,10 +2659,15 @@ class GPUQueue(base.GPUQueue, GPUObjectBase):
     def on_submitted_work_done(self):
         raise NotImplementedError()
 
+    def _destroy(self):
+        if self._internal is not None and libf is not None:
+            self._internal, internal = None, self._internal
+            libf.wgpuQueueRelease(internal)
+
 
 class GPURenderBundle(base.GPURenderBundle, GPUObjectBase):
     def _destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderBundle renderBundle)
             libf.wgpuRenderBundleRelease(internal)
@@ -2668,7 +2677,7 @@ class GPUQuerySet(base.GPUQuerySet, GPUObjectBase):
     pass
 
     def destroy(self):
-        if self._internal is not None and lib is not None:
+        if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUQuerySet querySet)
             libf.wgpuQuerySetRelease(internal)

--- a/wgpu/backends/rs_helpers.py
+++ b/wgpu/backends/rs_helpers.py
@@ -403,8 +403,7 @@ class NativeDiagnostics(Diagnostics):
                 name_map[name] = name[0].upper() + name[1:-1]
 
         # Initialize the result dict (sorted)
-        for name in sorted(names + root_names):
-            report_name = name_map[name]
+        for report_name in sorted(name_map[name] for name in names + root_names):
             result[report_name] = {"count": 0, "mem": 0}
 
         # Establish what backends are active

--- a/wgpu/backends/rs_helpers.py
+++ b/wgpu/backends/rs_helpers.py
@@ -222,29 +222,6 @@ def to_camel_case(name):
     return name2
 
 
-class DelayedReleaser:
-    """Helps release objects at a later time."""
-
-    # I found that when wgpuDeviceRelease() was called in Device._destroy,
-    # the tests would hang. I found that the release call was done around
-    # the time when another device was used (e.g. to create a buffer
-    # or shader module). For some reason, the delay in destruction (by
-    # Python's CG) causes a deadlock or something. We seem to be able
-    # to fix this by doing the actual release later - e.g. when the
-    # user creates a new device. Seems to be the same for the adapter.
-    def __init__(self):
-        self._things_to_release = []
-
-    def release_soon(self, fun, i):
-        self._things_to_release.append((fun, i))
-
-    def release_all_pending(self):
-        while self._things_to_release:
-            fun, i = self._things_to_release.pop(0)
-            release_func = getattr(lib, fun)
-            release_func(i)
-
-
 class ErrorHandler:
     """Object that logs errors, with the option to collect incoming
     errors elsewhere.

--- a/wgpu/gui/_offscreen.py
+++ b/wgpu/gui/_offscreen.py
@@ -23,7 +23,7 @@ class WgpuOffscreenCanvas(WgpuCanvasBase):
         # the backend (e.g. rs), but here we use our own context.
         assert kind == "gpupresent"
         if self._canvas_context is None:
-            self._canvas_context = GPUCanvasContextOffline(self)
+            self._canvas_context = GPUCanvasContext(self)
         return self._canvas_context
 
     def present(self, texture_view):
@@ -43,7 +43,7 @@ class WgpuOffscreenCanvas(WgpuCanvasBase):
         return "rgba8unorm-srgb"
 
 
-class GPUCanvasContextOffline(base.GPUCanvasContext):
+class GPUCanvasContext(base.GPUCanvasContext):
     """Helper class for canvases that render to a texture."""
 
     def __init__(self, canvas):

--- a/wgpu/gui/jupyter.py
+++ b/wgpu/gui/jupyter.py
@@ -91,7 +91,7 @@ class JupyterWgpuCanvas(WgpuAutoGui, WgpuOffscreenCanvas, RemoteFrameBuffer):
     # Implementation needed for WgpuOffscreenCanvas
 
     def present(self, texture_view):
-        # This gets called at the end of a draw pass via GPUCanvasContextOffline
+        # This gets called at the end of a draw pass via _offscreen.GPUCanvasContext
         device = texture_view._device
         size = texture_view.size
         bytes_per_pixel = 4

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -41,7 +41,7 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuOffscreenCanvas):
         call_later(0, self.draw)
 
     def present(self, texture_view):
-        # This gets called at the end of a draw pass via GPUCanvasContextOffline
+        # This gets called at the end of a draw pass via _offscreen.GPUCanvasContext
         device = texture_view._device
         size = texture_view.size
         bytes_per_pixel = 4

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -19,7 +19,7 @@
 * Validated 37 classes, 113 methods, 43 properties
 ### Patching API for backends/rs.py
 * Diffs for GPUAdapter: add request_device_tracing
-* Validated 37 classes, 100 methods, 0 properties
+* Validated 37 classes, 101 methods, 0 properties
 ## Validating rs.py
 * Enum field TextureFormat.rgb10a2uint missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
@@ -28,6 +28,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 232 enum mappings and 47 struct-field mappings to rs_mappings.py
-* Validated 88 C function calls
-* Not using 114 C functions
+* Validated 89 C function calls
+* Not using 113 C functions
 * Validated 71 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -19,7 +19,7 @@
 * Validated 37 classes, 113 methods, 43 properties
 ### Patching API for backends/rs.py
 * Diffs for GPUAdapter: add request_device_tracing
-* Validated 37 classes, 99 methods, 0 properties
+* Validated 37 classes, 100 methods, 0 properties
 ## Validating rs.py
 * Enum field TextureFormat.rgb10a2uint missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
@@ -28,6 +28,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 232 enum mappings and 47 struct-field mappings to rs_mappings.py
-* Validated 87 C function calls
-* Not using 116 C functions
+* Validated 88 C function calls
+* Not using 114 C functions
 * Validated 71 C structs


### PR DESCRIPTION
Closes #353

This adds tests, in a new folder so it won't interfere with the unit tests. The idea is basically, doing for each kind of object:

* Get how many objects we have of each kind.
* Create a bunch of objects of a specific kind.
* Make sure the counts are indeed up.
* Delete the objects. 
* Check that the counts are down.

Todo:

* [x] Generic logic that is the same for each unit test.
* [x] Implement some meta-tests to make sure that the tests indeed fail when they should. 
* [x] Implement a test function for every object.
* [x] Can we *now* remove that `delayed_releaser`? Yes!
* [x] Can we *now* enable some release calls that previously panicked? Yes!
* [x] ~Measure process memory consumption to detect leaks?~ --> #406
* [x] Do we want our `BindGroupLayout` object to cache instances like wgpu-core does?
* [ ] Does this close #275?
* [x] Investigate fails:
    * [ ] Device (simply does not clean up in native).
    * [ ] Queue (related to the above)
    * No luck yet.
    * Following up in #405

   

