### PR TITLE
Don't warn in present()

### DIFF
--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -653,8 +653,8 @@ class GPUCanvasContext(classes.GPUCanvasContext):
             # get_current_texture(). But then what was this person rendering to
             # then? The thing is that this also happens when there is an
             # exception in the draw function before the call to
-            # get_current_texture(). In this scenario any warning we log here
-            # will only add confusion.
+            # get_current_texture(). In this scenario our warning may
+            # add confusion, so provide context and make it a debug level warning.
             msg = "Warning in present(): No texture to present, missing call to get_current_texture()?"
             logger.debug(msg)
         else:

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -652,10 +652,11 @@ class GPUCanvasContext(classes.GPUCanvasContext):
             # This can happen when a user somehow forgot to call
             # get_current_texture(). But then what was this person rendering to
             # then? The thing is that this also happens when there is an
-            # exception in the draw function befor the call to
+            # exception in the draw function before the call to
             # get_current_texture(). In this scenario any warning we log here
             # will only add confusion.
-            pass  # ignore :)
+            msg = "Warning in present(): No texture to present, missing call to get_current_texture()?"
+            logger.debug(msg)
         else:
             # Present the texture, then destroy it
             # H: void f(WGPUSurface surface)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -649,9 +649,13 @@ class GPUCanvasContext(classes.GPUCanvasContext):
 
     def present(self):
         if not self._texture:
-            # Log warning but don't raise exception
-            msg = "No texture to present, missing call to get_current_texture()?"
-            logger.warning(msg)
+            # This can happen when a user somehow forgot to call
+            # get_current_texture(). But then what was this person rendering to
+            # then? The thing is that this also happens when there is an
+            # exception in the draw function befor the call to
+            # get_current_texture(). In this scenario any warning we log here
+            # will only add confusion.
+            pass  # ignore :)
         else:
             # Present the texture, then destroy it
             # H: void f(WGPUSurface surface)


### PR DESCRIPTION
The warning was intended to help people who forgot to call `get_current_texture()`. But it looks like it does more harm then help, because when an exception happens in the draw function, the warning is printed below, making it easy to interpret that *that* is the error message. See e.g. https://github.com/pygfx/pygfx/issues/682