### PR TITLE
Measure memory usage during memtests

### DIFF
--- a/tests_mem/test_gui_glfw.py
+++ b/tests_mem/test_gui_glfw.py
@@ -7,7 +7,7 @@ import weakref
 import asyncio
 
 import pytest
-import testutils
+import testutils  # noqa
 from testutils import create_and_release, can_use_glfw, can_use_wgpu_lib
 from test_gui_offscreen import make_draw_func_for_canvas
 
@@ -58,7 +58,6 @@ def test_release_canvas_context(n):
 
 
 if __name__ == "__main__":
-    # Set to true and run as script to do a memory stress test
-    testutils.TEST_MEM_USAGE = False
+    # testutils.TEST_ITERS = 40  # Uncomment for a mem-usage test run
 
     test_release_canvas_context()

--- a/tests_mem/test_gui_glfw.py
+++ b/tests_mem/test_gui_glfw.py
@@ -1,0 +1,52 @@
+"""
+Test creation of GLFW canvas windows.
+"""
+
+import gc
+import asyncio
+
+import pytest
+from testutils import create_and_release, can_use_glfw, can_use_wgpu_lib
+from test_gui_offscreen import make_draw_func_for_canvas
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need wgpu lib", allow_module_level=True)
+if not can_use_glfw:
+    pytest.skip("Need glfw for this test", allow_module_level=True)
+
+loop = asyncio.get_event_loop_policy().get_event_loop()
+if loop.is_running():
+    pytest.skip("Asyncio loop is running", allow_module_level=True)
+
+
+async def stub_event_loop():
+    pass
+
+
+@create_and_release
+def test_release_canvas_context(n):
+    # Test with GLFW canvases.
+
+    # Note: in a draw, the textureview is obtained (thus creating a
+    # Texture and a TextureView, but these are released in present(),
+    # so we don't see them in the counts.
+
+    from wgpu.gui.glfw import WgpuCanvas  # noqa
+
+    yield {}
+
+    for i in range(n):
+        c = WgpuCanvas()
+        c.request_draw(make_draw_func_for_canvas(c))
+        loop.run_until_complete(stub_event_loop())
+        yield c.get_context()
+
+    # Need some shakes to get all canvas refs gone
+    del c
+    loop.run_until_complete(stub_event_loop())
+    gc.collect()
+    loop.run_until_complete(stub_event_loop())
+
+
+if __name__ == "__main__":
+    test_release_canvas_context()

--- a/tests_mem/test_gui_glfw.py
+++ b/tests_mem/test_gui_glfw.py
@@ -6,8 +6,10 @@ import gc
 import asyncio
 
 import pytest
+import testutils
 from testutils import create_and_release, can_use_glfw, can_use_wgpu_lib
 from test_gui_offscreen import make_draw_func_for_canvas
+
 
 if not can_use_wgpu_lib:
     pytest.skip("Skipping tests that need wgpu lib", allow_module_level=True)
@@ -41,7 +43,9 @@ def test_release_canvas_context(n):
         loop.run_until_complete(stub_event_loop())
         yield c.get_context()
 
-    # Need some shakes to get all canvas refs gone
+    # Need some shakes to get all canvas refs gone.
+    # Note that the canvas objects are really deleted,
+    # otherwise the CanvasContext objects would not be freed.
     del c
     loop.run_until_complete(stub_event_loop())
     gc.collect()
@@ -49,4 +53,7 @@ def test_release_canvas_context(n):
 
 
 if __name__ == "__main__":
+    # Set to true and run as script to do a memory stress test
+    testutils.TEST_MEM_USAGE = False
+
     test_release_canvas_context()

--- a/tests_mem/test_gui_offscreen.py
+++ b/tests_mem/test_gui_offscreen.py
@@ -4,6 +4,7 @@ Test creation of offscreen canvas windows.
 
 import wgpu
 import pytest
+import testutils
 from testutils import can_use_wgpu_lib, create_and_release
 
 
@@ -72,4 +73,7 @@ TEST_FUNCS = [test_release_canvas_context]
 
 
 if __name__ == "__main__":
+    # Set to true and run as script to do a memory stress test
+    testutils.TEST_MEM_USAGE = False
+
     test_release_canvas_context()

