### PR TITLE
Finetune behavior for bare canvas usage

### DIFF
--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -650,10 +650,9 @@ class GPUCanvasContext(classes.GPUCanvasContext):
 
     def present(self):
         if not self._texture:
-            msg = "present() is called without a preceeding call to "
-            msg += "get_current_texture(). Note that present() is usually "
-            msg += "called automatically after the draw function returns."
-            raise RuntimeError(msg)
+            # Log error but don't raise exception
+            msg = "No texture to present, missing call to get_current_texture()?"
+            logger.error(msg)
         else:
             # Present the texture, then destroy it
             # H: void f(WGPUSurface surface)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -650,9 +650,9 @@ class GPUCanvasContext(classes.GPUCanvasContext):
 
     def present(self):
         if not self._texture:
-            # Log error but don't raise exception
+            # Log warning but don't raise exception
             msg = "No texture to present, missing call to get_current_texture()?"
-            logger.error(msg)
+            logger.warning(msg)
         else:
             # Present the texture, then destroy it
             # H: void f(WGPUSurface surface)

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -126,9 +126,13 @@ class WgpuCanvasInterface:
         if self._canvas_context is None:
             # Get the active wgpu backend module
             backend_module = sys.modules["wgpu"].gpu.__module__
+            if backend_module == "wgpu._classes":
+                raise RuntimeError(
+                    "A backend must be selected (e.g. with request_adapter()) before canvas.get_context() can be called."
+                )
             # Instantiate the context
-            PC = sys.modules[backend_module].GPUCanvasContext  # noqa: N806
-            self._canvas_context = PC(self)
+            CC = sys.modules[backend_module].GPUCanvasContext  # noqa: N806
+            self._canvas_context = CC(self)
         return self._canvas_context
 
 


### PR DESCRIPTION
Close #439

This should make things easier when building up code from scratch, or for people goofing around with canvases 😃

This works fine, and is tested for.
```py
from wgpu.gui.auto import WgpuCanvas, run
canvas = WgpuCanvas()
run()
```

This errors to prevent the base context class from being used, which results in confusing NotImplementeError later.
```py
from wgpu.gui.auto import WgpuCanvas, run
canvas = WgpuCanvas()
present_context = canvas.get_context()  # <--- raises exception
```

This previously raised an exception, but now logs a warning `No texture to present, missing call to get_current_texture()?`, which is a bit friendlier. We could technically also ignore the situation, but it does capture cases where a user uses old/wrong textures to render to for some reason.

```py
from wgpu.gui.auto import WgpuCanvas, run
import wgpu

canvas = WgpuCanvas()
adapter = wgpu.gpu.request_adapter()
device = adapter.request_device()

present_context = canvas.get_context()
render_texture_format = present_context.get_preferred_format(device.adapter)
present_context.configure(device=device, format=render_texture_format)

# Not setting an animate function that requests a texture on each draw.
run()
```
