### PR TITLE
Implement timestamp QuerySet

### DIFF
--- a/examples/compute_timestamps.py
+++ b/examples/compute_timestamps.py
@@ -1,6 +1,5 @@
 """
-Example compute shader that adds two arrays and measures the time it took
-for the GPU to perform the calculation using ComputePassTimestampWrites.
+A simple example to profile a compute pass using ComputePassTimestampWrites.
 """
 
 import wgpu

--- a/examples/compute_timestamps.py
+++ b/examples/compute_timestamps.py
@@ -1,0 +1,167 @@
+"""
+Example compute shader that adds two arrays and measures the time it took
+for the GPU to perform the calculation using ComputePassTimestampWrites.
+"""
+
+import wgpu
+
+"""
+Define the number of elements, global and local sizes.
+Change these and see how it affects performance.
+"""
+n = 512 * 512
+local_size = [32, 1, 1]
+global_size = [n // local_size[0], 1, 1]
+
+shader_source = f"""
+@group(0) @binding(0)
+var<storage,read> data1: array<i32>;
+
+@group(0) @binding(1)
+var<storage,read> data2: array<i32>;
+
+@group(0) @binding(2)
+var<storage,read_write> data3: array<i32>;
+
+@compute
+@workgroup_size({','.join(map(str, local_size))})
+fn main(@builtin(global_invocation_id) index: vec3<u32>) {{
+    let i: u32 = index.x;
+    data3[i] = data1[i] + data2[i];
+}}
+"""
+
+# Define two arrays
+data1 = memoryview(bytearray(n * 4)).cast("i")
+data2 = memoryview(bytearray(n * 4)).cast("i")
+
+# Initialize the arrays
+for i in range(n):
+    data1[i] = i
+
+for i in range(n):
+    data2[i] = i * 2
+
+adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
+
+# Request a device with the timestamp_query feature, so we can profile our computation
+device = adapter.request_device(required_features=[wgpu.FeatureName.timestamp_query])
+cshader = device.create_shader_module(code=shader_source)
+
+# Create buffer objects, input buffer is mapped.
+buffer1 = device.create_buffer_with_data(data=data1, usage=wgpu.BufferUsage.STORAGE)
+buffer2 = device.create_buffer_with_data(data=data2, usage=wgpu.BufferUsage.STORAGE)
+buffer3 = device.create_buffer(
+    size=data1.nbytes, usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.COPY_SRC
+)
+
+# Setup layout and bindings
+binding_layouts = [
+    {
+        "binding": 0,
+        "visibility": wgpu.ShaderStage.COMPUTE,
+        "buffer": {
+            "type": wgpu.BufferBindingType.read_only_storage,
+        },
+    },
+    {
+        "binding": 1,
+        "visibility": wgpu.ShaderStage.COMPUTE,
+        "buffer": {
+            "type": wgpu.BufferBindingType.read_only_storage,
+        },
+    },
+    {
+        "binding": 2,
+        "visibility": wgpu.ShaderStage.COMPUTE,
+        "buffer": {
+            "type": wgpu.BufferBindingType.storage,
+        },
+    },
+]
+bindings = [
+    {
+        "binding": 0,
+        "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
+    },
+    {
+        "binding": 1,
+        "resource": {"buffer": buffer2, "offset": 0, "size": buffer2.size},
+    },
+    {
+        "binding": 2,
+        "resource": {"buffer": buffer3, "offset": 0, "size": buffer3.size},
+    },
+]
+
+# Put everything together
+bind_group_layout = device.create_bind_group_layout(entries=binding_layouts)
+pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[bind_group_layout])
+bind_group = device.create_bind_group(layout=bind_group_layout, entries=bindings)
+
+# Create and run the pipeline
+compute_pipeline = device.create_compute_pipeline(
+    layout=pipeline_layout,
+    compute={"module": cshader, "entry_point": "main"},
+)
+
+"""
+Create a QuerySet to store the 'beginning_of_pass' and 'end_of_pass' timestamps.
+Set the 'count' parameter to 2, as this set will contain 2 timestamps.
+"""
+query_set = device.create_query_set(type=wgpu.QueryType.timestamp, count=2)
+command_encoder = device.create_command_encoder()
+
+# Pass our QuerySet and the indices into it, where the timestamps will be written.
+compute_pass = command_encoder.begin_compute_pass(
+    timestamp_writes={
+        "query_set": query_set,
+        "beginning_of_pass_write_index": 0,
+        "end_of_pass_write_index": 1,
+    }
+)
+
+"""
+Create the buffer to store our query results.
+Each timestamp is 8 bytes. We mark the buffer usage to be QUERY_RESOLVE,
+as we will use this buffer in a resolve_query_set call later.
+"""
+query_buf = device.create_buffer(
+    size=8 * query_set.count,
+    usage=wgpu.BufferUsage.QUERY_RESOLVE
+    | wgpu.BufferUsage.STORAGE
+    | wgpu.BufferUsage.COPY_SRC
+    | wgpu.BufferUsage.COPY_DST,
+)
+compute_pass.set_pipeline(compute_pipeline)
+compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 elements not used
+compute_pass.dispatch_workgroups(*global_size)  # x y z
+compute_pass.end()
+
+# Resolve our queries, and store the results in the destination buffer we created above.
+command_encoder.resolve_query_set(
+    query_set=query_set,
+    first_query=0,
+    query_count=2,
+    destination=query_buf,
+    destination_offset=0,
+)
+device.queue.submit([command_encoder.finish()])
+
+"""
+Read the query buffer to get the timestamps.
+Index 0: beginning timestamp
+Index 1: end timestamp
+"""
+timestamps = device.queue.read_buffer(query_buf).cast("Q").tolist()
+print(f"Adding two {n} sized arrays took {(timestamps[1]-timestamps[0])/1000} us")
+
+# Read result
+out = device.queue.read_buffer(buffer3).cast("i")
+result = out.tolist()
+
+# Calculate the result on the CPU for comparison
+result_cpu = [a + b for a, b in zip(data1, data2)]
+
+# Ensure results are the same
+assert result == result_cpu

