### PR TITLE
Make canvas arg in request_adapter() optional

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -43,7 +43,7 @@ you can obtain a device.
 
 .. code-block:: py
 
-    adapter = wgpu.gpu.request_adapter(canvas=canvas, power_preference="high-performance")
+    adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
     device = adapter.request_device()
 
 The ``wgpu.gpu`` object is the API entrypoint (:class:`wgpu.GPU`). It contains just a handful of functions,

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -16,7 +16,7 @@ import numpy as np
 canvas = WgpuCanvas(title="wgpu cube")
 
 # Create a wgpu device
-adapter = wgpu.gpu.request_adapter(canvas=canvas, power_preference="high-performance")
+adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
 device = adapter.request_device()
 
 # Prepare present context

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -62,18 +62,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
 def main(canvas, power_preference="high-performance", limits=None):
     """Regular function to setup a viz on the given canvas."""
-    # Note: passing the canvas here can (oddly enough) prevent the
-    # adapter from being found. Seen with wx/Linux.
-    adapter = wgpu.gpu.request_adapter(canvas=None, power_preference=power_preference)
+    adapter = wgpu.gpu.request_adapter(power_preference=power_preference)
     device = adapter.request_device(required_limits=limits)
     return _main(canvas, device)
 
 
 async def main_async(canvas):
     """Async function to setup a viz on the given canvas."""
-    adapter = await wgpu.gpu.request_adapter_async(
-        canvas=canvas, power_preference="high-performance"
-    )
+    adapter = await wgpu.gpu.request_adapter_async(power_preference="high-performance")
     device = await adapter.request_device_async(required_limits={})
     return _main(canvas, device)
 

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -47,18 +47,14 @@ void main()
 
 def main(canvas, power_preference="high-performance", limits=None):
     """Regular function to setup a viz on the given canvas."""
-    # Note: passing the canvas here can (oddly enough) prevent the
-    # adapter from being found. Seen with wx/Linux.
-    adapter = wgpu.gpu.request_adapter(canvas=None, power_preference=power_preference)
+    adapter = wgpu.gpu.request_adapter(power_preference=power_preference)
     device = adapter.request_device(required_limits=limits)
     return _main(canvas, device)
 
 
 async def main_async(canvas):
     """Async function to setup a viz on the given canvas."""
-    adapter = await wgpu.gpu.request_adapter_async(
-        canvas=canvas, power_preference="high-performance"
-    )
+    adapter = await wgpu.gpu.request_adapter_async(power_preference="high-performance")
     device = await adapter.request_device_async(required_limits={})
     return _main(canvas, device)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -107,7 +107,7 @@ def test_base_wgpu_api():
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_backend_is_selected_automatically():
     # Test this in a subprocess to have a clean wgpu with no backend imported yet
