### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+Describe the steps to reproduce the behavior. If possible, please provide a minimal reproducible example (an example that is complete but as small as possible to still demonstrate the issue).
+
+### Observed behavior
+A description of what happens and how that differs from expectations.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Your environment
+Details about the environment this issue was observed on, like OS, Python version, wgpu-py version.
+You can also include (the relevant sections of) the result of `wgpu.diagnostics.print_report()`.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,10 @@
+---
+name: Other
+about: For other issues such as questions and feature requests.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
With #462 you now get a choice when you create a new issue, but that choice only includes the "update wgpu" template 😅 . This PR adds other templates for bug reports, and a generic issue.