### PR TITLE
Add texture input to Shadertoy util (iChannel0, ...)

### DIFF
--- a/examples/shadertoy_glsl_textures.py
+++ b/examples/shadertoy_glsl_textures.py
@@ -1,15 +1,11 @@
 from wgpu.utils.shadertoy import Shadertoy, ShadertoyChannel
 
-import numpy as np
-
 shader_code = """
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     vec2 uv = fragCoord/iResolution.xy;
-    
     vec4 c0 = texture(iChannel0, 2.0*uv);
     vec4 c1 = texture(iChannel1, 3.0*uv);
-    
     fragColor = mix(c0,c1,abs(sin(i_time)));
 }
 

--- a/examples/shadertoy_glsl_textures.py
+++ b/examples/shadertoy_glsl_textures.py
@@ -14,10 +14,14 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 }
 
 """
-diag = np.eye(8, dtype=np.uint8).reshape((8, 8, 1)).repeat(4, axis=2) * 255
-gradient = np.linspace(0, 255, 32, dtype=np.uint8).reshape((32, 1, 1)).repeat(32, axis=1).repeat(4, axis=2)
+test_pattern = memoryview(
+    bytearray((int(i != k) * 255 for i in range(8) for k in range(8))) * 4
+).cast("B", shape=[8, 8, 4])
+gradient = memoryview(
+    bytearray((i for i in range(0, 255, 8) for _ in range(4))) * 32
+).cast("B", shape=[32, 32, 4])
 
-channel0 = ShadertoyChannel(diag, wrap="repeat")
+channel0 = ShadertoyChannel(test_pattern, wrap="repeat")
 channel1 = ShadertoyChannel(gradient)
 
 shader = Shadertoy(shader_code, resolution=(640, 480), inputs=[channel0, channel1])

--- a/examples/shadertoy_glsl_textures.py
+++ b/examples/shadertoy_glsl_textures.py
@@ -1,0 +1,24 @@
+from wgpu.utils.shadertoy import Shadertoy, ShadertoyChannel
+
+from PIL import Image
+import numpy as np
+
+shader_code = """
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec2 uv = fragCoord/iResolution.xy;
+    
+    vec4 c0 = texture(iChannel0, uv/(1.0+sin(iTime)));
+    
+    fragColor = c0;
+}
+
+"""
+texture_img = Image.open("examples/screenshots/cube.png")
+texture_arr = np.array(texture_img)
+channel0 = ShadertoyChannel(texture_arr)
+
+shader = Shadertoy(shader_code, resolution=(640, 480), inputs=[channel0])
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/shadertoy_glsl_textures.py
+++ b/examples/shadertoy_glsl_textures.py
@@ -1,6 +1,5 @@
 from wgpu.utils.shadertoy import Shadertoy, ShadertoyChannel
 
-from PIL import Image
 import numpy as np
 
 shader_code = """
@@ -8,17 +7,20 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     vec2 uv = fragCoord/iResolution.xy;
     
-    vec4 c0 = texture(iChannel0, uv/(1.0+sin(iTime)));
+    vec4 c0 = texture(iChannel0, 2.0*uv);
+    vec4 c1 = texture(iChannel1, 3.0*uv);
     
-    fragColor = c0;
+    fragColor = mix(c0,c1,abs(sin(i_time)));
 }
 
 """
-texture_img = Image.open("examples/screenshots/cube.png")
-texture_arr = np.array(texture_img)
-channel0 = ShadertoyChannel(texture_arr)
+diag = np.eye(8, dtype=np.uint8).reshape((8, 8, 1)).repeat(4, axis=2) * 255
+gradient = np.linspace(0, 255, 32, dtype=np.uint8).reshape((32, 1, 1)).repeat(32, axis=1).repeat(4, axis=2)
 
-shader = Shadertoy(shader_code, resolution=(640, 480), inputs=[channel0])
+channel0 = ShadertoyChannel(diag, wrap="repeat")
+channel1 = ShadertoyChannel(gradient)
+
+shader = Shadertoy(shader_code, resolution=(640, 480), inputs=[channel0, channel1])
 
 if __name__ == "__main__":
     shader.show()

