### PR TITLE
Enable manual CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       run: |
           python -m pip install --upgrade pip wheel setuptools twine
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.16.2
+      uses: pypa/cibuildwheel@v2.16
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
         CIBW_ARCHS_LINUX: x86_64

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -1,6 +1,7 @@
 """
 This example renders a simple textured rotating cube.
 """
+
 # test_example = true
 
 import time

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,6 +1,7 @@
 """
 A simple example to demonstrate events.
 """
+
 from wgpu.gui.auto import WgpuCanvas, run, call_later
 
 

--- a/examples/triangle_auto.py
+++ b/examples/triangle_auto.py
@@ -1,6 +1,7 @@
 """
 Import the viz from triangle.py and run it using the auto-gui.
 """
+
 # test_example = true
 
 import sys

--- a/examples/triangle_qt.py
+++ b/examples/triangle_qt.py
@@ -4,6 +4,7 @@ Works with either PySide6, PyQt6, PyQt5 or PySide2.
 
 # run_example = false
 """
+
 import importlib
 
 # For the sake of making this example Just Work, we try multiple QT libs

--- a/examples/triangle_qt_embed.py
+++ b/examples/triangle_qt_embed.py
@@ -4,6 +4,7 @@ If needed, change the PySide6 import to e.g. PyQt6, PyQt5, or PySide2.
 
 # run_example = false
 """
+
 import importlib
 
 # For the sake of making this example Just Work, we try multiple QT libs

--- a/examples/triangle_wx.py
+++ b/examples/triangle_wx.py
@@ -1,6 +1,7 @@
 """
 Import the viz from triangle.py and run it in a wxPython window.
 """
+
 # run_example = false
 
 import wx

--- a/examples/triangle_wx_embed.py
+++ b/examples/triangle_wx_embed.py
@@ -1,6 +1,7 @@
 """
 An example demonstrating a wx app with a wgpu viz inside.
 """
+
 # run_example = false
 
 import wx

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -2,7 +2,6 @@
 assumptions here.
 """
 
-
 import ctypes
 import numpy as np
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,7 +2,6 @@
 This tests the diagnostics logic itself. It does not do a tests that *uses* the diagnostics.
 """
 
-
 import wgpu
 from wgpu import _diagnostics
 from wgpu._diagnostics import (

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -14,7 +14,6 @@ new methods and checks plus annotates all structs and C api calls.
 Read the codegen/readme.md for more information.
 """
 
-
 import os
 import ctypes
 import logging
@@ -2173,7 +2172,7 @@ class GPUCommandEncoder(
         struct = new_struct_p(
             "WGPUComputePassDescriptor *",
             label=to_c_label(label),
-            timestampWrites=timestamp_writes_struct
+            timestampWrites=timestamp_writes_struct,
             # not used: nextInChain
         )
         # H: WGPUComputePassEncoder f(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor)

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -7,7 +7,6 @@ On Linux, install the glfw lib using ``sudo apt install libglfw3``,
 or ``sudo apt install libglfw3-wayland`` when using Wayland.
 """
 
-
 import os
 import sys
 import time


### PR DESCRIPTION
When CI errors in a PR, it's sometimes convenient to trigger CI for `main` to see if its due to changes in the pr or something external that changed. 