### PR TITLE
Remove call to device._poll in _destroy methods

### DIFF
--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -102,7 +102,7 @@ def get_arch():
 
 
 def main(version, os_string, arch, upstream):
-    for build in ("release", "debug"):
+    for build in ["release"]:  # ["release", "debug"]
         filename = f"wgpu-{os_string}-{arch}-{build}.zip"
         url = f"https://github.com/{upstream}/releases/download/v{version}/{filename}"
         tmp = tempfile.gettempdir()

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -81,13 +81,14 @@ def test_release_bind_group_layout(n):
     # does not seem to clean them up. Perhaps it just caches them? There
     # are only so many possible combinations, and its just 152 bytes
     # (on Metal) per object.
+    # TODO: the above seems to no longer be the case
 
     global _bind_group_layout_binding
     _bind_group_layout_binding += 1
 
     yield {
         "expected_counts_after_create": {"BindGroupLayout": (n, 1)},
-        "expected_counts_after_release": {"BindGroupLayout": (0, 1)},
+        # "expected_counts_after_release": {"BindGroupLayout": (0, 1)},
     }
 
     binding_layouts = [

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -77,18 +77,13 @@ _bind_group_layout_binding = 10
 @create_and_release
 def test_release_bind_group_layout(n):
     # Note: when we use the same binding layout descriptor, wgpu-native
-    # re-uses the BindGroupLayout object. On the other hand, it also
-    # does not seem to clean them up. Perhaps it just caches them? There
-    # are only so many possible combinations, and its just 152 bytes
-    # (on Metal) per object.
-    # TODO: the above seems to no longer be the case
+    # re-uses the BindGroupLayout object.
 
     global _bind_group_layout_binding
     _bind_group_layout_binding += 1
 
     yield {
         "expected_counts_after_create": {"BindGroupLayout": (n, 1)},
-        # "expected_counts_after_release": {"BindGroupLayout": (0, 1)},
     }
 
     binding_layouts = [

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -72,13 +72,18 @@ def get_memory_usage():
 
 
 def clear_mem():
+
     time.sleep(0.001)
     gc.collect()
+
     time.sleep(0.001)
     gc.collect()
+
     if is_pypy:
         gc.collect()
 
+    device = wgpu.utils.get_default_device()
+    device._poll()
 
 def get_counts():
     """Get a dict that maps object names to a 2-tuple represening
@@ -183,6 +188,9 @@ def create_and_release(create_objects_func):
 
             # Test that class matches function name (should prevent a group of copy-paste errors)
             assert ob_name == cls.__name__[3:]
+
+            # Give wgpu some slack to clean up temporary resources
+            wgpu.utils.get_default_device()._poll()
 
             # Measure peak object counts
             counts2 = get_counts()

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -72,7 +72,6 @@ def get_memory_usage():
 
 
 def clear_mem():
-
     time.sleep(0.001)
     gc.collect()
 
@@ -84,6 +83,7 @@ def clear_mem():
 
     device = wgpu.utils.get_default_device()
     device._poll()
+
 
 def get_counts():
     """Get a dict that maps object names to a 2-tuple represening

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1821,14 +1821,6 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUBuffer buffer)
             libf.wgpuBufferRelease(internal)
-            self._device._poll()
-            # Note: from the memtests it looks like we need to poll the device
-            # after releasing an object for some objects (buffer, texture,
-            # texture view, sampler, pipeline layout, compute pipeline, and
-            # render pipeline). But not others. Would be nice to at some point
-            # have more clarity on this. In the mean time, we now poll the
-            # device quite a bit, so leaks by not polling the device after
-            # releasing something are highly unlikely.
 
 
 class GPUTexture(classes.GPUTexture, GPUObjectBase):
@@ -1886,7 +1878,6 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUTexture texture)
             libf.wgpuTextureRelease(internal)
-            self._device._poll()
 
 
 class GPUTextureView(classes.GPUTextureView, GPUObjectBase):
@@ -1895,7 +1886,6 @@ class GPUTextureView(classes.GPUTextureView, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUTextureView textureView)
             libf.wgpuTextureViewRelease(internal)
-            self._device._poll()
 
 
 class GPUSampler(classes.GPUSampler, GPUObjectBase):
@@ -1904,7 +1894,6 @@ class GPUSampler(classes.GPUSampler, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUSampler sampler)
             libf.wgpuSamplerRelease(internal)
-            self._device._poll()
 
 
 class GPUBindGroupLayout(classes.GPUBindGroupLayout, GPUObjectBase):