--- a/tests/test_wgpu_native_query_set.py
+++ b/tests/test_wgpu_native_query_set.py
@@ -1,0 +1,151 @@
+import wgpu.utils
+
+from testutils import run_tests, can_use_wgpu_lib
+from pytest import mark
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_query_set():
+    shader_source = """
+    @group(0) @binding(0)
+    var<storage,read> data1: array<f32>;
+
+    @group(0) @binding(1)
+    var<storage,read_write> data2: array<f32>;
+
+    @compute
+    @workgroup_size(1)
+    fn main(@builtin(global_invocation_id) index: vec3<u32>) {
+        let i: u32 = index.x;
+        data2[i] = data1[i] / 2.0;
+    }
+    """
+
+    n = 1024
+    data1 = memoryview(bytearray(n * 4)).cast("f")
+
+    for i in range(n):
+        data1[i] = float(i)
+
+    adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
+    device = adapter.request_device(
+        required_features=[wgpu.FeatureName.timestamp_query]
+    )
+
+    assert repr(device).startswith("<wgpu.backends.wgpu_native.GPUDevice ")
+
+    cshader = device.create_shader_module(code=shader_source)
+
+    # Create buffer objects, input buffer is mapped.
+    buffer1 = device.create_buffer_with_data(data=data1, usage=wgpu.BufferUsage.STORAGE)
+    buffer2 = device.create_buffer(
+        size=data1.nbytes, usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.COPY_SRC
+    )
+
+    # Setup layout and bindings
+    binding_layouts = [
+        {
+            "binding": 0,
+            "visibility": wgpu.ShaderStage.COMPUTE,
+            "buffer": {
+                "type": wgpu.BufferBindingType.read_only_storage,
+            },
+        },
+        {
+            "binding": 1,
+            "visibility": wgpu.ShaderStage.COMPUTE,
+            "buffer": {
+                "type": wgpu.BufferBindingType.storage,
+            },
+        },
+    ]
+    bindings = [
+        {
+            "binding": 0,
+            "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
+        },
+        {
+            "binding": 1,
+            "resource": {"buffer": buffer2, "offset": 0, "size": buffer2.size},
+        },
+    ]
+
+    bind_group_layout = device.create_bind_group_layout(entries=binding_layouts)
+    pipeline_layout = device.create_pipeline_layout(
+        bind_group_layouts=[bind_group_layout]
+    )
+    bind_group = device.create_bind_group(layout=bind_group_layout, entries=bindings)
+
+    compute_pipeline = device.create_compute_pipeline(
+        layout=pipeline_layout,
+        compute={"module": cshader, "entry_point": "main"},
+    )
+
+    query_count = 2
+    query_type = wgpu.QueryType.timestamp
+    query_label = "div_by_2"
+    query_set = device.create_query_set(
+        label=query_label, type=query_type, count=query_count
+    )
+    assert query_set.count == query_count
+    assert query_set.type == query_type
+    assert query_set._device == device._internal
+    assert query_set.label == query_label
+
+    command_encoder = device.create_command_encoder()
+
+    compute_pass = command_encoder.begin_compute_pass(
+        timestamp_writes={
+            "query_set": query_set,
+            "beginning_of_pass_write_index": 0,
+            "end_of_pass_write_index": 1,
+        }
+    )
+
+    query_buf_size = 8 * query_set.count
+    query_usage = (
+        wgpu.BufferUsage.QUERY_RESOLVE
+        | wgpu.BufferUsage.STORAGE
+        | wgpu.BufferUsage.COPY_SRC
+        | wgpu.BufferUsage.COPY_DST
+    )
+    query_buf = device.create_buffer(
+        size=query_buf_size,
+        usage=query_usage,
+    )
+
+    assert query_buf.size == query_buf_size
+    assert query_buf.usage == query_usage
+
+    compute_pass.set_pipeline(compute_pipeline)
+    compute_pass.set_bind_group(
+        0, bind_group, [], 0, 999999
+    )  # last 2 elements not used
+    compute_pass.dispatch_workgroups(n, 1, 1)  # x y z
+    compute_pass.end()
+
+    command_encoder.resolve_query_set(
+        query_set=query_set,
+        first_query=0,
+        query_count=2,
+        destination=query_buf,
+        destination_offset=0,
+    )
+
+    device.queue.submit([command_encoder.finish()])
+    timestamps = device.queue.read_buffer(query_buf).cast("Q").tolist()
+    assert len(timestamps) == 2
+    assert timestamps[0] > 0 and timestamps[1] > 0 and timestamps[1] > timestamps[0]
+
+    out = device.queue.read_buffer(buffer2).cast("f")
+    result = out.tolist()
+
+    # Perform the same division on the CPU
+    result_cpu = [a / 2.0 for a in data1]
+
+    # Ensure results are the same
+    assert result == result_cpu
+
+
+if __name__ == "__main__":
+    run_tests(globals())

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -186,8 +186,9 @@ def test_release_pipeline_layout(n):
 
 @create_and_release
 def test_release_query_set(n):