--- a/tests_mem/test_gui_offscreen.py
+++ b/tests_mem/test_gui_offscreen.py
@@ -1,0 +1,75 @@
+"""
+Test creation of offscreen canvas windows.
+"""
+
+import wgpu
+import pytest
+from testutils import can_use_wgpu_lib, create_and_release
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need wgpu lib", allow_module_level=True)
+
+
+DEVICE = wgpu.utils.get_default_device()
+
+
+def make_draw_func_for_canvas(canvas):
+    """Create a draw function for the given canvas,
+    so that we can really present something to a canvas being tested.
+    """
+    ctx = canvas.get_context()
+    ctx.configure(device=DEVICE, format="bgra8unorm-srgb")
+
+    def draw():
+        ctx = canvas.get_context()
+        command_encoder = DEVICE.create_command_encoder()
+        current_texture_view = ctx.get_current_texture()
+        render_pass = command_encoder.begin_render_pass(
+            color_attachments=[
+                {
+                    "view": current_texture_view,
+                    "resolve_target": None,
+                    "clear_value": (1, 1, 1, 1),
+                    "load_op": wgpu.LoadOp.clear,
+                    "store_op": wgpu.StoreOp.store,
+                }
+            ],
+        )
+        render_pass.end()
+        DEVICE.queue.submit([command_encoder.finish()])
+        ctx.present()
+
+    return draw
+
+
+@create_and_release
+def test_release_canvas_context(n):
+    # Test with offscreen canvases. A context is created, but not a wgpu-native surface.
+
+    # Note: the offscreen canvas keeps the render-texture-view alive, since it
+    # is used to e.g. download the resulting image. That's why we also see
+    # Textures and TextureViews in the counts.
+
+    from wgpu.gui.offscreen import WgpuCanvas
+
+    yield {
+        "expected_counts_after_create": {
+            "CanvasContext": (n, 0),
+            "Texture": (n, n),
+            "TextureView": (n, n),
+        },
+    }
+
+    for i in range(n):
+        c = WgpuCanvas()
+        c.request_draw(make_draw_func_for_canvas(c))
+        c.draw()
+        yield c.get_context()
+
+
+TEST_FUNCS = [test_release_canvas_context]
+
+
+if __name__ == "__main__":
+    test_release_canvas_context()

--- a/tests_mem/test_gui_offscreen.py
+++ b/tests_mem/test_gui_offscreen.py
@@ -4,7 +4,7 @@ Test creation of offscreen canvas windows.
 
 import wgpu
 import pytest
-import testutils
+import testutils  # noqa
 from testutils import can_use_wgpu_lib, create_and_release
 
 
@@ -73,7 +73,6 @@ TEST_FUNCS = [test_release_canvas_context]
 
 
 if __name__ == "__main__":
-    # Set to true and run as script to do a memory stress test
-    testutils.TEST_MEM_USAGE = False
+    # testutils.TEST_ITERS = 40  # Uncomment for a mem-usage test run
 
     test_release_canvas_context()

--- a/tests_mem/test_gui_qt.py
+++ b/tests_mem/test_gui_qt.py
@@ -1,0 +1,48 @@
+"""
+Test creation of Qt canvas windows.
+"""
+
+import gc
+
+import pytest
+from testutils import create_and_release, can_use_pyside6, can_use_wgpu_lib
+from test_gui_offscreen import make_draw_func_for_canvas
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need wgpu lib", allow_module_level=True)
+if not can_use_pyside6:
+    pytest.skip("Need pyside6 for this test", allow_module_level=True)
+
+
+@create_and_release
+def test_release_canvas_context(n):
+    # Test with PySide canvases.
+
+    # Note: in a draw, the textureview is obtained (thus creating a
+    # Texture and a TextureView, but these are released in present(),
+    # so we don't see them in the counts.
+
+    import PySide6  # noqa
+    from wgpu.gui.qt import WgpuCanvas  # noqa
+
+    app = PySide6.QtWidgets.QApplication.instance()
+    if app is None:
+        app = PySide6.QtWidgets.QApplication([""])
+
+    yield {}
+
+    for i in range(n):
+        c = WgpuCanvas()
+        c.request_draw(make_draw_func_for_canvas(c))
+        app.processEvents()
+        yield c.get_context()
+
+    # Need some shakes to get all canvas refs gone
+    del c
+    gc.collect()
+    app.processEvents()
+
+
+if __name__ == "__main__":
+    test_release_canvas_context()