-    code = "import wgpu; print(wgpu.gpu.request_adapter(canvas=None))"
+    code = "import wgpu; print(wgpu.gpu.request_adapter())"
     result = subprocess.run(
         [sys.executable, "-c", code],
         stdout=subprocess.PIPE,

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -112,11 +112,7 @@ def test_glfw_canvas_render():
 
     canvas = WgpuCanvas(max_fps=9999)
 
-    # wgpu.utils.get_default_device()
-    adapter = wgpu.gpu.request_adapter(
-        canvas=canvas, power_preference="high-performance"
-    )
-    device = adapter.request_device()
+    device = wgpu.utils.get_default_device()
     draw_frame1 = _get_draw_function(device, canvas)
 
     frame_counter = 0
@@ -203,6 +199,7 @@ def test_glfw_canvas_render_custom_canvas():
 
     canvas = CustomCanvas()
 
+    # Also pass canvas here, to touch that code somewhere
     adapter = wgpu.gpu.request_adapter(
         canvas=canvas, power_preference="high-performance"
     )

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -180,7 +180,7 @@ def test_shader_module_creation_spirv():
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_adapter_destroy():
-    adapter = wgpu.gpu.request_adapter(canvas=None, power_preference="high-performance")
+    adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
     assert adapter._internal is not None
     adapter.__del__()
     assert adapter._internal is None

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -20,7 +20,7 @@ DEVICE = wgpu.utils.get_default_device()
 def test_release_adapter(n):
     yield {}
     for i in range(n):
-        yield wgpu.gpu.request_adapter(canvas=None, power_preference="high-performance")
+        yield wgpu.gpu.request_adapter(power_preference="high-performance")
 
 
 @create_and_release

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -177,21 +177,19 @@ libf = SafeLibCalls(lib, error_handler)
 
 class GPU(base.GPU):
     def request_adapter(
-        self, *, canvas, power_preference=None, force_fallback_adapter=False
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 
-        This is the implementation based on the Rust wgpu-native library.
+        This is the implementation based on wgpu-native.
 
         Arguments:
-            canvas (WgpuCanvas): The canvas that the adapter should be able to
-                render to (to create a swap chain for, to be precise). Can be None
-                if you're not rendering to screen (or if you're confident that the
-                returned adapter will work just fine).
-            power_preference(PowerPreference): "high-performance" or "low-power".
+            power_preference (PowerPreference): "high-performance" or "low-power".
             force_fallback_adapter (bool): whether to use a (probably CPU-based)
                 fallback adapter.
+            canvas (WgpuCanvasInterface): The canvas that the adapter should
+                be able to render to. This can typically be left to None.
         """
 
         # ----- Surface ID
@@ -335,15 +333,15 @@ class GPU(base.GPU):
         return GPUAdapter(adapter_id, features, limits, adapter_info)
 
     async def request_adapter_async(
-        self, *, canvas, power_preference=None, force_fallback_adapter=False
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Async version of ``request_adapter()``.
-        This function uses the Rust WGPU library.
+        This is the implementation based on wgpu-native.
         """
         return self.request_adapter(
-            canvas=canvas,
             power_preference=power_preference,
             force_fallback_adapter=force_fallback_adapter,
+            canvas=canvas,
         )  # no-cover
 
 

--- a/wgpu/base.py
+++ b/wgpu/base.py
@@ -82,39 +82,37 @@ class GPU:
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     @apidiff.change("arguments include a canvas object")
     def request_adapter(
-        self, *, canvas, power_preference=None, force_fallback_adapter=False
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 
         Arguments:
-            canvas (WgpuCanvasInterface): The canvas that the adapter should
-                be able to render to (to create a swap chain for, to be precise).
-                Can be None if you're not rendering to screen (or if you're
-                confident that the returned adapter will work just fine).
             power_preference (PowerPreference): "high-performance" or "low-power".
             force_fallback_adapter (bool): whether to use a (probably CPU-based)
                 fallback adapter.
+            canvas (WgpuCanvasInterface): The canvas that the adapter should
+                be able to render to. This can typically be left to None.
         """
         # If this method gets called, no backend has been loaded yet, let's do that now!
         from .backends.auto import gpu  # noqa
 
         return gpu.request_adapter(
-            canvas=canvas,
             power_preference=power_preference,
             force_fallback_adapter=force_fallback_adapter,
+            canvas=canvas,
         )
 
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     @apidiff.change("arguments include a canvas object")
     async def request_adapter_async(
-        self, *, canvas, power_preference=None, force_fallback_adapter=False
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Async version of `request_adapter()`."""
         return self.request_adapter(
-            canvas=canvas,
             power_preference=power_preference,
             force_fallback_adapter=force_fallback_adapter,
+            canvas=canvas,
         )
 
     # IDL: GPUTextureFormat getPreferredCanvasFormat();

--- a/wgpu/utils/device.py
+++ b/wgpu/utils/device.py
@@ -12,8 +12,6 @@ def get_default_device():
     if _default_device is None:
         import wgpu.backends.auto  # noqa
 
-        adapter = wgpu.gpu.request_adapter(
-            canvas=None, power_preference="high-performance"
-        )
+        adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
         _default_device = adapter.request_device()
     return _default_device


### PR DESCRIPTION
### Background

The `canvas` argument in `request_adapter()` is not part of the WebGPU spec. It is an optional argument to `wgpuInstanceRequestAdapter()`, so it seemed like a good idea to make it possible to pass this argument. I initially made it a required argument, but in practice it is often set to None, because we often want to create a (global) device before we have a canvas.

 ### Changes

This PR makes the argument optional, and puts it to the end of the arg to move it a bit out of sight, making the API feel more like WebGPU.

I want to get this into the 0.12.0 release, because our users will have to adjust their `request_adapter()` calls already.