@@ -1929,7 +1918,6 @@ class GPUPipelineLayout(classes.GPUPipelineLayout, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUPipelineLayout pipelineLayout)
             libf.wgpuPipelineLayoutRelease(internal)
-            self._device._poll()
 
 
 class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
@@ -1991,7 +1979,6 @@ class GPUComputePipeline(classes.GPUComputePipeline, GPUPipelineBase, GPUObjectB
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePipeline computePipeline)
             libf.wgpuComputePipelineRelease(internal)
-            self._device._poll()
 
 
 class GPURenderPipeline(classes.GPURenderPipeline, GPUPipelineBase, GPUObjectBase):
@@ -2000,7 +1987,6 @@ class GPURenderPipeline(classes.GPURenderPipeline, GPUPipelineBase, GPUObjectBas
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPipeline renderPipeline)
             libf.wgpuRenderPipelineRelease(internal)
-            self._device._poll()
 
 
 class GPUCommandBuffer(classes.GPUCommandBuffer, GPUObjectBase):
@@ -2015,7 +2001,6 @@ class GPUCommandBuffer(classes.GPUCommandBuffer, GPUObjectBase):
             self._internal, internal = None, self._internal
             # H: void f(WGPUCommandBuffer commandBuffer)
             libf.wgpuCommandBufferRelease(internal)
-
 
 class GPUCommandsMixin(classes.GPUCommandsMixin):
     pass
@@ -2506,7 +2491,7 @@ class GPUCommandEncoder(
         id = libf.wgpuCommandEncoderFinish(self._internal, struct)
         # WGPU destroys the command encoder when it's finished. So we set
         # _internal to None to avoid releasing a nonexistent object.
-        self._internal = None
+        # self._internal = None
         return GPUCommandBuffer(label, id, self)
 
     def resolve_query_set(
@@ -2652,8 +2637,8 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         libf.wgpuQueueSubmit(self._internal, len(command_buffer_ids), c_command_buffers)
         # WGPU destroys the resource when submitting. We follow this
         # to avoid releasing a nonexistent object.
-        for cb in command_buffers:
-            cb._internal = None
+        # for cb in command_buffers:
+        #     cb._internal = None
 
     def write_buffer(self, buffer, buffer_offset, data, data_offset=0, size=None):
         # We support anything that memoryview supports, i.e. anything

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2002,6 +2002,7 @@ class GPUCommandBuffer(classes.GPUCommandBuffer, GPUObjectBase):
             # H: void f(WGPUCommandBuffer commandBuffer)
             libf.wgpuCommandBufferRelease(internal)
 
+
 class GPUCommandsMixin(classes.GPUCommandsMixin):
     pass
 
@@ -2489,9 +2490,6 @@ class GPUCommandEncoder(
         )
         # H: WGPUCommandBuffer f(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor)
         id = libf.wgpuCommandEncoderFinish(self._internal, struct)
-        # WGPU destroys the command encoder when it's finished. So we set
-        # _internal to None to avoid releasing a nonexistent object.
-        # self._internal = None
         return GPUCommandBuffer(label, id, self)
 
     def resolve_query_set(
@@ -2635,10 +2633,6 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         c_command_buffers = ffi.new("WGPUCommandBuffer []", command_buffer_ids)
         # H: void f(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands)
         libf.wgpuQueueSubmit(self._internal, len(command_buffer_ids), c_command_buffers)
-        # WGPU destroys the resource when submitting. We follow this
-        # to avoid releasing a nonexistent object.
-        # for cb in command_buffers:
-        #     cb._internal = None
 
     def write_buffer(self, buffer, buffer_offset, data, data_offset=0, size=None):
         # We support anything that memoryview supports, i.e. anything


### PR DESCRIPTION
We've found that in a rather particular use-case, when run in a Docker container, the process would (on some machines) die hard with a segfault. This was traced back to the call to `wgpuDevicePoll` from the `GPUPipelineLayout._destroy()`.

This PR:
* [x] Removes the aforementioned calls from all destructors.
* [x] Instead the memtest does a call to `wgpuDevicePoll` to help wgpu clean its stuff up.
* [x] Removes some code where we set the `_internal` to None, preventing the calling of the destructor. In an earlier version this was necessary to prevent errors, but this case seems now correctly handled in wgpu.
* [x] The download script only downloads the release build of the library, since we never use the debug build anyway, saving quite some download-time.