### PR TITLE
Tweaks to diagnostics

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -39,7 +39,7 @@ To inspect (for example) the total buffer usage:
     :members:
 
 
-.. autoclass:: wgpu._diagnostics.Diagnostics
+.. autoclass:: wgpu.DiagnosticsBase
     :members:
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,7 +6,7 @@ import wgpu
 from wgpu import _diagnostics
 from wgpu._diagnostics import (
     DiagnosticsRoot,
-    Diagnostics,
+    DiagnosticsBase,
     ObjectTracker,
     dict_to_text,
     int_repr,
@@ -29,7 +29,7 @@ class CustomDiagnosticsRoot(DiagnosticsRoot):
         _diagnostics.diagnostics = wgpu.diagnostics
 
 
-class CustomDiagnostics(Diagnostics):
+class CustomDiagnostics(DiagnosticsBase):
     def __init__(self, name):
         super().__init__(name)
         self.tracker = ObjectTracker()

--- a/wgpu/__init__.py
+++ b/wgpu/__init__.py
@@ -3,7 +3,7 @@ The wgpu library is a Python implementation of WebGPU.
 """
 
 from ._coreutils import logger  # noqa: F401,F403
-from ._diagnostics import diagnostics  # noqa: F401,F403
+from ._diagnostics import diagnostics, DiagnosticsBase  # noqa: F401,F403
 from .flags import *  # noqa: F401,F403
 from .enums import *  # noqa: F401,F403
 from .classes import *  # noqa: F401,F403

--- a/wgpu/backends/wgpu_native/_helpers.py
+++ b/wgpu/backends/wgpu_native/_helpers.py
@@ -6,7 +6,7 @@ import sys
 import ctypes
 
 from ._ffi import ffi, lib
-from ..._diagnostics import Diagnostics
+from ..._diagnostics import DiagnosticsBase
 from ...classes import (
     GPUError,
     GPUOutOfMemoryError,
@@ -357,7 +357,7 @@ def generate_report():
     return report
 
 
-class WgpuNativeCountsDiagnostics(Diagnostics):
+class WgpuNativeCountsDiagnostics(DiagnosticsBase):
     def get_subscript(self):
         text = ""
         text += "    * The a, k, r, e are allocated, kept, released, and error, respectively.\n"


### PR DESCRIPTION
While hooking pygfx diagnostics on wgpu's nice system, I ran into a few small issues that this pr fixes:

* The `DiagnosticsBase` is now public API, so it can be subclasses without accessing `wgpu._diagnostics.Diagnostics`.
* Bools are now rendered using a checkmark/dash instead of 1 or 0.
* Better handling of very large ints (fall back to scientific notation).
* Check that a diagnostics name is an identifier, so that it can be reached via e.g. `wgpu.diagnostics.pygfx_caches`.

----

```
██ system:

             platform:  Windows-11-10.0.22631-SP0
python_implementation:  CPython
               python:  3.12.1

██ versions:

    wgpu:  0.14.0
    cffi:  1.16.0
    glfw:  2.6.5
   numpy:  1.26.4
   pygfx:  0.1.17
pylinalg:  0.4.1

██ wgpu_native_info:

expected_version:  0.19.1.1
     lib_version:  0.19.1.1
        lib_path:  .\resources\wgpu_native-release.dll

██ object_counts:

                      count  resource_mem

            Adapter:      1
          BindGroup:      3
    BindGroupLayout:      3
             Buffer:      9         6.32K
      CanvasContext:      1
      CommandBuffer:      0
     CommandEncoder:      0
 ComputePassEncoder:      0
    ComputePipeline:      0
             Device:      1
     PipelineLayout:      0
           QuerySet:      0
              Queue:      1
       RenderBundle:      0
RenderBundleEncoder:      0
  RenderPassEncoder:      0
     RenderPipeline:      3
            Sampler:      0
       ShaderModule:      3
            Texture:      3         19.6M
        TextureView:      3

              total:     31         19.6M

██ wgpu_native_counts:

                  count    mem  backend   a  k  r  e  el_size

        Adapter:      1  1.98K   vulkan:  1  1  0  0    1.98K
      BindGroup:      3  1.10K   vulkan:  3  3  0  0      368
BindGroupLayout:      3    960   vulkan:  5  3  2  0      320
         Buffer:      9  2.66K   vulkan:  9  9  0  0      296
  CanvasContext:      1    160            1  1  0  0      160
  CommandBuffer:      1  1.25K   vulkan:  0  0  0  1    1.25K
ComputePipeline:      0      0   vulkan:  0  0  0  0      288
         Device:      1  11.8K   vulkan:  1  1  0  0    11.8K
 PipelineLayout:      0      0   vulkan:  2  0  2  0      200
       QuerySet:      0      0   vulkan:  0  0  0  0       80
          Queue:      1    184   vulkan:  1  1  0  0      184
   RenderBundle:      0      0   vulkan:  0  0  0  0      848
 RenderPipeline:      3  1.68K   vulkan:  3  3  0  0      560
        Sampler:      0      0   vulkan:  0  0  0  0       80
   ShaderModule:      3  2.42K   vulkan:  3  3  0  0      808
        Texture:      3  2.47K   vulkan:  4  3  2  0      824
    TextureView:      3    744   vulkan:  4  3  2  0      248

          total:     32  27.4K

    * The a, k, r, e are allocated, kept, released, and error, respectively.
    * Reported memory does not include buffer/texture data.

██ pygfx_adapter_info:

      vendor:  Intel Corporation
architecture:
      device:  Intel(R) UHD Graphics 730
 description:  Intel driver
adapter_type:  IntegratedGPU
backend_type:  Vulkan

██ pygfx_features:

                                       adapter  device

                  bgra8unorm-storage:        ✓       -
               depth32float-stencil8:        ✓       -
                  depth-clip-control:        ✓       -
                  float32-filterable:        ✓       ✓
             indirect-first-instance:        ✓       -
            rg11b10ufloat-renderable:        ✓       -
                          shader-f16:        ✓       -
            texture-compression-astc:        ✓       -
              texture-compression-bc:        ✓       -
            texture-compression-etc2:        ✓       -
                     timestamp-query:        ✓       -
                   MultiDrawIndirect:        ✓       -
              MultiDrawIndirectCount:        ✓       -
                       PushConstants:        ✓       -
TextureAdapterSpecificFormatFeatures:        ✓       -
               VertexWritableStorage:        ✓       -

██ pygfx_limits:

                                                  adapter  device

                                max_bind_groups:        8       8
            max_bind_groups_plus_vertex_buffers:        0       0
                    max_bindings_per_bind_group:    1.00K   1.00K
                                max_buffer_size:  18.4E18    268M
          max_color_attachment_bytes_per_sample:        0       0
                          max_color_attachments:        0       0
          max_compute_invocations_per_workgroup:    1.02K   1.02K
                   max_compute_workgroup_size_x:    1.02K   1.02K
                   max_compute_workgroup_size_y:    1.02K   1.02K
                   max_compute_workgroup_size_z:       64      64
             max_compute_workgroup_storage_size:    32.7K   32.7K
           max_compute_workgroups_per_dimension:    65.5K   65.5K
max_dynamic_storage_buffers_per_pipeline_layout:       16      16
max_dynamic_uniform_buffers_per_pipeline_layout:       16      16
              max_inter_stage_shader_components:      128     128
               max_inter_stage_shader_variables:        0       0
          max_sampled_textures_per_shader_stage:      200     200
                  max_samplers_per_shader_stage:       64      64
                max_storage_buffer_binding_size:    1.07G   1.07G
           max_storage_buffers_per_shader_stage:      200     200
          max_storage_textures_per_shader_stage:       16      16
                       max_texture_array_layers:    2.04K   2.04K
                        max_texture_dimension1d:    16.3K   16.3K
                        max_texture_dimension2d:    16.3K   16.3K
                        max_texture_dimension3d:    2.04K   2.04K
                max_uniform_buffer_binding_size:     134M    134M
           max_uniform_buffers_per_shader_stage:      200     200
                          max_vertex_attributes:       32      32
                 max_vertex_buffer_array_stride:    4.09K   4.09K
                             max_vertex_buffers:       16      16
            min_storage_buffer_offset_alignment:       64      64
            min_uniform_buffer_offset_alignment:       64      64

██ pygfx_caches:

                    count  hits  misses

full_quad_objects:      1     0       2
 mipmap_pipelines:      0     0       0
          layouts:      1     0       2
         bindings:      1     0       1
   shader_modules:      2     0       2
        pipelines:      2     0       2
 shadow_pipelines:      0     0       0

██ pygfx_resources:

Texture:  6
 Buffer:  10
```