--- a/tests_mem/test_gui_qt.py
+++ b/tests_mem/test_gui_qt.py
@@ -5,6 +5,7 @@ Test creation of Qt canvas windows.
 import gc
 
 import pytest
+import testutils
 from testutils import create_and_release, can_use_pyside6, can_use_wgpu_lib
 from test_gui_offscreen import make_draw_func_for_canvas
 
@@ -38,11 +39,16 @@ def test_release_canvas_context(n):
         app.processEvents()
         yield c.get_context()
 
-    # Need some shakes to get all canvas refs gone
+    # Need some shakes to get all canvas refs gone.
+    # Note that the canvas objects are really deleted,
+    # otherwise the CanvasContext objects would not be freed.
     del c
     gc.collect()
     app.processEvents()
 
 
 if __name__ == "__main__":
+    # Set to true and run as script to do a memory stress test
+    testutils.TEST_MEM_USAGE = False
+
     test_release_canvas_context()

--- a/tests_mem/test_gui_qt.py
+++ b/tests_mem/test_gui_qt.py
@@ -6,7 +6,7 @@ import gc
 import weakref
 
 import pytest
-import testutils
+import testutils  # noqa
 from testutils import create_and_release, can_use_pyside6, can_use_wgpu_lib
 from test_gui_offscreen import make_draw_func_for_canvas
 
@@ -53,7 +53,6 @@ def test_release_canvas_context(n):
 
 
 if __name__ == "__main__":
-    # Set to true and run as script to do a memory stress test
-    testutils.TEST_MEM_USAGE = False
+    # testutils.TEST_ITERS = 40  # Uncomment for a mem-usage test run
 
     test_release_canvas_context()

--- a/tests_mem/test_gui_qt.py
+++ b/tests_mem/test_gui_qt.py
@@ -3,6 +3,7 @@ Test creation of Qt canvas windows.
 """
 
 import gc
+import weakref
 
 import pytest
 import testutils
@@ -33,18 +34,22 @@ def test_release_canvas_context(n):
 
     yield {}
 
+    canvases = weakref.WeakSet()
+
     for i in range(n):
         c = WgpuCanvas()
+        canvases.add(c)
         c.request_draw(make_draw_func_for_canvas(c))
         app.processEvents()
         yield c.get_context()
 
     # Need some shakes to get all canvas refs gone.
-    # Note that the canvas objects are really deleted,
-    # otherwise the CanvasContext objects would not be freed.
     del c
     gc.collect()
     app.processEvents()
+
+    # Check that the canvas objects are really deleted
+    assert not canvases
 
 
 if __name__ == "__main__":

--- a/tests_mem/test_meta.py
+++ b/tests_mem/test_meta.py
@@ -1,0 +1,81 @@
+"""
+Some tests to confirm that the test mechanism is sound, and that tests
+indeed fail under the right circumstances.
+"""
+
+import wgpu
+
+import pytest
+from testutils import can_use_wgpu_lib, create_and_release
+from testutils import get_counts, ob_name_from_test_func
+from test_objects import TEST_FUNCS as OBJECT_TEST_FUNCS
+from test_gui_offscreen import TEST_FUNCS as GUI_TEST_FUNCS
+
+
+ALL_TEST_FUNCS = OBJECT_TEST_FUNCS + GUI_TEST_FUNCS
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need wgpu lib", allow_module_level=True)
+
+
+DEVICE = wgpu.utils.get_default_device()
+
+
+def test_meta_all_objects_covered():
+    """Test that we have a test_release test function for each known object."""
+
+    ref_obnames = set(key for key in get_counts().keys())
+    func_obnames = set(ob_name_from_test_func(func) for func in ALL_TEST_FUNCS)
+
+    missing = ref_obnames - func_obnames
+    extra = func_obnames - ref_obnames
+    assert not missing
+    assert not extra
+
+
+def test_meta_all_functions_solid():
+    """Test that all funcs starting with "test_release_" are decorated appropriately."""
+    for func in ALL_TEST_FUNCS:
+        is_decorated = func.__code__.co_name == "core_test_func"
+        assert is_decorated, func.__name__ + " not decorated"
+
+
+def test_meta_buffers_1():
+    """Making sure that the test indeed fails, when holding onto the objects."""
+
+    lock = []
+
+    @create_and_release
+    def test_release_buffer(n):
+        yield {}
+        for i in range(n):
+            b = DEVICE.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
+            lock.append(b)
+            yield b
+
+    with pytest.raises(AssertionError):
+        test_release_buffer()
+
+
+def test_meta_buffers_2():
+    """Making sure that the test indeed fails, by disabling the release call."""
+
+    ori = wgpu.backends.rs.GPUBuffer._destroy
+    wgpu.backends.rs.GPUBuffer._destroy = lambda self: None
+
+    from test_objects import test_release_buffer  # noqa
+
+    try:
+        with pytest.raises(AssertionError):
+            test_release_buffer()
+
+    finally:
+        wgpu.backends.rs.GPUBuffer._destroy = ori
+
+
+if __name__ == "__main__":
+    test_meta_all_objects_covered()
+    test_meta_all_functions_solid()
+    test_meta_buffers_1()
+    test_meta_buffers_2()

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -3,7 +3,7 @@ Test all the wgpu objects.
 """
 
 import pytest
