### PR TITLE
update wgpu-native version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,14 +226,42 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.16.2
       env:
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_SKIP: cp39-musllinux_x86_64
+        CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+        CIBW_ARCHS_LINUX: x86_64
+        CIBW_SKIP: cp39-musllinux_x86_64
       with:
         output-dir: dist
     - name: Twine check
       run: |
           twine check dist/*
+    - name: Upload distributions
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+        name: dist
+
+  # Thees release builds uses QEMU so that we can build wheels for arm64.
+  # We build wheels and upload the wheel as an artifact, but we don't test them here.
+  qemu-release-builds:
+    name: Build wheels on ubuntu-latest with QEMU
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.16.2
+      env:
+        CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+        CIBW_ARCHS_LINUX: aarch64
+        CIBW_SKIP: cp39-musllinux_aarch64
+      with:
+        output-dir: dist
     - name: Upload distributions
       uses: actions/upload-artifact@v2
       with:
@@ -281,7 +309,7 @@ jobs:
   publish:
     name: Publish to Github and Pypi
     runs-on: ubuntu-latest
-    needs: [test-builds, release-builds, sdist-build]
+    needs: [test-builds, release-builds, qemu-release-builds, sdist-build]
     if: success() && startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/checkout@v3

--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -87,14 +87,14 @@ def get_arch():
     # https://github.com/pypa/cibuildwheel/blob/4307b52ff28b631519d38bfa0dd09d6a9b39a81e/cibuildwheel/macos.py#L277
     if os.environ.get("CIBUILDWHEEL") == "1" and "ARCHFLAGS" in os.environ:
         archflags = os.environ["ARCHFLAGS"]
-        return "arm64" if "arm64" in archflags else "x86_64"
+        return "aarch64" if "arm64" in archflags else "x86_64"
 
     if machine == "armv7l":
         # Raspberry pi
         return "armv7"
     elif is_64_bit and machine.startswith(("arm", "aarch64")):
         # Includes MacOS M1, arm linux, ...
-        return "arm64"
+        return "aarch64"
     elif is_64_bit:
         return "x86_64"
     else:
@@ -165,7 +165,7 @@ if __name__ == "__main__":
         "--arch",
         help=f"Architecture to download for (default: {arch_string})",
         default=arch_string,
-        choices=("x86_64", "i686", "arm64"),
+        choices=("x86_64", "i686", "aarch64"),
     )
     upstream = "gfx-rs/wgpu-native"
     parser.add_argument(

--- a/wgpu/backends/wgpu_native/__init__.py
+++ b/wgpu/backends/wgpu_native/__init__.py
@@ -9,8 +9,8 @@ from .. import _register_backend
 
 
 # The wgpu-native version that we target/expect
-__version__ = "0.18.1.2"
-__commit_sha__ = "f326782ecb69544126579fd335effa1e7259bd2c"
+__version__ = "0.18.1.3"
+__commit_sha__ = "8561b0d8c0b5af7dfb8631d6f924e5418c92f2ce"
 version_info = tuple(map(int, __version__.split(".")))
 _check_expected_version(version_info)  # produces a warning on mismatch
 


### PR DESCRIPTION
This is a follow-up to the `0.18.1.3` release of wgpu-native. See https://github.com/gfx-rs/wgpu-native/pull/326#issuecomment-1840189996

## Changes

- update wgpu-native version from `0.18.1.2` to `0.18.1.3`
- use "aarch64" for mac and linux instead of arm/arm64

Verified to work on Raspberry Pi OS (64-bit).

Resolves #187.