--- a/examples/shadertoy_textures.py
+++ b/examples/shadertoy_textures.py
@@ -1,7 +1,5 @@
 from wgpu.utils.shadertoy import Shadertoy, ShadertoyChannel
 
-import numpy as np
-
 shader_code_wgsl = """
 fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
     let uv = frag_coord / i_resolution.xy;
@@ -10,10 +8,14 @@ fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
     return mix(c0,c1,abs(sin(i_time)));
 }
 """
-diag = np.eye(8, dtype=np.uint8).reshape((8, 8, 1)).repeat(4, axis=2) * 255
-gradient = np.linspace(0, 255, 32, dtype=np.uint8).reshape((32, 1, 1)).repeat(32, axis=1).repeat(4, axis=2)
+test_pattern = memoryview(
+    bytearray((int(i != k) * 255 for i in range(8) for k in range(8))) * 4
+).cast("B", shape=[8, 8, 4])
+gradient = memoryview(
+    bytearray((i for i in range(0, 255, 8) for _ in range(4))) * 32
+).cast("B", shape=[32, 32, 4])
 
-channel0 = ShadertoyChannel(diag, wrap="repeat")
+channel0 = ShadertoyChannel(test_pattern, wrap="repeat")
 channel1 = ShadertoyChannel(gradient)
 
 shader = Shadertoy(shader_code_wgsl, resolution=(640, 480), inputs=[channel0, channel1])

--- a/examples/shadertoy_textures.py
+++ b/examples/shadertoy_textures.py
@@ -1,20 +1,22 @@
 from wgpu.utils.shadertoy import Shadertoy, ShadertoyChannel
 
-from PIL import Image
 import numpy as np
 
 shader_code_wgsl = """
 fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
     let uv = frag_coord / i_resolution.xy;
-    let c0 = textureSample(i_channel0, sampler0, uv/(1.0+sin(i_time)));
-    return c0;
+    let c0 = textureSample(i_channel0, sampler0, 2.0*uv);
+    let c1 = textureSample(i_channel1, sampler1, 3.0*uv);
+    return mix(c0,c1,abs(sin(i_time)));
 }
 """
-texture_img = Image.open("examples/screenshots/cube.png")
-texture_arr = np.array(texture_img)
-channel0 = ShadertoyChannel(texture_arr)
+diag = np.eye(8, dtype=np.uint8).reshape((8, 8, 1)).repeat(4, axis=2) * 255
+gradient = np.linspace(0, 255, 32, dtype=np.uint8).reshape((32, 1, 1)).repeat(32, axis=1).repeat(4, axis=2)
 
-shader = Shadertoy(shader_code_wgsl, resolution=(640, 480), inputs=[channel0])
+channel0 = ShadertoyChannel(diag, wrap="repeat")
+channel1 = ShadertoyChannel(gradient)
+
+shader = Shadertoy(shader_code_wgsl, resolution=(640, 480), inputs=[channel0, channel1])
 
 if __name__ == "__main__":
     shader.show()

--- a/examples/shadertoy_textures.py
+++ b/examples/shadertoy_textures.py
@@ -1,4 +1,4 @@
-from wgpu.utils.shadertoy import Shadertoy
+from wgpu.utils.shadertoy import Shadertoy, ShadertoyChannel
 
 from PIL import Image
 import numpy as np
@@ -6,15 +6,15 @@ import numpy as np
 shader_code_wgsl = """
 fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
     let uv = frag_coord / i_resolution.xy;
-    let c0 = textureSample(i_channel0, r_sampler, uv/(1.0+sin(i_time)));
+    let c0 = textureSample(i_channel0, sampler0, uv/(1.0+sin(i_time)));
     return c0;
 }
 """
-texture_img = Image.open("./screenshots/cube.png")
+texture_img = Image.open("examples/screenshots/cube.png")
 texture_arr = np.array(texture_img)
+channel0 = ShadertoyChannel(texture_arr)
 
