### PR TITLE
Wayland support by forcing x11

### DIFF
--- a/docs/start.rst
+++ b/docs/start.rst
@@ -65,9 +65,9 @@ On MacOS you need at least 10.13 (High Sierra) to have Metal/Vulkan support.
 Linux
 +++++
 
-On Linux, it's advisable to install the proprietary drivers of your GPU
-(if you have a dedicated GPU). You may need to ``apt install
-mesa-vulkan-drivers``. Wgpu-py works with both X and Wayland.
+On Linux, it's advisable to install the proprietary drivers of your GPU (if you
+have a dedicated GPU). You may need to ``apt install mesa-vulkan-drivers``. On
+Wayland, wgpu-py requires XWayland (available by default on most distributions).
 
 Binary wheels for Linux are only available for **manylinux_2_24**.
 This means that the installation requires ``pip >= 20.3``, and you need

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -67,8 +67,7 @@ Linux
 
 On Linux, it's advisable to install the proprietary drivers of your GPU
 (if you have a dedicated GPU). You may need to ``apt install
-mesa-vulkan-drivers``. Wayland support is currently broken (we could use
-a hand to fix this).
+mesa-vulkan-drivers``. Wgpu-py works with both X and Wayland.
 
 Binary wheels for Linux are only available for **manylinux_2_24**.
 This means that the installation requires ``pip >= 20.3``, and you need

--- a/examples/triangle_subprocess.py
+++ b/examples/triangle_subprocess.py
@@ -12,6 +12,7 @@ process. Just a proof of concept, this is far from perfect yet:
 """
 
 import sys
+import json
 import time
 import subprocess
 
@@ -23,14 +24,14 @@ from triangle import main
 
 code = """
 import sys
+import json
 from PySide6 import QtWidgets  # Use either PySide6 or PyQt6
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])
 canvas = WgpuCanvas(title="wgpu triangle in Qt subprocess")
 
-print(canvas.get_window_id())
-#print(canvas.get_display_id())
+print(json.dumps(canvas.get_surface_info()))
 print(canvas.get_physical_size())
 sys.stdout.flush()
 
@@ -41,15 +42,15 @@ app.exec_()
 class ProxyCanvas(WgpuCanvasBase):
     def __init__(self):
         super().__init__()
-        self._window_id = int(p.stdout.readline().decode())
+        self._surface_info = json.loads(p.stdout.readline().decode())
         self._psize = tuple(
             int(x) for x in p.stdout.readline().decode().strip().strip("()").split(",")
         )
         print(self._psize)
         time.sleep(0.2)
 
-    def get_window_id(self):
-        return self._window_id
+    def get_surface_info(self):
+        return self._surface_info
 
     def get_physical_size(self):
         return self._psize

--- a/tests/test_gui_base.py
+++ b/tests/test_gui_base.py
@@ -248,7 +248,7 @@ def test_autogui_mixin():
 
 
 def test_weakbind():
-    weakbind = wgpu.gui.base.weakbind
+    weakbind = wgpu.gui._gui_utils.weakbind
 
     xx = []
 

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -172,22 +172,33 @@ def test_glfw_canvas_render_custom_canvas():
             self.window = glfw.create_window(300, 200, "canvas", None, None)
             self._present_context = None
 
-        def get_window_id(self):
+        def get_surface_info(self):
             if sys.platform.startswith("win"):
-                return int(glfw.get_win32_window(self.window))
+                return {
+                    "platform": "windows",
+                    "window": int(glfw.get_win32_window(self._window)),
+                }
             elif sys.platform.startswith("darwin"):
-                return int(glfw.get_cocoa_window(self.window))
+                return {
+                    "platform": "cocoa",
+                    "window": int(glfw.get_cocoa_window(self._window)),
+                }
             elif sys.platform.startswith("linux"):
-                is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+                is_wayland = hasattr("get_wayland_display", glfw)
                 if is_wayland:
-                    return int(glfw.get_wayland_window(self.window))
+                    return {
+                        "platform": "wayland",
+                        "window": int(glfw.get_wayland_window(self._window)),
+                        "display": int(glfw.get_wayland_display()),
+                    }
                 else:
-                    return int(glfw.get_x11_window(self.window))
+                    return {
+                        "platform": "x11",
+                        "window": int(glfw.get_x11_window(self._window)),
+                        "display": int(glfw.get_x11_display()),
+                    }
             else:
-                raise RuntimeError(f"Cannot get GLFW window id on {sys.platform}.")
-
-        def get_display_id(self):
-            return wgpu.WgpuCanvasInterface.get_display_id(self)
+                raise RuntimeError(f"Cannot get GLFW surafce info on {sys.platform}.")
 
         def get_physical_size(self):
             psize = glfw.get_framebuffer_size(self.window)

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -175,25 +175,25 @@ def test_glfw_canvas_render_custom_canvas():
             if sys.platform.startswith("win"):
                 return {
                     "platform": "windows",
-                    "window": int(glfw.get_win32_window(self._window)),
+                    "window": int(glfw.get_win32_window(self.window)),
                 }
             elif sys.platform.startswith("darwin"):
                 return {
                     "platform": "cocoa",
-                    "window": int(glfw.get_cocoa_window(self._window)),
+                    "window": int(glfw.get_cocoa_window(self.window)),
                 }
             elif sys.platform.startswith("linux"):
-                is_wayland = hasattr("get_wayland_display", glfw)
+                is_wayland = hasattr(glfw, "get_wayland_display")
                 if is_wayland:
                     return {
                         "platform": "wayland",
-                        "window": int(glfw.get_wayland_window(self._window)),
+                        "window": int(glfw.get_wayland_window(self.window)),
                         "display": int(glfw.get_wayland_display()),
                     }
                 else:
                     return {
                         "platform": "x11",
-                        "window": int(glfw.get_x11_window(self._window)),
+                        "window": int(glfw.get_x11_window(self.window)),
                         "display": int(glfw.get_x11_display()),
                     }
             else:

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -3,7 +3,6 @@ Test the canvas, and parts of the rendering that involves a canvas,
 like the canvas context and surface texture.
 """
 
-import os
 import sys
 import time
 import weakref

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -198,8 +198,7 @@ class GPU(classes.GPU):
         # able to create a surface texture for it (from this adapter).
         surface_id = ffi.NULL
         if canvas is not None:
-            window_id = canvas.get_window_id()
-            if window_id:  # e.g. could be an off-screen canvas
+            if canvas.get_surface_info():  # e.g. could be an off-screen canvas
                 surface_id = canvas.get_context()._get_surface_id()
 
         # ----- Select backend

--- a/wgpu/backends/wgpu_native/_helpers.py
+++ b/wgpu/backends/wgpu_native/_helpers.py
@@ -1,7 +1,6 @@
 """Utilities used in the wgpu-native backend.
 """
 
-import os
 import sys
 import ctypes
 
@@ -98,6 +97,7 @@ def get_surface_id_from_canvas(canvas):
     """
 
     surface_info = canvas.get_surface_info()
+    print(surface_info)
 
     # todo: cache the surface id for each canvas?
 
@@ -165,7 +165,7 @@ def get_surface_id_from_canvas(canvas):
             struct.display = ffi.cast("void *", surface_info["display"])
             struct.window = int(surface_info["window"])
             struct.chain.sType = lib.WGPUSType_SurfaceDescriptorFromXlibWindow
-        elif platform == "wayland"
+        elif platform == "wayland":
             struct = ffi.new("WGPUSurfaceDescriptorFromWaylandSurface *")
             struct.display = ffi.cast("void *", surface_info["display"])
             struct.surface = ffi.cast("void *", surface_info["window"])