-import testutils
+import testutils  # noqa
 from testutils import can_use_wgpu_lib, create_and_release
 
 
@@ -369,8 +369,7 @@ TEST_FUNCS = [
 ]
 
 if __name__ == "__main__":
-    # Set to true and run as script to do a memory stress test
-    testutils.TEST_MEM_USAGE = False
+    # testutils.TEST_ITERS = 40  # Uncomment for a mem-usage test run
 
     for func in TEST_FUNCS:
         print(func.__name__ + " ...")

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -3,6 +3,7 @@ Test all the wgpu objects.
 """
 
 import pytest
+import testutils
 from testutils import can_use_wgpu_lib, create_and_release
 
 
@@ -368,6 +369,9 @@ TEST_FUNCS = [
 ]
 
 if __name__ == "__main__":
+    # Set to true and run as script to do a memory stress test
+    testutils.TEST_MEM_USAGE = False
+
     for func in TEST_FUNCS:
         print(func.__name__ + " ...")
         try:

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -1,9 +1,15 @@
 import gc
 import os
 import sys
+import time
 import subprocess
 
+import psutil
 import wgpu
+from wgpu._diagnostics import int_repr
+
+
+p = psutil.Process()
 
 
 def _determine_can_use_wgpu_lib():
@@ -51,6 +57,24 @@ can_use_wgpu_lib = _determine_can_use_wgpu_lib()
 can_use_glfw = _determine_can_use_glfw()
 can_use_pyside6 = _determine_can_use_pyside6()
 is_ci = bool(os.getenv("CI", None))
+
+TEST_MEM_USAGE = False
+
+
+def get_memory_usage():
+    """Get how much memory the process consumes right now."""
+    # vms: total virtual memory. Seems not suitable, because it gets less but bigger differences.
+    # rss: the part of the virtual memory that is not in swap, i.e. consumers ram.
+    # uss: memory that would become available when the process is killed (excludes shared).
+    # return p.memory_info().rss
+    return p.memory_full_info().uss
+
+
+def clear_mem():
+    time.sleep(0.001)
+    gc.collect()
+    time.sleep(0.001)
+    gc.collect()
 
 
 def get_counts():
@@ -113,65 +137,94 @@ def create_and_release(create_objects_func):
     def core_test_func():
         """The core function that does the testing."""
 
-        n = 32
+        if TEST_MEM_USAGE:
+            n_objects_list = [8 for i in range(40)]
+        else:
+            n_objects_list = [32, 17]
 
-        generator = create_objects_func(n)
-        ob_name = ob_name_from_test_func(create_objects_func)
+        clear_mem()
+        mem0 = get_memory_usage()
+        mem3 = mem0
+        mems = []  # (diff after create, diff after release, diff with mem0)
 
-        # ----- Collect options
+        for n_objects in n_objects_list:
+            generator = create_objects_func(n_objects)
+            ob_name = ob_name_from_test_func(create_objects_func)
 
-        options = {
-            "expected_counts_after_create": {ob_name: (32, 32)},
-            "expected_counts_after_release": {},
-        }
+            # ----- Collect options
 
-        func_options = next(generator)
-        assert isinstance(func_options, dict), "First yield must be an options dict"
-        options.update(func_options)
+            options = {
+                "expected_counts_after_create": {ob_name: (n_objects, n_objects)},
+                "expected_counts_after_release": {},
+            }
 
-        # Measure baseline object counts
-        counts1 = get_counts()
+            func_options = next(generator)
+            assert isinstance(func_options, dict), "First yield must be an options dict"
+            options.update(func_options)
 
-        # ----- Create
+            # Measure baseline object counts
+            clear_mem()
+            mem1 = mem3  # initial mem is end-mem of last iter
+            counts1 = get_counts()
 
-        # Create objects
-        objects = list(generator)
+            # ----- Create
 
-        # Test the count
-        assert len(objects) == n
+            # Create objects
+            objects = list(generator)
 
-        # Test that all objects are of the same class.
-        # (this for-loop is a bit weird, but its to avoid leaking refs to objects)
-        cls = objects[0].__class__
-        assert all(isinstance(objects[i], cls) for i in range(len(objects)))
+            # Test the count
+            assert len(objects) == n_objects
 
-        # Test that class matches function name (should prevent a group of copy-paste errors)
-        assert ob_name == cls.__name__[3:]
+            # Test that all objects are of the same class.
+            # (this for-loop is a bit weird, but its to avoid leaking refs to objects)
+            cls = objects[0].__class__
+            assert all(isinstance(objects[i], cls) for i in range(len(objects)))
 
-        # Measure peak object counts
-        counts2 = get_counts()
-        more2 = get_excess_counts(counts1, counts2)
-        print("  more after create:", more2)
+            # Test that class matches function name (should prevent a group of copy-paste errors)
+            assert ob_name == cls.__name__[3:]
 
-        # Make sure the actual object has increased
-        assert more2  # not empty
-        assert more2 == options["expected_counts_after_create"]
+            # Measure peak object counts
+            mem2 = get_memory_usage()
+            counts2 = get_counts()
+            more2 = get_excess_counts(counts1, counts2)
+            if not TEST_MEM_USAGE:
+                print("  more after create:", more2)
 
-        # It's ok if other objects are created too ...
+            # Make sure the actual object has increased
+            assert more2  # not empty
+            assert more2 == options["expected_counts_after_create"]
 
-        # ----- Release
+            # It's ok if other objects are created too ...
 
-        # Delete objects
-        del objects
-        gc.collect()
+            # ----- Release
 
-        # Measure after-release object counts
-        counts3 = get_counts()
-        more3 = get_excess_counts(counts1, counts3)
-        print("  more after release:", more3)
+            # Delete objects
+            del objects
+            clear_mem()
 
-        # Check!
-        assert more3 == options["expected_counts_after_release"]
+            # Measure after-release object counts
+            mem3 = get_memory_usage()
+            counts3 = get_counts()
+            more3 = get_excess_counts(counts1, counts3)
+            if not TEST_MEM_USAGE:
+                print("  more after release:", more3)
+
+            # Check!
+            assert more3 == options["expected_counts_after_release"]
+
+            mems.append((mem2 - mem1, mem3 - mem1, mem3 - mem0))
+
+        if TEST_MEM_USAGE:
+            # For each iter, print the mem compared to last step
+            i, cols = 0, 10
+            while i < len(mems):
+                row = mems[i : i + cols]
+                i += cols
+                print(" ".join((int_repr(x[1]) + "B").rjust(7) for x in row))
+
+            # If the latter half contains nonzero, mark it as suspicious
+            if any(m[1] for m in mems[len(mems) // 2 :]):
+                print(">> SUSPICIOUS!")
 
     core_test_func.__name__ = create_objects_func.__name__
     return core_test_func

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -141,8 +141,15 @@ class WgpuCanvasBase(WgpuCanvasInterface):
         self._vsync = bool(vsync)
 
     def __del__(self):
+        # On delete, we call the custom close method.
         try:
             self.close()
+        except Exception:
+            pass
+        # Since this is sometimes used in a multiple inheritance, the
+        # superclass may (or may not) have a __del__ method.
+        try:
+            super().__del__()
         except Exception:
             pass
 

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -185,7 +185,7 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
 
     def _on_close(self, *args):
         all_glfw_canvases.discard(self)
-        glfw.hide_window(self._window)
+        glfw.destroy_window(self._window)  # not just glfw.hide_window
         self._handle_event_and_flush({"event_type": "close"})
 
     def _on_window_dirty(self, *args):

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -17,12 +17,14 @@ for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
         QtWidgets = importlib.import_module(".QtWidgets", libname)
         try:
             WA_PaintOnScreen = QtCore.Qt.WidgetAttribute.WA_PaintOnScreen
+            WA_DeleteOnClose = QtCore.Qt.WidgetAttribute.WA_DeleteOnClose
             PreciseTimer = QtCore.Qt.TimerType.PreciseTimer
             KeyboardModifiers = QtCore.Qt.KeyboardModifier
             FocusPolicy = QtCore.Qt.FocusPolicy
             Keys = QtCore.Qt.Key
         except AttributeError:
             WA_PaintOnScreen = QtCore.Qt.WA_PaintOnScreen
+            WA_DeleteOnClose = QtCore.Qt.WA_DeleteOnClose
             PreciseTimer = QtCore.Qt.PreciseTimer
             KeyboardModifiers = QtCore.Qt
             FocusPolicy = QtCore.Qt
@@ -138,6 +140,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
 
         # Configure how Qt renders this widget
         self.setAttribute(WA_PaintOnScreen, True)
+        self.setAttribute(WA_DeleteOnClose, True)
         self.setAutoFillBackground(False)
         self.setMouseTracking(True)
         self.setFocusPolicy(FocusPolicy.StrongFocus)
@@ -332,6 +335,7 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
 
         super().__init__(**kwargs)
 
+        self.setAttribute(WA_DeleteOnClose, True)
         self.set_logical_size(*(size or (640, 480)))
         self.setWindowTitle(title or "qt wgpu canvas")
         self.setMouseTracking(True)


### PR DESCRIPTION
Closes #406.

This modifies the tests in `tests_mem/` to help investigate potential memory leaks.

In normal mode, runs the test twice for each object, with two different object-amounts. In memory-usage-mode, runs 40 iterations with an object-count of 8, track memory usage at each iteration, and report that.

* [x] Improve destruction of glfw and qt widgets.
* [x] Move some of the mem tests into their own test module (meta, gui). 
* [x] Change the test so it can do multiple iterations.
* [x] By default it runs two iterations, one with 32 objects and another with 17.
* [x] By setting `TEST_ITERS` it will run that many iterations with 8 objects, printing diff memory usage at each iteration.

This work was originally about that last step, but in the end these memory measurement are pretty hard to interpret. They can sometimes be useful, and perhaps we can improve it in the future? But for now we only run those tests manually, not in CI.

----
Example:
```
test_release_adapter ...
 49.1KB      0B      0B      0B      0B      0B      0B      0B  16.3KB      0B
 16.3KB  16.3KB      0B      0B      0B      0B      0B      0B      0B      0B
     0B  16.3KB      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B  16.3KB      0B      0B  16.3KB      0B      0B  16.3KB      0B
>> SUSPICIOUS!
test_release_device ...
  skipped
test_release_bind_group ...
 49.1KB      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B  16.3KB      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B  16.3KB
>> SUSPICIOUS!
test_release_bind_group_layout ...
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B  32.7KB      0B
     0B      0B      0B      0B      0B      0B  16.3KB      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B  16.3KB
>> SUSPICIOUS!
test_release_buffer ...
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
test_release_command_buffer ...
 32.7KB      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B  16.3KB      0B      0B      0B      0B
>> SUSPICIOUS!
test_release_command_encoder ...
     0B      0B      0B -16.3KB      0B  16.3KB      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
test_release_compute_pass_encoder ...
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
     0B      0B      0B      0B      0B      0B      0B      0B      0B      0B
...
```

For the GUI backends, the memory usage seems to consistently increase. E.g. for glfw:
```
 18.6MB  2.49MB  2.94MB  3.08MB  1.04MB  1.37MB  1.14MB   966KB  1.34MB  2.14MB
  983KB   950KB  1.47MB  1.42MB  1.63MB  1.16MB  1.67MB  1.45MB  1.42MB   999KB
 2.06MB   671KB  1.04MB  1.50MB  1.03MB  1.34MB  1.44MB  1.42MB  1.29MB  1.44MB
 1.09MB  1.68MB  1.68MB  1.39MB  1.68MB  1.39MB  1.99MB  1.54MB  1.29MB  1.70MB
```

I'm not sure what to make of this, t.b.h. ... I wonder how useful these numbers are at all ...

For example, the glfw `Canvas` objects are deleted, so this is probably memory that glfw manages and may release at a later time? If I run with more iterations, I do see that memory is released (i.e. negative numbers in above tables), but not as much as is consumed.