-shader = Shadertoy(shader_code_wgsl, resolution=(640, 480),
-                   inputs=[texture_arr])
+shader = Shadertoy(shader_code_wgsl, resolution=(640, 480), inputs=[channel0])
 
 if __name__ == "__main__":
     shader.show()

--- a/examples/shadertoy_textures.py
+++ b/examples/shadertoy_textures.py
@@ -1,0 +1,20 @@
+from wgpu.utils.shadertoy import Shadertoy
+
+from PIL import Image
+import numpy as np
+
+shader_code_wgsl = """
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{
+    let uv = frag_coord / i_resolution.xy;
+    let c0 = textureSample(i_channel0, r_sampler, uv/(1.0+sin(i_time)));
+    return c0;
+}
+"""
+texture_img = Image.open("./screenshots/cube.png")
+texture_arr = np.array(texture_img)
+
+shader = Shadertoy(shader_code_wgsl, resolution=(640, 480),
+                   inputs=[texture_arr])
+
+if __name__ == "__main__":
+    shader.show()

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -83,7 +83,6 @@ void main(){
     i_time = input.time;
     i_time_delta = input.time_delta;
     i_frame = input.frame;
-    
     vec2 uv = vec2(uv.x, 1.0 - uv.y);
     vec2 frag_coord = uv * i_resolution.xy;
 
@@ -181,7 +180,6 @@ fn main(in: Varyings) -> @location(0) vec4<f32> {
     i_time = input.time;
     i_time_delta = input.time_delta;
     i_frame = input.frame;
-    
     let uv = vec2<f32>(in.uv.x, 1.0 - in.uv.y);
     let frag_coord = uv * i_resolution.xy;
 

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -244,10 +244,10 @@ class ShadertoyChannel:
     """
     Represents a shadertoy channel. It can be a texture.
     Parameters:
-        data (memoryview): will be converted to memoryview. For example read in your images using ``np.asarray(Image.open("image.png"))``
+        data (array-like): Of shape (width, height, 4), will be converted to memoryview. For example read in your images using ``np.asarray(Image.open("image.png"))``
         kind (str): The kind of channel. Can be one of ("texture"). More will be supported in the future
-        ``wrap`` (str): The wrap mode, can be one of ("clamp-to-edge", "repeat", "clamp"). Default is "clamp-to-edge".
         **kwargs: Additional arguments for the sampler:
+        wrap (str): The wrap mode, can be one of ("clamp-to-edge", "repeat", "clamp"). Default is "clamp-to-edge".
     """
 
     # TODO: add cubemap/volume, buffer, webcam, video, audio, keyboard?

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -34,7 +34,21 @@ float i_time;
 float i_time_delta;
 int i_frame;
 
+layout(binding = 1) uniform texture2D i_channel0;
+layout(binding = 2) uniform sampler sampler0;
+layout(binding = 3) uniform texture2D i_channel1;
+layout(binding = 4) uniform sampler sampler1;
+layout(binding = 5) uniform texture2D i_channel2;
+layout(binding = 6) uniform sampler sampler2;
+layout(binding = 7) uniform texture2D i_channel3;
+layout(binding = 8) uniform sampler sampler3;
+
 // Shadertoy compatibility, see we can use the same code copied from shadertoy website
+
+#define iChannel0 sampler2D(i_channel0, sampler0)
+#define iChannel1 sampler2D(i_channel1, sampler1)
+#define iChannel2 sampler2D(i_channel2, sampler2)
+#define iChannel3 sampler2D(i_channel3, sampler3)
 
 #define iMouse i_mouse
 #define iDate i_date
@@ -243,8 +257,9 @@ class ShadertoyChannel:  # maybe wgpu.structs.Struct?
         data (memoryview): will be converted to memoryview. For example read in your images using ``np.asarray(Image.open("image.png"))``
         kind (str): The kind of channel. Can be one of ("texture"). More will be supported in the future
     """
+
     # TODO: add cubemap/volume, buffer, webcam, video, audio, keyboard?
-    
+
     def __init__(self, data=None, kind="texture", **kwargs):
         if kind != "texture":
             raise NotImplementedError("Only texture is supported for now.")
@@ -259,23 +274,26 @@ class ShadertoyChannel:  # maybe wgpu.structs.Struct?
                 .cast("B")
                 .cast("B", shape=[256, 256, 4])
             )
-        self.size = self.data.shape
+        self.size = self.data.shape  # (rows, columns, channels)
 
         # step 2 setup texture data
         self.texture_size = (
             self.data.shape[1],
             self.data.shape[0],
             1,
-        )  # orientation mismatch somehow?
+        )  # orientation mismatch somehow (columns, rows, 1)
 
         self.bytes_per_pixel = (
             self.data.nbytes // self.data.shape[1] // self.data.shape[0]
-        ) #is this ndim+1 ?
+        )
 
-        #TODO add sampler kwargs here (midmap, offset, edges, filtering, ...?)
+        # TODO add sampler kwargs here (midmap, offset, edges, filtering, ...?)
         self.sampler_settings = {}
 
     def __repr__(self):
+        """
+        Convenience method to get a representation of this object for debugging.
+        """
         return repr({k: v for k, v in self.__dict__.items() if k != "data"})
 
 

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -263,13 +263,13 @@ class ShadertoyChannel:  # maybe wgpu.structs.Struct?
 
         # step 2 setup texture data
         self.texture_size = (
-            self.data.shape[0],
             self.data.shape[1],
+            self.data.shape[0],
             1,
         )  # orientation mismatch somehow?
 
         self.bytes_per_pixel = (
-            self.data.nbytes // self.data.shape[0] // self.data.shape[1]
+            self.data.nbytes // self.data.shape[1] // self.data.shape[0]
         ) #is this ndim+1 ?
 
         #TODO add sampler kwargs here (midmap, offset, edges, filtering, ...?)
@@ -457,8 +457,8 @@ class Shadertoy:
                 {
                     "offset": 0,
                     "bytes_per_row": channel_input.bytes_per_pixel
-                    * channel_input.size[0],  # must be multiple of 256?
-                    "rows_per_image": channel_input.size[1],  # same is done internally
+                    * channel_input.size[1],  # must be multiple of 256?
+                    "rows_per_image": channel_input.size[0],  # same is done internally
                 },
                 texture.size,
             )

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -256,7 +256,7 @@ class ShadertoyChannel:
     Parameters:
         data (memoryview): will be converted to memoryview. For example read in your images using ``np.asarray(Image.open("image.png"))``
         kind (str): The kind of channel. Can be one of ("texture"). More will be supported in the future
-        **kwargs: Additional arguments for the sampler. 
+        **kwargs: Additional arguments for the sampler.
     """
 
     # TODO: add cubemap/volume, buffer, webcam, video, audio, keyboard?

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -189,7 +189,6 @@ fn main(in: Varyings) -> @location(0) vec4<f32> {
 """
 
 
-
 class UniformArray:
     """Convenience class to create a uniform array.
 
@@ -247,7 +246,8 @@ class ShadertoyChannel:
     Parameters:
         data (memoryview): will be converted to memoryview. For example read in your images using ``np.asarray(Image.open("image.png"))``
         kind (str): The kind of channel. Can be one of ("texture"). More will be supported in the future
-        **kwargs: Additional arguments for the sampler.
+        ``wrap`` (str): The wrap mode, can be one of ("clamp-to-edge", "repeat", "clamp"). Default is "clamp-to-edge".
+        **kwargs: Additional arguments for the sampler:
     """
 
     # TODO: add cubemap/volume, buffer, webcam, video, audio, keyboard?
@@ -272,9 +272,10 @@ class ShadertoyChannel:
         self.bytes_per_pixel = (
             self.data.nbytes // self.data.shape[1] // self.data.shape[0]
         )
-        # TODO add sampler kwargs here (midmap, offset, edges, filtering, ...?)
         self.sampler_settings = {}
         wrap = kwargs.pop("wrap", "clamp-to-edge")
+        if wrap.startswith("clamp"):
+            wrap = "clamp-to-edge"
         self.sampler_settings["address_mode_u"] = wrap
         self.sampler_settings["address_mode_v"] = wrap
         self.sampler_settings["address_mode_w"] = wrap
@@ -283,7 +284,16 @@ class ShadertoyChannel:
         """
         Convenience method to get a representation of this object for debugging.
         """
-        return repr({k: v for k, v in self.__dict__.items() if k != "data"})
+        data_repr = {
+            "repr": self.data.__repr__(),
+            "shape": self.data.shape,
+            "strides": self.data.strides,
+            "nbytes": self.data.nbytes,
+            "obj": self.data.obj,
+        }
+        class_repr = {k: v for k, v in self.__dict__.items() if k != "data"}
+        class_repr["data"] = data_repr
+        return repr(class_repr)
 
 
 class Shadertoy:

--- a/wgpu/utils/shadertoy.py
+++ b/wgpu/utils/shadertoy.py
@@ -188,13 +188,6 @@ fn main(in: Varyings) -> @location(0) vec4<f32> {
 
 """
 
-binding_layout = [
-    {
-        "binding": 0,
-        "visibility": wgpu.ShaderStage.FRAGMENT,
-        "buffer": {"type": wgpu.BufferBindingType.uniform},
-    },
-]
 
 
 class UniformArray:
@@ -302,6 +295,7 @@ class Shadertoy:
         shader_code (str): The shader code to use.
         resolution (tuple): The resolution of the shadertoy.
         offscreen (bool): Whether to render offscreen. Default is False.
+        inputs (list): A list of :class:`ShadertoyChannel` objects. Supports up to 4 inputs. Defaults to sampling a black texture.
 
     The shader code must contain a entry point function:
 
@@ -428,6 +422,14 @@ class Shadertoy:
                     "offset": 0,
                     "size": self._uniform_data.nbytes,
                 },
+            },
+        ]
+
+        binding_layout = [
+            {
+                "binding": 0,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "buffer": {"type": wgpu.BufferBindingType.uniform},
             },
         ]
 


