### PR TITLE
Better support for interactive sessions

### DIFF
--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -34,17 +34,19 @@ canvas classes that you can use.
 The auto GUI backend
 --------------------
 
-The default approach for examples and small applications is to use
-the automatically selected GUI backend. At the moment this selects
-either the GLFW, Qt, or Jupyter backend, depending on the environment.
+Generally the best approach for examples and small applications is to use the
+automatically selected GUI backend. This ensures that the code is portable
+across different machines and environments. Using ``wgpu.gui.auto`` selects a
+suitable backend depending on the environment and more. See
+:ref:`interactive_use` for details.
 
 To implement interaction, the ``canvas`` has a :func:`WgpuAutoGui.handle_event()` method
 that can be overloaded. Alternatively you can use it's :func:`WgpuAutoGui.add_event_handler()`
 method. See the `event spec <https://jupyter-rfb.readthedocs.io/en/stable/events.html>`_
 for details about the event objects.
 
-Also see :ref:`interactive_use`. Further, the `triangle auto <https://github.com/pygfx/wgpu-py/blob/main/examples/triangle_auto.py>`_
-and `cube <https://github.com/pygfx/wgpu-py/blob/main/examples/cube.py>`_ examples demonstrate the auto gui.
+Also see the `triangle auto <https://github.com/pygfx/wgpu-py/blob/main/examples/triangle_auto.py>`_
+and `cube <https://github.com/pygfx/wgpu-py/blob/main/examples/cube.py>`_ examples that demonstrate the auto gui.
 
 .. code-block:: py
 
@@ -181,16 +183,20 @@ realized by automatically selecting the appropriate GUI backend. Secondly, the
 ``run()`` function (which normally enters the event-loop) does nothing in an
 interactive session.
 
+Many interactive environments have some sort of GUI support, allowing the repl
+to stay active (i.e. you can run new code), while the GUI windows is also alive.
+In wgpu we try to select the GUI that matches the current environment.
+
 On ``jupyter notebook`` and ``jupyter lab`` the jupyter backend (i.e.
-``jupyter_rfb``) is normally selected. When you are using `%gui qt`, wgpu will
+``jupyter_rfb``) is normally selected. When you are using ``%gui qt``, wgpu will
 honor that and use Qt instead.
 
-On ``jupyter console`` and ``qtconsole``, the kernel is the same as in ``jupyter notebook``
-and ``jupyter lab``, making it (about) impossible to tell that we
-cannot actually use ipywidgets. It will try to use  ``jupyter_rfb``, but cannot
-render anything. It's advised to either use ``%gui qt`` or set the
-``WGPU_GUI_BACKEND`` env var to "glfw". The latter option works well, because
-these kernels *do* have a running asyncio event loop!
+On ``jupyter console`` and ``qtconsole``, the kernel is the same as in ``jupyter notebook``,
+making it (about) impossible to tell that we cannot actually use
+ipywidgets. So it will try to use ``jupyter_rfb``, but cannot render anything.
+It's theefore advised to either use ``%gui qt`` or set the ``WGPU_GUI_BACKEND`` env var
+to "glfw". The latter option works well, because these kernels *do* have a
+running asyncio event loop!
 
 On other environments that have a running ``asyncio`` loop, the glfw backend is
 preferred. E.g on ``ptpython --asyncio``.
@@ -200,3 +206,8 @@ On IPython (the old-school terminal app) it's advised to use ``%gui qt`` (or
 
 On IDE's like Spyder or Pyzo, wgpu detects the integrated GUI, running on
 glfw if asyncio is enabled or Qt if a qt app is running.
+
+On an interactive session without GUI support, one must call ``run()`` to make
+the canvases interactive. This enters the main loop, which prevents entering new
+code. Once all canvases are closed, the loop returns. If you make new canvases
+afterwards, you can call ``run()`` again. This is similar to ``plt.show()`` in Matplotlib.

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -43,9 +43,8 @@ that can be overloaded. Alternatively you can use it's :func:`WgpuAutoGui.add_ev
 method. See the `event spec <https://jupyter-rfb.readthedocs.io/en/stable/events.html>`_
 for details about the event objects.
 