--- a/wgpu/gui/__init__.py
+++ b/wgpu/gui/__init__.py
@@ -2,6 +2,7 @@
 Code to provide a canvas to render to.
 """
 
+from . import _gui_utils  # noqa: F401
 from .base import WgpuCanvasInterface, WgpuCanvasBase, WgpuAutoGui  # noqa: F401
 from .offscreen import WgpuOffscreenCanvasBase  # noqa: F401
 

--- a/wgpu/gui/_gui_utils.py
+++ b/wgpu/gui/_gui_utils.py
@@ -69,6 +69,8 @@ if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
         os.environ["PYGLFW_LIBRARY_VARIANT"] = "x11"
     # Force Qt to use X11. Qt is more flexible - it ok if e.g. PySide6 is already imported.
     os.environ["QT_QPA_PLATFORM"] = "xcb"
+    # Force wx to use X11, probably.
+    os.environ["GDK_BACKEND"] = "x11"
 
 
 _x11_display = None

--- a/wgpu/gui/_gui_utils.py
+++ b/wgpu/gui/_gui_utils.py
@@ -1,0 +1,55 @@
+""" Private gui utilities.
+"""
+
+import os
+import sys
+import ctypes.util
+import logging
+
+
+logger = logging.getLogger("wgpu")
+
+
+SYSTEM_IS_WAYLAND = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+
+if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
+    # Force glfw to use X11. Note that this does not work if glfw is already imported.
+    if "glfw" not in sys.modules:
+        os.environ["PYGLFW_LIBRARY_VARIANT"] = "x11"
+    # Force Qt to use X11. Qt is more flexible - it ok if e.g. PySide6 is already imported.
+    os.environ["QT_QPA_PLATFORM"] = "xcb"
+
+
+_x11_display = None
+
+
+def get_alt_x11_display():
+    """Get (the pointer to) a process-global x11 display instance."""
+    # Ideally we'd get the real display object used by the GUI toolkit.
+    # But this is not always possible. In that case, using an alt display
+    # object can be used.
+    global _x11_display
+    assert sys.platform.startswith("linux")
+    if _x11_display is None:
+        x11 = ctypes.CDLL(ctypes.util.find_library("X11"))
+        x11.XOpenDisplay.restype = ctypes.c_void_p
+        _x11_display = x11.XOpenDisplay(None)
+    return _x11_display
+
+
+_wayland_display = None
+
+
+def get_alt_wayland_display():
+    """Get (the pointer to) a process-global Wayland display instance."""
+    # Ideally we'd get the real display object used by the GUI toolkit.
+    # This creates a global object, similar to what we do for X11.
+    # Unfortunately, this segfaults, so it looks like the real display object
+    # is needed? Leaving this here for reference.
+    global _wayland_display
+    assert sys.platform.startswith("linux")
+    if _wayland_display is None:
+        wl = ctypes.CDLL(ctypes.util.find_library("wayland-client"))
+        wl.wl_display_connect.restype = ctypes.c_void_p
+        _wayland_display = wl.wl_display_connect(None)
+    return _wayland_display

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -1,10 +1,8 @@
-import os
 import sys
 import time
 import weakref
 import logging
 from contextlib import contextmanager
-import ctypes.util
 from collections import defaultdict
 
 from .._coreutils import error_message_hash
@@ -56,41 +54,6 @@ def weakbind(method):
 
     proxy.__name__ = class_func.__name__
     return proxy
-
-
-_x11_display = None
-
-
-def get_alt_x11_display():
-    """Get (the pointer to) a process-global x11 display instance."""
-    # Ideally we'd get the real display object used by the GUI toolkit.
-    # But this is not always possible. In that case, using an alt display
-    # object can be used.
-    global _x11_display
-    assert sys.platform.startswith("linux")
-    if _x11_display is None:
-        x11 = ctypes.CDLL(ctypes.util.find_library("X11"))
-        x11.XOpenDisplay.restype = ctypes.c_void_p
-        _x11_display = x11.XOpenDisplay(None)
-    return _x11_display
-
-
-_wayland_display = None
-
-
-def get_alt_wayland_display():
-    """Get (the pointer to) a process-global Wayland display instance."""
-    # Ideally we'd get the real display object used by the GUI toolkit.
-    # This creates a global object, similar to what we do for X11.
-    # Unfortunately, this segfaults, so it looks like the real display object
-    # is needed? Leaving this here for reference.
-    global _wayland_display
-    assert sys.platform.startswith("linux")
-    if _wayland_display is None:
-        wl = ctypes.CDLL(ctypes.util.find_library("wayland-client"))
-        wl.wl_display_connect.restype = ctypes.c_void_p
-        _wayland_display = w.wl_display_connect(None)
-    return _wayland_display
 
 
 class WgpuCanvasInterface:

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -58,6 +58,41 @@ def weakbind(method):
     return proxy
 
 
+_x11_display = None
+
+
+def get_alt_x11_display():
+    """Get (the pointer to) a process-global x11 display instance."""
+    # Ideally we'd get the real display object used by the GUI toolkit.
+    # But this is not always possible. In that case, using an alt display
+    # object can be used.
+    global _x11_display
+    assert sys.platform.startswith("linux")
+    if _x11_display is None:
+        x11 = ctypes.CDLL(ctypes.util.find_library("X11"))
+        x11.XOpenDisplay.restype = ctypes.c_void_p
+        _x11_display = x11.XOpenDisplay(None)
+    return _x11_display
+
+
+_wayland_display = None
+
+
+def get_alt_wayland_display():
+    """Get (the pointer to) a process-global Wayland display instance."""
+    # Ideally we'd get the real display object used by the GUI toolkit.
+    # This creates a global object, similar to what we do for X11.
+    # Unfortunately, this segfaults, so it looks like the real display object
+    # is needed? Leaving this here for reference.
+    global _wayland_display
+    assert sys.platform.startswith("linux")
+    if _wayland_display is None:
+        wl = ctypes.CDLL(ctypes.util.find_library("wayland-client"))
+        wl.wl_display_connect.restype = ctypes.c_void_p
+        _wayland_display = w.wl_display_connect(None)
+    return _wayland_display
+
+
 class WgpuCanvasInterface:
     """The minimal interface to be a valid canvas.
 