### PR DESCRIPTION
Task for this PR:
- [x] add bindings to wglsl
- [x] add bindings to glsl
- [x] add ShadertoyChannel class
- [x] add full example/test with multiple inputs
- [x] fix binding conflict when running multiple Shadertoy instances in the same python file (like during pytest)
***
as it seems to be the most common issue according to #426 (even though the filtered dataset has no shadertoys with inputs declared), the built in `iChannel0 .. 3` samplers are still used. They output 0 if nothing is attached to the channels. 

The Shadertoy website allows for various kinds of inputs, be it textures, cubemaps, buffers (other Shadertoys) or even webcam and audio. The most basic support will be to resolve "Unknown Variable iChannel0" by having a sort of default input of 0 that can be sampled. Texture input would be most useful, so that is my aim with this PR.

**So oddities I encountered:**
- only seems to work with unit8 (not float32)
- has to be flipped vertically?

**Some ideas I have had:**
- a `ShadertoyChannel` struct/class that can be used to hold all the various settings for the sampler as well as useful defaults (like the 0 texture), do conversions (as array, dtype)
- would Buffers be just the code or a whole instance of the Shadertoy class?

**I need advice on:**
- can this be done without adding numpy as a dependency
- use a single texture array or individual bindings for channels 0..3 with individual samplers
- can glsl be done at this point or is there releases required from wgpu/naga (bunch of glsl-in commits recently)
- how to structure the user facing args to Shadertoy if texture inputs are used?

I will add some more commits but would welcome some guidance or references on the above points. 

<details>

<summary>How channel inputs are structured on the Shadertoy website</summary>

```json
{
     "inputs": [
    {
     "id": "4sfGRn",
     "filepath": "/media/a/fb918796edc3d2221218db0811e240e72e340350008338b0c07a52bd353666a6.jpg",
     "type": "texture",
     "channel": 0,
     "sampler": {
      "filter": "mipmap",
      "wrap": "repeat",
      "vflip": "true",
      "srgb": "false",
      "internal": "byte"
     },
     "published": 1
    },
    { "..." 
    }
  ],
```
</details>