### PR TITLE
List projects using wgpu-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ well with Asyncio or Trio.
 
 This code is distributed under the 2-clause BSD license.
 
+## Projects using `wgpu-py`
+
+* [pygfx](https://github.com/pygfx/pygfx) - A python render engine running on wgpu.
+* [shadertoy](https://github.com/pygfx/shadertoy) - Shadertoy implementation using wgpu-py.
+* [tinygrad](https://github.com/tinygrad/tinygrad) - deep learning framework
+* [fastplotlib](https://github.com/fastplotlib/fastplotlib) - A fast plotting library
+* [xdsl](https://github.com/xdslproject/xdsl) - A Python Compiler Design Toolkit (optional wgpu interpreter)
 
 ## Developers
 


### PR DESCRIPTION
This came up during #455 

I used a [search](https://github.com/search?q=%22import+wgpu%22+path%3A*.py&type=code&) and [dependands](https://github.com/pygfx/pygfx/network/dependents) to find some projects that use `wgpu-py`