-    # todo: implement this when we do support them
-    pytest.skip("Query set not implemented")
+    yield {}
+    for i in range(n):
+        yield DEVICE.create_query_set(type=wgpu.QueryType.occlusion, count=2)
 
 
 @create_and_release

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -2024,23 +2024,31 @@ class GPUCompilationInfo:
 
 
 class GPUQuerySet(GPUObjectBase):
-    """TODO"""
+    """An object to store the results of queries on passes.
 
-    # IDL: undefined destroy();
-    def destroy(self):
-        """Destroy the queryset."""
-        raise NotImplementedError()
+    You can obtain a query set object via :attr:`GPUDevice.create_query_set`.
+    """
+
+    def __init__(self, label, internal, device, type, count):
+        super().__init__(label, internal, device)
+        self._type = type
+        self._count = count
 
     # IDL: readonly attribute GPUQueryType type;
     @property
     def type(self):
         """The type of the queries managed by this queryset."""
-        raise NotImplementedError()
+        return self._type
 
     # IDL: readonly attribute GPUSize32Out count;
     @property
     def count(self):
-        """The type of the queries managed by this queryset."""
+        """The number of the queries managed by this queryset."""
+        return self._count
+
+    # IDL: undefined destroy();
+    def destroy(self):
+        """Destroy this QuerySet."""
         raise NotImplementedError()
 
 

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1618,11 +1618,13 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         # Note: also enable the coresponing memtest when implementing this!
 
     def create_query_set(self, *, label="", type: "enums.QueryType", count: int):
+        # H: nextInChain: WGPUChainedStruct *, label: char *, type: WGPUQueryType, count: int
         query_set_descriptor = new_struct_p(
             "WGPUQuerySetDescriptor *",
             label=to_c_label(label),
             type=type,
             count=count,
+            # not used: nextInChain
         )
 
         # H: WGPUQuerySet f(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1618,8 +1618,16 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         # Note: also enable the coresponing memtest when implementing this!
 
     def create_query_set(self, *, label="", type: "enums.QueryType", count: int):