@@ -72,39 +107,16 @@ class WgpuCanvasInterface:
         super().__init__(*args, **kwargs)
         self._canvas_context = None
 
-    def get_window_id(self):
-        """Get the native window id.
+    def get_surface_info(self):
+        """Get information about the native window / surface.
 
-        This is used to obtain a surface id, so that wgpu can render
-        to the region of the screen occupied by the canvas.
+        This is used to obtain a surface id, so that wgpu can render to the
+        region of the screen occupied by the canvas. Should return None for
+        offscreen canvases. Otherwise, this should return a dict with a "window"
+        field. On Linux the dict should contain more fields, see the existing
+        implementations for reference.
         """
-        raise NotImplementedError()
-
-    def get_display_id(self):
-        """Get the native display id (Linux only).
-
-        On Linux this is needed in addition to the window id to obtain
-        a surface id. The default implementation calls into the X11 lib
-        to get the display id.
-        """
-        # Re-use to avoid creating loads of id's
-        if getattr(self, "_display_id", None) is not None:
-            return self._display_id
-
-        if sys.platform.startswith("linux"):
-            is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
-            if is_wayland:
-                raise NotImplementedError(
-                    f"Cannot (yet) get display id on {self.__class__.__name__}."
-                )
-            else:
-                x11 = ctypes.CDLL(ctypes.util.find_library("X11"))
-                x11.XOpenDisplay.restype = ctypes.c_void_p
-                self._display_id = x11.XOpenDisplay(None)
-        else:
-            raise RuntimeError(f"Cannot get display id on {sys.platform}.")
-
-        return self._display_id
+        return None
 
     def get_physical_size(self):
         """Get the physical size of the canvas in integer pixels."""

--- a/wgpu/gui/base.py
+++ b/wgpu/gui/base.py
@@ -1,59 +1,8 @@
 import sys
 import time
-import weakref
-import logging
-from contextlib import contextmanager
 from collections import defaultdict
 
-from .._coreutils import error_message_hash
-
-logger = logging.getLogger("wgpu")
-
-err_hashes = {}
-
-
-@contextmanager
-def log_exception(kind):
-    """Context manager to log any exceptions, but only log a one-liner
-    for subsequent occurances of the same error to avoid spamming by
-    repeating errors in e.g. a draw function or event callback.
-    """
-    try:
-        yield
-    except Exception as err:
-        # Store exc info for postmortem debugging
-        exc_info = list(sys.exc_info())
-        exc_info[2] = exc_info[2].tb_next  # skip *this* function
-        sys.last_type, sys.last_value, sys.last_traceback = exc_info
-        # Show traceback, or a one-line summary
-        msg = str(err)
-        msgh = error_message_hash(msg)
-        if msgh not in err_hashes:
-            # Provide the exception, so the default logger prints a stacktrace.
-            # IDE's can get the exception from the root logger for PM debugging.
-            err_hashes[msgh] = 1
-            logger.error(kind, exc_info=err)
-        else:
-            # We've seen this message before, return a one-liner instead.
-            err_hashes[msgh] = count = err_hashes[msgh] + 1
-            msg = kind + ": " + msg.split("\n")[0].strip()
-            msg = msg if len(msg) <= 70 else msg[:69] + "…"
-            logger.error(msg + f" ({count})")
-
-
-def weakbind(method):
-    """Replace a bound method with a callable object that stores the `self` using a weakref."""
-    ref = weakref.ref(method.__self__)
-    class_func = method.__func__
-    del method
-
-    def proxy(*args, **kwargs):
-        self = ref()
-        if self is not None:
-            return class_func(self, *args, **kwargs)
-
-    proxy.__name__ = class_func.__name__
-    return proxy
+from ._gui_utils import log_exception
 
 
 class WgpuCanvasInterface:

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -14,8 +14,8 @@ import asyncio
 
 import glfw
 
-from .base import WgpuCanvasBase, WgpuAutoGui, weakbind
-from ._gui_utils import SYSTEM_IS_WAYLAND, logger
+from .base import WgpuCanvasBase, WgpuAutoGui
+from ._gui_utils import SYSTEM_IS_WAYLAND, weakbind, logger
 
 
 # Make sure that glfw is new enough

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -13,6 +13,13 @@ import time
 import weakref
 import asyncio
 
+# os.environ["PYGLFW_LIBRARY_VARIANT"] = "x11"
+# os.environ["XDG_SESSION_TYPE"] = "x11"
+
+# os.environ["PYGLFW_LIBRARY"] = (
+#     "/home/almar/.pyenv/versions/3.12.1/lib/python3.12/site-packages/glfw/x11/libglfw.so"
+# )
+
 import glfw
 
 from .base import WgpuCanvasBase, WgpuAutoGui, weakbind
@@ -27,11 +34,18 @@ if glfw_version_info < (1, 9):
 is_wayland = False
 if sys.platform.startswith("linux"):
     is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
-    if is_wayland and not hasattr(glfw, "get_wayland_window"):
-        raise RuntimeError(
-            "We're on Wayland but Wayland functions not available. "
-            + "Did you apt install libglfw3-wayland?"
-        )
+    if is_wayland:
+        # glfw.init_hint(glfw.PLATFORM, glfw.PLATFORM_X11)  # produces invalid platform
+        if not hasattr(glfw, "get_wayland_window"):
+            is_wayland = False
+            # raise RuntimeError(
+            #     "We're on Wayland but Wayland functions not available. "
+            #     + "Did you apt install libglfw3-wayland?"
+            # )
+        # Not needed because WAYLAND_PREFER_LIBDECOR is the default?
+        # if hasattr(glfw, "WAYLAND_LIBDECOR"):
+        #     glfw.init_hint(glfw.WAYLAND_LIBDECOR, glfw.WAYLAND_PREFER_LIBDECOR)
+
 
 # Some glfw functions are not always available
 set_window_content_scale_callback = lambda *args: None  # noqa: E731
@@ -120,11 +134,6 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
         # Set window hints
         glfw.window_hint(glfw.CLIENT_API, glfw.NO_API)
         glfw.window_hint(glfw.RESIZABLE, True)
-        # see https://github.com/FlorianRhiem/pyGLFW/issues/42
-        # Alternatively, from pyGLFW 1.10 one can set glfw.ERROR_REPORTING='warn'
-        if sys.platform.startswith("linux"):
-            if is_wayland:
-                glfw.window_hint(glfw.FOCUSED, False)  # prevent Wayland focus error
 
         # Create the window (the initial size may not be in logical pixels)
         self._window = glfw.create_window(int(size[0]), int(size[1]), title, None, None)
@@ -269,27 +278,32 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
 
     # API
 
-    def get_window_id(self):
+    def get_surface_info(self):
         if sys.platform.startswith("win"):
-            return int(glfw.get_win32_window(self._window))
+            return {
+                "platform": "windows",
+                "window": int(glfw.get_win32_window(self._window)),
+            }
         elif sys.platform.startswith("darwin"):
-            return int(glfw.get_cocoa_window(self._window))
+            return {
+                "platform": "cocoa",
+                "window": int(glfw.get_cocoa_window(self._window)),
+            }
         elif sys.platform.startswith("linux"):
             if is_wayland:
-                return int(glfw.get_wayland_window(self._window))
+                return {
+                    "platform": "wayland",
+                    "window": int(glfw.get_wayland_window(self._window)),
+                    "display": int(glfw.get_wayland_display()),
+                }
             else:
-                return int(glfw.get_x11_window(self._window))
+                return {
+                    "platform": "x11",
+                    "window": int(glfw.get_x11_window(self._window)),
+                    "display": int(glfw.get_x11_display()),
+                }
         else:
-            raise RuntimeError(f"Cannot get GLFW window id on {sys.platform}.")
-
-    def get_display_id(self):
-        if sys.platform.startswith("linux"):
-            if is_wayland:
-                return glfw.get_wayland_display()
-            else:
-                return glfw.get_x11_display()
-        else:
-            raise RuntimeError(f"Cannot get GLFW display id on {sys.platform}.")
+            raise RuntimeError(f"Cannot get GLFW surafce info on {sys.platform}.")
 
     def get_pixel_ratio(self):
         return self._pixel_ratio

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -94,7 +94,7 @@ class WgpuOffscreenCanvasBase(WgpuCanvasBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def get_window_id(self):
+    def get_surface_info(self):
         """This canvas does not correspond to an on-screen window."""
         return None
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -7,8 +7,25 @@ import sys
 import ctypes
 import importlib
 
-from .base import WgpuCanvasBase, WgpuAutoGui, weakbind
+from .base import (
+    WgpuCanvasBase,
+    WgpuAutoGui,
+    weakbind,
+    get_alt_x11_display,
+    get_alt_wayland_display,
+)
 
+
+is_wayland = False
+
+# Make Qt not ignore XDG_SESSION_TYPE
+import os
+
+# is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
+# if is_wayland:
+#     os.environ["QT_QPA_PLATFORM"] = "wayland-egl"
+#     os.environ["QT_QPA_PLATFORM"] = "xcb"
+#     os.environ["QT_WAYLAND_FORCE_DPI"] = "=physical"  # don't use fixed 96 dpi
 
 # Select GUI toolkit
 for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
@@ -102,12 +119,6 @@ KEY_MAP = {
 }
 
 
-# Make Qt not ignore XDG_SESSION_TYPE
-# is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
-# if is_wayland:
-#     os.environ["QT_QPA_PLATFORM"] = "wayland"
-
-
 def enable_hidpi():
     """Enable high-res displays."""
     set_dpi_aware = qt_version_info < (6, 4)  # Pyside
@@ -160,13 +171,26 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
 
     # Methods that we add from wgpu (snake_case)
 
-    def get_display_id(self):
-        # There is qx11info, but it is rarely available.
-        # https://doc.qt.io/qt-5/qx11info.html#display
-        return super().get_display_id()  # uses X11 lib
-
-    def get_window_id(self):
-        return int(self.winId())
+    def get_surface_info(self):
+        if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
+            return {
+                "window": int(self.winId()),
+            }
+        elif sys.platform.startswith("linux"):
+            if is_wayland:
+                return {
+                    "platform": "wayland",
+                    "window": int(self.winId()),
+                    "display": int(get_alt_wayland_display()),
+                }
+            else:
+                return {
+                    "platform": "x11",
+                    "window": int(self.winId()),
+                    "display": int(get_alt_x11_display()),
+                }
+        else:
+            raise RuntimeError(f"Cannot get Qt surafce info on {sys.platform}.")
 
     def get_pixel_ratio(self):
         # Observations:
@@ -185,6 +209,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         lsize = self.width(), self.height()
         lsize = float(lsize[0]), float(lsize[1])
         ratio = self.devicePixelRatioF()
+
         # When the ratio is not integer (qt6), we need to somehow round
         # it. It turns out that we need to round it, but also add a
         # small offset. Tested on Win10 with several different OS
@@ -343,11 +368,10 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
         self._subwidget = QWgpuWidget(self, max_fps=max_fps)
         self._subwidget.add_event_handler(weakbind(self.handle_event), "*")
 
-        # Get the window id one time. For some reason this is needed
-        # to "activate" the canvas. Otherwise the viz is not shown if
-        # one does not provide canvas to request_adapter().
-        # (AK: Cannot reproduce this now, what qtlib/os/versions was this on?)
-        self._subwidget.get_window_id()
+        # Note: At some point we called `self._subwidget.winId()` here. For some
+        # reason this was needed to "activate" the canvas. Otherwise the viz was
+        # not shown if no canvas was provided to request_adapter(). Removed
+        # later because could not reproduce.
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -372,11 +396,8 @@ class QWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
     def draw_frame(self, f):
         self._subwidget.draw_frame = f
 
-    def get_display_id(self):
-        return self._subwidget.get_display_id()
-
-    def get_window_id(self):
-        return self._subwidget.get_window_id()
+    def get_surface_info(self):
+        return self._subwidget.get_surface_info()
 
     def get_pixel_ratio(self):
         return self._subwidget.get_pixel_ratio()

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -7,8 +7,8 @@ import sys
 import ctypes
 import importlib
 
-from .base import WgpuCanvasBase, WgpuAutoGui, weakbind
-from ._gui_utils import get_alt_x11_display, get_alt_wayland_display
+from .base import WgpuCanvasBase, WgpuAutoGui
+from ._gui_utils import get_alt_x11_display, get_alt_wayland_display, weakbind
 
 
 is_wayland = False  # We force Qt to use X11 in _gui_utils.py

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -164,6 +164,7 @@ class QWgpuWidget(WgpuAutoGui, WgpuCanvasBase, QtWidgets.QWidget):
                 "window": int(self.winId()),
             }
         elif sys.platform.startswith("linux"):
+            # The trick to use an al display pointer works for X11, but results in a segfault on Wayland ...
             if is_wayland:
                 return {
                     "platform": "wayland",

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -7,25 +7,12 @@ import sys
 import ctypes
 import importlib
 
-from .base import (
-    WgpuCanvasBase,
-    WgpuAutoGui,
-    weakbind,
-    get_alt_x11_display,
-    get_alt_wayland_display,
-)
+from .base import WgpuCanvasBase, WgpuAutoGui, weakbind
+from ._gui_utils import get_alt_x11_display, get_alt_wayland_display
 
 
-is_wayland = False
+is_wayland = False  # We force Qt to use X11 in _gui_utils.py
 
-# Make Qt not ignore XDG_SESSION_TYPE
-import os
-
-# is_wayland = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
-# if is_wayland:
-#     os.environ["QT_QPA_PLATFORM"] = "wayland-egl"
-#     os.environ["QT_QPA_PLATFORM"] = "xcb"
-#     os.environ["QT_WAYLAND_FORCE_DPI"] = "=physical"  # don't use fixed 96 dpi
 
 # Select GUI toolkit
 for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -6,7 +6,8 @@ can be used as a standalone window or in a larger GUI.
 import sys
 import ctypes
 
-from .base import WgpuCanvasBase, weakbind, get_alt_x11_display, get_alt_wayland_display
+from .base import WgpuCanvasBase
+from ._gui_utils import get_alt_x11_display, get_alt_wayland_display, weakbind
 
 import wx
 

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -5,9 +5,11 @@ can be used as a standalone window or in a larger GUI.
 
 import ctypes
 
-from .base import WgpuCanvasBase, weakbind
+from .base import WgpuCanvasBase, weakbind, get_alt_x11_display, get_alt_wayland_display
 
 import wx
+
+is_wayland = False
 
 
 def enable_hidpi():
@@ -69,8 +71,26 @@ class WxWgpuWindow(WgpuCanvasBase, wx.Window):
 
     # Methods that we add from wgpu
 
-    def get_window_id(self):
-        return int(self.GetHandle())
+    def get_surface_info(self):
+        if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
+            return {
+                "window": int(self.GetHandle()),
+            }
+        elif sys.platform.startswith("linux"):
+            if is_wayland:
+                return {
+                    "platform": "wayland",
+                    "window": int(self.winId()),
+                    "display": int(get_alt_wayland_display()),
+                }
+            else:
+                return {
+                    "platform": "x11",
+                    "window": int(self.winId()),
+                    "display": int(get_alt_x11_display()),
+                }
+        else:
+            raise RuntimeError(f"Cannot get Qt surafce info on {sys.platform}.")
 
     def get_pixel_ratio(self):
         # todo: this is not hidpi-ready (at least on win10)
@@ -133,11 +153,8 @@ class WxWgpuCanvas(WgpuCanvasBase, wx.Frame):
 
     # Methods that we add from wgpu
 
-    def get_display_id(self):
-        return self._subwidget.get_display_id()
-
-    def get_window_id(self):
-        return self._subwidget.get_window_id()
+    def get_surface_info(self):
+        return self._subwidget.get_surface_info()
 
     def get_pixel_ratio(self):
         return self._subwidget.get_pixel_ratio()

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -12,8 +12,7 @@ from ._gui_utils import get_alt_x11_display, get_alt_wayland_display, weakbind
 import wx
 
 
-# Fot now just assume wx uses X11
-is_wayland = False
+is_wayland = False  # We force wx to use X11 in _gui_utils.py
 
 
 def enable_hidpi():

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -3,6 +3,7 @@ Support for rendering in a wxPython window. Provides a widget that
 can be used as a standalone window or in a larger GUI.
 """
 
