### PR TITLE
Use wgpu-native 0.19.3.1

### DIFF
--- a/wgpu/backends/wgpu_native/__init__.py
+++ b/wgpu/backends/wgpu_native/__init__.py
@@ -9,8 +9,8 @@ from .. import _register_backend
 
 
 # The wgpu-native version that we target/expect
-__version__ = "0.19.1.1"
-__commit_sha__ = "569a2be60d1dc90a660c1c96ffb3722942ada782"
+__version__ = "0.19.3.1"
+__commit_sha__ = "8f94e257f4abef4e5333fc1b181c2b404d6e34c0"
 version_info = tuple(map(int, __version__.split(".")))
 _check_expected_version(version_info)  # produces a warning on mismatch
 

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -27,6 +27,8 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_TextureBindingArray = 0x00030006,
     WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing = 0x00030007,
     WGPUNativeFeature_PipelineStatisticsQuery = 0x00030008,
+    WGPUNativeFeature_StorageResourceBindingArray = 0x00030009,
+    WGPUNativeFeature_PartiallyBoundBindingArray = 0x0003000A,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 


### PR DESCRIPTION
The wgpu-native project just had a new release. Hardly any changes required on our end.

## Preparations

* [x] Warp up outstanding PR's.
* [ ] ~Make release of wgpu-py.~
* [ ] ~Perhaps release pygfx too.~

## Upstream

* [x] wgpu-native is updated to a recent wgpu-core.
* [x] wgpu-native uses a recent `webgpu.h`.
* [x] wgpu-native has a release with these changes.

## Update to latest wgpu-native

* [x] Run `python download-wgpu-native.py --version xx` to download the latest webgpu.h and DLL.
* [x] Run `python codegen` to apply the automatic patches to the code.
* [x] It may be necessary to tweak the `hparser.py` to adjust to new formatting.
* [x] Make sure that the tests run and provide full coverage.
* [x] Make sure that the examples all work.
* [x] Make sure that pygfx works (again).
* [ ] Update release notes.

## Wrapping up

* [ ] Release new wgpu-py.
* [ ] Release new pygfx.