-        raise NotImplementedError()
-        # Note: also enable the coresponing memtest when implementing this!
+        query_set_descriptor = new_struct_p(
+            "WGPUQuerySetDescriptor *",
+            label=to_c_label(label),
+            type=type,
+            count=count,
+        )
+
+        # H: WGPUQuerySet f(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor)
+        query_id = libf.wgpuDeviceCreateQuerySet(self._internal, query_set_descriptor)
+        return GPUQuerySet(label, query_id, self._internal, type, count)
 
     def _destroy(self):
         if self._queue is not None:
@@ -2147,13 +2155,23 @@ class GPUCommandEncoder(
     def begin_compute_pass(
         self, *, label="", timestamp_writes: "structs.ComputePassTimestampWrites" = None
     ):
+        timestamp_writes_struct = ffi.NULL
         if timestamp_writes is not None:
             check_struct("ComputePassTimestampWrites", timestamp_writes)
+            # H: querySet: WGPUQuerySet, beginningOfPassWriteIndex: int, endOfPassWriteIndex: int
+            timestamp_writes_struct = new_struct_p(
+                "WGPUComputePassTimestampWrites *",
+                querySet=timestamp_writes["query_set"]._internal,
+                beginningOfPassWriteIndex=timestamp_writes[
+                    "beginning_of_pass_write_index"
+                ],
+                endOfPassWriteIndex=timestamp_writes["end_of_pass_write_index"],
+            )
         # H: nextInChain: WGPUChainedStruct *, label: char *, timestampWrites: WGPUComputePassTimestampWrites *
         struct = new_struct_p(
             "WGPUComputePassDescriptor *",
             label=to_c_label(label),
-            # not used: timestampWrites
+            timestampWrites=timestamp_writes_struct
             # not used: nextInChain
         )
         # H: WGPUComputePassEncoder f(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor)
@@ -2495,7 +2513,15 @@ class GPUCommandEncoder(
     def resolve_query_set(
         self, query_set, first_query, query_count, destination, destination_offset
     ):
-        raise NotImplementedError()
+        # H: void f(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t firstQuery, uint32_t queryCount, WGPUBuffer destination, uint64_t destinationOffset)
+        libf.wgpuCommandEncoderResolveQuerySet(
+            self._internal,
+            query_set._internal,
+            int(first_query),
+            int(query_count),
+            destination._internal,
+            int(destination_offset),
+        )
 
     def _destroy(self):
         # Note that the native object gets destroyed on finish.
@@ -2841,13 +2867,14 @@ class GPURenderBundle(classes.GPURenderBundle, GPUObjectBase):
 
 
 class GPUQuerySet(classes.GPUQuerySet, GPUObjectBase):
-    pass
-
-    def destroy(self):
+    def _destroy(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUQuerySet querySet)
             libf.wgpuQuerySetRelease(internal)
+
+    def destroy(self):
+        self._destroy()
 
 
 # %% Subclasses that don't need anything else

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -29,6 +29,7 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 232 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 103 C function calls
-* Not using 99 C functions
-* Validated 73 C structs
+* Validated 105 C function calls
+* Not using 97 C functions
+* Notice: made a struct multiline. Rerun codegen to validate the struct.
+* Validated 75 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -16,9 +16,9 @@
 * Diffs for GPUTexture: add size
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 111 methods, 43 properties
+* Validated 37 classes, 112 methods, 43 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 106 methods, 0 properties
+* Validated 37 classes, 107 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field TextureFormat.rgb10a2uint missing in wgpu.h
 * Enum field StorageTextureAccess.read-only missing in wgpu.h
@@ -31,5 +31,4 @@
 * Wrote 232 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
 * Validated 105 C function calls
 * Not using 97 C functions
-* Notice: made a struct multiline. Rerun codegen to validate the struct.
 * Validated 75 C structs


### PR DESCRIPTION
This PR adds the following functionality

- `device.create_query_set`
- `timestamp_writes` support in `command_encoder.begin_compute_pass`
- `command_encoder.resolve_query_set`
- add a new example (`examples/compute_timestamps.py`) that demonstrates the usage of the newly added features

Tests added

- `tests_mem/test_objects.py` to check release of `QuerySet`s
- `tests/test_wgpu_native_query_set.py` to test the newly added functionality