+import sys
 import ctypes
 
 from .base import WgpuCanvasBase, weakbind, get_alt_x11_display, get_alt_wayland_display

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -10,6 +10,8 @@ from .base import WgpuCanvasBase, weakbind, get_alt_x11_display, get_alt_wayland
 
 import wx
 
+
+# Fot now just assume wx uses X11
 is_wayland = False
 
 
@@ -81,13 +83,13 @@ class WxWgpuWindow(WgpuCanvasBase, wx.Window):
             if is_wayland:
                 return {
                     "platform": "wayland",
-                    "window": int(self.winId()),
+                    "window": int(self.GetHandle()),
                     "display": int(get_alt_wayland_display()),
                 }
             else:
                 return {
                     "platform": "x11",
-                    "window": int(self.winId()),
+                    "window": int(self.GetHandle()),
                     "display": int(get_alt_x11_display()),
                 }
         else:


### PR DESCRIPTION
Deals with #92. Probably won't entirely close it yet. 

## Changes

* [x] Change `canvas.get_window_id()` into `canvas.get_surface_info()` to package all info in one dict, so that the `get_display_id()` method can be removed, and we can add info on the platform that the GUI toolkit uses (x11/wayland).
* [x] New `gui._gui_utils` module to put some of this logic in.
* [x] Also moved some utlils from `gui.base` to the gui utils module. 
* [x] Make it work for GLFW, by forcing x11.
* [x] Make it work for Qt, by forcing x11.
* [x] Make it work for wx, by forcing x11 (untested).
* [x] Make sure the docs are correct.
* [x] Add notes to the top post of #92.

Notes:
* This PR could be smaller if it'd just force x11 for glfw and qt, but in the process of trying out things, I also refactored a bit. These extra changes do make the code more "future ready" for when Wayland is supported better.
* Not sure what happens on more special linuxes like Raspberry Pi.