-
-Also see the `triangle auto example <https://github.com/pygfx/wgpu-py/blob/main/examples/triangle_auto.py>`_
-and `cube example <https://github.com/pygfx/wgpu-py/blob/main/examples/cube.py>`_.
+Also see :ref:`interactive_use`. Further, the `triangle auto <https://github.com/pygfx/wgpu-py/blob/main/examples/triangle_auto.py>`_
+and `cube <https://github.com/pygfx/wgpu-py/blob/main/examples/cube.py>`_ examples demonstrate the auto gui.
 
 .. code-block:: py
 
@@ -170,3 +169,34 @@ subclass implementing a remote frame-buffer. There are also some `wgpu examples 
     # ... wgpu code
 
     canvas  # Use as cell output
+
+
+.. _interactive_use:
+
+Using wgpu interactively
+------------------------
+
+The wgpu gui's are designed to support interactive use. Firstly, this is
+realized by automatically selecting the appropriate GUI backend. Secondly, the
+``run()`` function (which normally enters the event-loop) does nothing in an
+interactive session.
+
+On ``jupyter notebook`` and ``jupyter lab`` the jupyter backend (i.e.
+``jupyter_rfb``) is normally selected. When you are using `%gui qt`, wgpu will
+honor that and use Qt instead.
+
+On ``jupyter console`` and ``qtconsole``, the kernel is the same as in ``jupyter notebook``
+and ``jupyter lab``, making it (about) impossible to tell that we
+cannot actually use ipywidgets. It will try to use  ``jupyter_rfb``, but cannot
+render anything. It's advised to either use ``%gui qt`` or set the
+``WGPU_GUI_BACKEND`` env var to "glfw". The latter option works well, because
+these kernels *do* have a running asyncio event loop!
+
+On other environments that have a running ``asyncio`` loop, the glfw backend is
+preferred. E.g on ``ptpython --asyncio``.
+
+On IPython (the old-school terminal app) it's advised to use ``%gui qt`` (or
+``--gui qt``). It seems not possible to have a running asyncio loop here.
+
+On IDE's like Spyder or Pyzo, wgpu detects the integrated GUI, running on
+glfw if asyncio is enabled or Qt if a qt app is running.

--- a/wgpu/gui/auto.py
+++ b/wgpu/gui/auto.py
@@ -7,21 +7,14 @@ for e.g. wx later. Or we might decide to stick with these three.
 
 __all__ = ["WgpuCanvas", "run", "call_later"]
 
-import importlib
 import os
 import sys
+import importlib
+from ._gui_utils import logger, QT_MODULE_NAMES, get_imported_qt_lib, asyncio_is_running
 
 
-def is_jupyter():
-    """Determine whether the user is executing in a Jupyter Notebook / Lab."""
-    try:
-        ip = get_ipython()
-        if ip.has_trait("kernel"):
-            return True
-        else:
-            return False
-    except NameError:
-        return False
+# Note that wx is not in here, because it does not (yet) implement base.WgpuAutoGui
+WGPU_GUI_BACKEND_NAMES = ["glfw", "qt", "jupyter", "offscreen"]
 
 
 def _load_backend(backend_name):
@@ -41,66 +34,146 @@ def _load_backend(backend_name):
     return module
 
 
-def _auto_load_backend():
-    """Decide on the gui backend automatically."""
+def select_backend():
+    """Select a backend using a careful multi-stage selection process."""
 
-    # Backends to auto load, ordered by preference. Maps libname -> backend_name
-    gui_backends = {
-        "glfw": "glfw",
-        "PySide6": "qt",
-        "PyQt6": "qt",
-        "PySide2": "qt",
-        "PyQt5": "qt",
-    }
+    # If a backend is forced, we use that, or fail.
+    backend_name = backend_by_env_vars()
+    if backend_name:
+        return _load_backend(backend_name)
 
-    # The module that we try to find
+    # Otherwise we try ...
     module = None
-
-    # Any errors we come accross as we try to import the gui backends
     errors = []
+    failed_backends = set()
 
-    # Prefer a backend for which the lib is already imported
-    imported = [libname for libname in gui_backends if libname in sys.modules]
-    for libname in imported:
-        try:
-            module = _load_backend(gui_backends[libname])
-            break
-        except Exception as err:
-            errors.append(err)
-
-    # If no module found yet, try importing the lib, then import the backend
-    if not module:
-        for libname in gui_backends:
-            try:
-                importlib.import_module(libname)
-            except ModuleNotFoundError:
+    for func in [
+        backends_by_jupyter,
+        backends_by_imported_modules,
+        backends_by_trying_in_order,
+    ]:
+        for backend_name in func():
+            if backend_name in failed_backends:
                 continue
             try:
-                module = _load_backend(gui_backends[libname])
-                break
+                module = _load_backend(backend_name)
             except Exception as err:
                 errors.append(err)
+                failed_backends.add(backend_name)
+            else:
+                logger.warning(f"Selected {backend_name} via {func.__name__}")
+                return module
 
     # If still nothing found, raise a useful error
     if not module:
         msg = "\n".join(str(err) for err in errors)
-        msg += "\n\n  Could not find either glfw or Qt framework."
+        msg += "\n\n  WGPU Could not load any of the GUI backends."
         msg += "\n  Install glfw using e.g. ``pip install -U glfw``,"
         msg += "\n  or install a qt framework using e.g. ``pip install -U pyside6``."
         if sys.platform.startswith("linux"):
             msg += "\n  You may also need to run the equivalent of ``apt install libglfw3``."
         raise ImportError(msg) from None
 
-    return module
+
+def backend_by_env_vars():
+    """Get the backend set via one the supported environment variables."""
+    # Env var intended for testing, overrules everything else
+    if os.environ.get("WGPU_FORCE_OFFSCREEN") == "true":
+        return "offscreen"
+    # Env var to force a backend for general use
+    backend_name = os.getenv("WGPU_GUI_BACKEND", "").lower().strip() or None
+    if backend_name:
+        if backend_name not in WGPU_GUI_BACKEND_NAMES:
+            logger.error(
+                f"Ignoring invalid WGPU_GUI_BACKEND '{backend_name}', must be one of {WGPU_GUI_BACKEND_NAMES}"
+            )
+            backend_name = None
+    return backend_name
 
 
-# Triage
-if os.environ.get("WGPU_FORCE_OFFSCREEN") == "true":
-    module = _load_backend("offscreen")
-elif is_jupyter():
-    module = _load_backend("jupyter")
-else:
-    module = _auto_load_backend()
+def backends_by_jupyter():
+    """Generate backend names that are appropriate for the current Jupyter session (if any)."""
+    try:
+        ip = get_ipython()
+    except NameError:
+        return
+    if not ip.has_trait("kernel"):
+        # probably old-school ipython, we follow the normal selection process
+        return
+
+    # We're in a Jupyter kernel. This might be a notebook, jupyter lab, or
+    # jupyter console. In the latter case we cannot render ipywidgets.
+    # Unfortunately, there does not seem to be a (reasonable) way to detect
+    # whether we're in a console or notebook. Technically this kernel could be
+    # connected to a client of each. So we assume that ipywidgets can be used.
+    # User on jupyter console (or similar) should ``%gui qt`` or set
+    # WGPU_GUI_BACKEND to 'glfw'.
+
+    # If GUI integration is enabled, we select the corresponding backend instead of jupyter
+    app = getattr(ip.kernel, "app", None)
+    if app:
+        gui_module_name = app.__class__.__module__.split(".")[0]
+        if gui_module_name in QT_MODULE_NAMES:
+            yield "qt"
+        # elif "wx" in app.__class__.__name__.lower() == "wx":
+        #     yield "wx"
+
+    yield "jupyter"
 
 
+def backends_by_imported_modules():
+    """Generate backend names based on what modules are currently imported."""
+
+    # Get some info on loaded backends, and available apps/loops
+    qtlib, has_qt_app = get_imported_qt_lib()
+    has_asyncio_loop = asyncio_is_running()
+
+    # If there is a qt app instance, chances are high that the user wants to run in Qt.
+    # More so than with asyncio, because asyncio may just be used by the runtime.
+    if has_qt_app:
+        yield "qt"
+
+    # If there is an asyncio loop, we can nicely run glfw, if glfw is available.
+    if has_asyncio_loop:
+        try:
+            importlib.import_module("glfw")
+        except ModuleNotFoundError:
+            pass
+        else:
+            yield "glfw"
+
+    # The rest is just "is the corresponding lib imported?"
+
+    if "glfw" in sys.modules:
+        yield "glfw"
+
+    if qtlib:
+        yield "qt"
+
+    # if "wx" in sys.modules:
+    #     yield "wx"
+
+
+def backends_by_trying_in_order():
+    """Generate backend names by trying to import the GUI lib in order. This is the final fallback."""
+
+    gui_lib_to_backend = {
+        "glfw": "glfw",
+        "PySide6": "qt",
+        "PyQt6": "qt",
+        "PySide2": "qt",
+        "PyQt5": "qt",
+        # "wx": "wx",
+    }
+
+    for libname, backend_name in gui_lib_to_backend.items():
+        try:
+            importlib.import_module(libname)
+        except ModuleNotFoundError:
+            continue
+        yield backend_name
+
+
+# Load!
+module = select_backend()
 WgpuCanvas, run, call_later = module.WgpuCanvas, module.run, module.call_later

--- a/wgpu/gui/auto.py
+++ b/wgpu/gui/auto.py
@@ -61,7 +61,7 @@ def select_backend():
                 errors.append(err)
                 failed_backends.add(backend_name)
             else:
-                logger.warning(f"Selected {backend_name} via {func.__name__}")
+                logger.info(f"Selected {backend_name} via {func.__name__}")
                 return module
 
     # If still nothing found, raise a useful error
@@ -78,7 +78,7 @@ def select_backend():
 def backend_by_env_vars():
     """Get the backend set via one the supported environment variables."""
     # Env var intended for testing, overrules everything else
-    if os.environ.get("WGPU_FORCE_OFFSCREEN") == "true":
+    if os.environ.get("WGPU_FORCE_OFFSCREEN").lower() in ("1", "true", "yes"):
         return "offscreen"
     # Env var to force a backend for general use
     backend_name = os.getenv("WGPU_GUI_BACKEND", "").lower().strip() or None
@@ -101,8 +101,8 @@ def backends_by_jupyter():
         # probably old-school ipython, we follow the normal selection process
         return
 
-    # We're in a Jupyter kernel. This might be a notebook, jupyter lab, or
-    # jupyter console. In the latter case we cannot render ipywidgets.
+    # We're in a Jupyter kernel. This might be a notebook, jupyter lab, jupyter
+    # console, qtconsole, etc. In the latter cases we cannot render ipywidgets.
     # Unfortunately, there does not seem to be a (reasonable) way to detect
     # whether we're in a console or notebook. Technically this kernel could be
     # connected to a client of each. So we assume that ipywidgets can be used.

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -9,6 +9,7 @@ or ``sudo apt install libglfw3-wayland`` when using Wayland.
 
 import sys
 import time
+import atexit
 import weakref
 import asyncio
 
@@ -109,7 +110,7 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
     # See https://www.glfw.org/docs/latest/group__window.html
 
     def __init__(self, *, size=None, title=None, **kwargs):
-        ensure_app()
+        app.init_glfw()
         super().__init__(**kwargs)
 
         # Handle inputs
@@ -131,7 +132,7 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
         self._is_minimized = False
 
         # Register ourselves
-        all_glfw_canvases.add(self)
+        app.all_glfw_canvases.add(self)
 
         # Register callbacks. We may get notified too often, but that's
         # ok, they'll result in a single draw.
@@ -185,7 +186,7 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
             self._on_close()
 
     def _on_close(self, *args):
-        all_glfw_canvases.discard(self)
+        app.all_glfw_canvases.discard(self)
         if self._window is not None:
             glfw.destroy_window(self._window)  # not just glfw.hide_window
             self._window = None
@@ -495,9 +496,42 @@ class GlfwWgpuCanvas(WgpuAutoGui, WgpuCanvasBase):
 WgpuCanvas = GlfwWgpuCanvas
 
 
-all_glfw_canvases = weakref.WeakSet()
-glfw._pygfx_mainloop = None
-glfw._pygfx_stop_if_no_more_canvases = False
+class AppState:
+    """Little container for state about the loop and glfw."""
+
+    def __init__(self):
+        self.all_glfw_canvases = weakref.WeakSet()
+        self._loop = None
+        self.stop_if_no_more_canvases = False
+        self._glfw_initialized = False
+
+    def init_glfw(self):
+        glfw.init()  # Safe to call multiple times
+        if not self._glfw_initialized:
+            self._glfw_initialized = True
+            atexit.register(glfw.terminate)
+
+    def get_loop(self):
+        if self._loop is None:
+            self._loop = self._get_loop()
+            self._loop.create_task(keep_glfw_alive())
+        return self._loop
+
+    def _get_loop(self):
+        try:
+            return asyncio.get_running_loop()
+        except Exception:
+            pass
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            pass
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
+app = AppState()
 
 
 def update_glfw_canvasses():
@@ -506,7 +540,7 @@ def update_glfw_canvasses():
     """
     # Note that _draw_frame_and_present already catches errors, it can
     # only raise errors if the logging system fails.
-    canvases = tuple(all_glfw_canvases)
+    canvases = tuple(app.all_glfw_canvases)
     for canvas in canvases:
         if canvas._need_draw and not canvas._is_minimized:
             canvas._need_draw = False
@@ -514,43 +548,34 @@ def update_glfw_canvasses():
     return len(canvases)
 
 
-async def mainloop():
-    loop = asyncio.get_event_loop()
+async def keep_glfw_alive():
+    """Co-routine that lives forever, keeping glfw going.
+
+    Although it stops the event-loop if there are no more canvases (and we're
+    runnning the loop), this task stays active and continues when the loop is
+    restarted.
+    """
+    # TODO: this is not particularly pretty. It'd be better to use normal asyncio to
+    # schedule draws and then also process events. But let's address when we do #355 / #391
     while True:
-        n = update_glfw_canvasses()
-        if glfw._pygfx_stop_if_no_more_canvases and not n:
-            break
         await asyncio.sleep(0.001)
         glfw.poll_events()
-    loop.stop()
-    glfw.terminate()
-
-
-def ensure_app():
-    # It is safe to call init multiple times:
-    # "Additional calls to this function after successful initialization
-    # but before termination will return GLFW_TRUE immediately."
-    glfw.init()
-    if glfw._pygfx_mainloop is None:
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-        glfw._pygfx_mainloop = mainloop()
-        loop.create_task(glfw._pygfx_mainloop)
+        n = update_glfw_canvasses()
+        if app.stop_if_no_more_canvases and not n:
+            loop = asyncio.get_running_loop()
+            loop.stop()
 
 
 def call_later(delay, callback, *args):
-    loop = asyncio.get_event_loop()
+    loop = app.get_loop()
     loop.call_later(delay, callback, *args)
 
 
 def run():
-    ensure_app()
-    loop = asyncio.get_event_loop()
-    if not loop.is_running():
-        glfw._pygfx_stop_if_no_more_canvases = True
-        loop.run_forever()
-    else:
-        pass  # Probably an interactive session
+    loop = app.get_loop()
+    if loop.is_running():
+        return  # Interactive mode!
+
+    app.stop_if_no_more_canvases = True
+    loop.run_forever()
+    app.stop_if_no_more_canvases = False

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -532,7 +532,11 @@ def ensure_app():
     # but before termination will return GLFW_TRUE immediately."
     glfw.init()
     if glfw._pygfx_mainloop is None:
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         glfw._pygfx_mainloop = mainloop()
         loop.create_task(glfw._pygfx_mainloop)
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -20,7 +20,7 @@ is_wayland = False  # We force Qt to use X11 in _gui_utils.py
 
 
 # Select GUI toolkit
-libname, already_has_app = get_imported_qt_lib()
+libname, already_had_app_on_import = get_imported_qt_lib()
 if libname:
     QtCore = importlib.import_module(".QtCore", libname)
     QtWidgets = importlib.import_module(".QtWidgets", libname)
@@ -435,8 +435,8 @@ def get_app():
 
 
 def run():
-    if already_has_app:
-        return
+    if already_had_app_on_import:
+        return  # Likely in an interactive session or larger application that will start the Qt app.
     app = get_app()
     app.exec() if hasattr(app, "exec") else app.exec_()
 

--- a/wgpu/gui/qt.py
+++ b/wgpu/gui/qt.py
@@ -8,32 +8,36 @@ import ctypes
 import importlib
 
 from .base import WgpuCanvasBase, WgpuAutoGui
-from ._gui_utils import get_alt_x11_display, get_alt_wayland_display, weakbind
+from ._gui_utils import (
+    get_alt_x11_display,
+    get_alt_wayland_display,
+    weakbind,
+    get_imported_qt_lib,
+)
 
 
 is_wayland = False  # We force Qt to use X11 in _gui_utils.py
 
 
 # Select GUI toolkit
-for libname in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
-    if libname in sys.modules:
-        QtCore = importlib.import_module(".QtCore", libname)
-        QtWidgets = importlib.import_module(".QtWidgets", libname)
-        try:
-            WA_PaintOnScreen = QtCore.Qt.WidgetAttribute.WA_PaintOnScreen
-            WA_DeleteOnClose = QtCore.Qt.WidgetAttribute.WA_DeleteOnClose
-            PreciseTimer = QtCore.Qt.TimerType.PreciseTimer
-            KeyboardModifiers = QtCore.Qt.KeyboardModifier
-            FocusPolicy = QtCore.Qt.FocusPolicy
-            Keys = QtCore.Qt.Key
-        except AttributeError:
-            WA_PaintOnScreen = QtCore.Qt.WA_PaintOnScreen
-            WA_DeleteOnClose = QtCore.Qt.WA_DeleteOnClose
-            PreciseTimer = QtCore.Qt.PreciseTimer
-            KeyboardModifiers = QtCore.Qt
-            FocusPolicy = QtCore.Qt
-            Keys = QtCore.Qt
-        break
+libname, already_has_app = get_imported_qt_lib()
+if libname:
+    QtCore = importlib.import_module(".QtCore", libname)
+    QtWidgets = importlib.import_module(".QtWidgets", libname)
+    try:
+        WA_PaintOnScreen = QtCore.Qt.WidgetAttribute.WA_PaintOnScreen
+        WA_DeleteOnClose = QtCore.Qt.WidgetAttribute.WA_DeleteOnClose
+        PreciseTimer = QtCore.Qt.TimerType.PreciseTimer
+        KeyboardModifiers = QtCore.Qt.KeyboardModifier
+        FocusPolicy = QtCore.Qt.FocusPolicy
+        Keys = QtCore.Qt.Key
+    except AttributeError:
+        WA_PaintOnScreen = QtCore.Qt.WA_PaintOnScreen
+        WA_DeleteOnClose = QtCore.Qt.WA_DeleteOnClose
+        PreciseTimer = QtCore.Qt.PreciseTimer
+        KeyboardModifiers = QtCore.Qt
+        FocusPolicy = QtCore.Qt
+        Keys = QtCore.Qt
 else:
     raise ImportError(
         "Before importing wgpu.gui.qt, import one of PySide6/PySide2/PyQt6/PyQt5 to select a Qt toolkit."
@@ -431,6 +435,8 @@ def get_app():
 
 
 def run():
+    if already_has_app:
+        return
     app = get_app()
     app.exec() if hasattr(app, "exec") else app.exec_()
 


### PR DESCRIPTION
This PR overhauls the GUI backend selection, making it clearer (I hope), improving support for various use-cases, and making it easier to add support for specific use-cases.

* [x] When on IPython, honor the selected `%gui`.
* [x] Prevent Qt backend from running the event loop if it's already made active by the env.
* [x] If multiple Qt libs are imported, check if any of them has an app object.
* [x] The above also makes that Qt is selected in  `$ ipython --gui qt`.
* [x] Prefer glfw when we detect a running asyncio loop.
* [x] The above makes wgpu interactive in e.g. `$ ptpython --asyncio` and `$ python -m asyncio`.
* [x] Users can set `WGPU_GUI_BACKEND` to force a backend. Though `WGPU_FORCE_OFFSCREEN` still exists to overload during tests.
* [x] Docs on interactive use.  
* [x] Can call `run()` multiple times (for both qt and glfw).
* [x] Fix that for the glfw backend, obtaining an asyncio event loop fails on e.g. ipython.