### PR TITLE
Provide more control to select a specific GPU

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -44,15 +44,6 @@ It also works out of the box, because the wgpu-native DLL is shipped with wgpu-p
 
 The wgpu_native backend provides a few extra functionalities:
 
-
-.. py:function:: wgpu.backends.wgpu_native.enumerate_adapters()
-
-    Return a list of all available adapters on this system.
-
-    :return: Adapters
-    :rtype: list
-
-
 .. py:function:: wgpu.backends.wgpu_native.request_device_tracing(adapter, trace_path, *, label="", required_features, required_limits, default_queue)
 
     An alternative to :func:`wgpu.GPUAdapter.request_adapter`, that streams a trace

--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -61,14 +61,16 @@ assert result == list(range(20))
 # Create device and shader object
 device = wgpu.utils.get_default_device()
 
-# Or, you can select GPU by requesting all available adapters
-# adapters = wgpu.backends.wgpu_native.enumerate_adapters()
+# Show all available adapters
+adapters = wgpu.gpu.enumerate_adapters()
+for a in adapters:
+    print(a.summary)
+
+# You can select specific GPU from the available adapters
 # adapter = None
-# for adap in adapters:
-#     adapter_info = adap.request_adapter_info()
-#     print(adapter_info)
-#     if "NVIDIA" in adapter_info["device"]:
-#         adapter = adap
+# for a in adapters:
+#     if "NVIDIA" in a.summary:
+#         adapter = a
 #         break
 # assert adapter is not None
 # device = adapter.request_device()

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -12,7 +12,9 @@ import numpy as np
 
 
 print("Available adapters:")
-print("\n".join(wgpu.gpu.enumerate_adapter_info()))
+for a in wgpu.gpu.enumerate_adapters():
+    print(a.summary)
+
 
 # %% Create canvas and device
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -11,7 +11,7 @@ import wgpu
 import numpy as np
 
 
-print("Available adapters:")
+print("Available adapters on this system:")
 for a in wgpu.gpu.enumerate_adapters():
     print(a.summary)
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -11,6 +11,9 @@ import wgpu
 import numpy as np
 
 
+print("Available adapters:")
+print("\n".join(wgpu.gpu.enumerate_adapter_info()))
+
 # %% Create canvas and device
 
 # Create a canvas to render to

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -269,10 +269,16 @@ def test_wgpu_native_tracer():
 
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
-def test_wgpu_native_enumerate_adapters():
+def test_enumerate_adapters():
     # Get all available adapters
-    adapters = wgpu.backends.wgpu_native.enumerate_adapters()
+    adapters = wgpu.gpu.enumerate_adapters()
     assert len(adapters) > 0
+
+    # Check adapter summaries
+    for adapter in adapters:
+        assert isinstance(adapter.summary, str)
+        assert "\n" not in adapter.summary
+        assert len(adapter.summary.strip()) > 10
 
     # Check that we can get a device from each adapter
     for adapter in adapters:

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -80,14 +80,26 @@ class GPU:
     """
 
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
-    @apidiff.change("arguments include a canvas object")
+    @apidiff.change("arguments include gpu_preference and canvas")
     def request_adapter(
-        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
+        self,
+        *,
+        gpu_preference=None,
+        power_preference=None,
+        force_fallback_adapter=False,
+        canvas=None,
     ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 
         Arguments:
+            gpu_preference (str): keywords (separated by commas) to select an adapter.
+                Matches on device name, backend type
+                (metal/vulkan/d3d12/opengl) and adpater type
+                (CPU/IntegratedGPU/DiscreteGPU). Case insensitive. Multiple keywords
+                can be given, in order of preference. The best match is selected,
+                but no guarantee is made whether the returned adapter
+                matches the preference. If given, it overrides power_preference.
             power_preference (PowerPreference): "high-performance" or "low-power".
             force_fallback_adapter (bool): whether to use a (probably CPU-based)
                 fallback adapter.
@@ -98,22 +110,50 @@ class GPU:
         from .backends.auto import gpu  # noqa
 
         return gpu.request_adapter(
+            gpu_preference=gpu_preference,
             power_preference=power_preference,
             force_fallback_adapter=force_fallback_adapter,
             canvas=canvas,
         )
 
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
-    @apidiff.change("arguments include a canvas object")
+    @apidiff.change("arguments include gpu_preference and canvas")
     async def request_adapter_async(
-        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
+        self,
+        *,
+        gpu_preference=None,
+        power_preference=None,
+        force_fallback_adapter=False,
+        canvas=None,
     ):
         """Async version of `request_adapter()`."""
         return self.request_adapter(
+            gpu_preference=gpu_preference,
             power_preference=power_preference,
             force_fallback_adapter=force_fallback_adapter,
             canvas=canvas,
         )
+
+    @apidiff.add("Method useful on desktop")
+    def enumerate_adapter_info(self):
+        """Get a list of strings describing the different possible adapters.
+
+        This information can be used for the ``gpu_preference`` arg in
+        ``request_adapter()``.
+        """
+        # Note that backends that cannot enumerate adapters, like WebGL,
+        # can at least request two adapters with different power preference,
+        # and list these (if they have different info).
+
+        # If this method gets called, no backend has been loaded yet, let's do that now!
+        from .backends.auto import gpu  # noqa
+
+        return gpu.enumerate_adapter_info()
+
+    @apidiff.add("Method useful on desktop")
+    async def enumerate_adapter_info_async(self):
+        """Async version of enumerate_adapter_info."""
+        return self.enumerate_adapter_info()
 
     # IDL: GPUTextureFormat getPreferredCanvasFormat();
     @apidiff.change("Disabled because we put it on the canvas context")

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -368,13 +368,14 @@ class GPUAdapter:
     @apidiff.add("Useful in multi-gpu environments")
     @property
     def summary(self):
-        """A one-line summary of the info of this adapter (name, backend_type, adapter_type)."""
+        """A one-line summary of the info of this adapter (name, adapter_type, backend_type)."""
         d = self._adapter_info
         return f"{d['device']} ({d['adapter_type']}) via {d['backend_type']}"
 
     # IDL: Promise<GPUAdapterInfo> requestAdapterInfo();
     def request_adapter_info(self):
         """Get a dict with information about this adapter, such as the vendor and devicen name."""
+        # Note: returns a dict rather than an GPUAdapterInfo instance.
         return self._adapter_info
 
     # IDL: Promise<GPUAdapterInfo> requestAdapterInfo();

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -82,11 +82,7 @@ class GPU:
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     @apidiff.change("arguments include canvas")
     def request_adapter(
-        self,
-        *,
-        power_preference=None,
-        force_fallback_adapter=False,
-        canvas=None,
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
@@ -110,11 +106,7 @@ class GPU:
     # IDL: Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     @apidiff.change("arguments include canvas")
     async def request_adapter_async(
-        self,
-        *,
-        power_preference=None,
-        force_fallback_adapter=False,
-        canvas=None,
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Async version of `request_adapter()`."""
         return self.request_adapter(

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -176,7 +176,12 @@ libf = SafeLibCalls(lib, error_handler)
 
 class GPU(classes.GPU):
     def request_adapter(
-        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
+        self,
+        *,
+        gpu_preference=None,
+        power_preference=None,
+        force_fallback_adapter=False,
+        canvas=None,
     ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
@@ -184,6 +189,13 @@ class GPU(classes.GPU):
         This is the implementation based on wgpu-native.
 
         Arguments:
+            gpu_preference (str): keywords (separated by commas) to select an adapter.
+                Matches on device name, backend type
+                (metal/vulkan/d3d12/opengl) and adpater type
+                (CPU/IntegratedGPU/DiscreteGPU). Case insensitive. Multiple keywords
+                can be given, in order of preference. The best match is selected,
+                but no guarantee is made whether the returned adapter
+                matches the preference. If given, it overrides power_preference.
             power_preference (PowerPreference): "high-performance" or "low-power".
             force_fallback_adapter (bool): whether to use a (probably CPU-based)
                 fallback adapter.
@@ -205,7 +217,7 @@ class GPU(classes.GPU):
 
         # Try to read the WGPU_BACKEND_TYPE environment variable to see
         # if a backend should be forced.
-        force_backend = os.getenv("WGPU_BACKEND_TYPE", None)
+        force_backend = os.getenv("WGPU_BACKEND_TYPE", "").strip()
         backend = enum_str2int["BackendType"]["Undefined"]
         if force_backend:
             try:
@@ -218,7 +230,41 @@ class GPU(classes.GPU):
             else:
                 logger.warning(f"Forcing backend: {force_backend} ({backend})")
 
-        # ----- Request adapter
+        # Get keywords for adapter selection
+        gpu_keywords = [kw.strip() for kw in (gpu_preference or "").split(",")]
+        gpu_keywords = [kw.lower() for kw in gpu_keywords if kw]
+
+        if gpu_keywords:
+
+            # Get all adapters and select best one based on keywords
+            adapters = self._enumerate_adapters()
+            if force_backend:
+                gpu_keywords.insert(0, force_backend.lower())
+            # Score all adapters
+            for adapter in adapters:
+                adapter_info_str = str(adapter.request_adapter_info()).lower()
+                adapter._score = 0
+                for i, keyword in enumerate(gpu_keywords):
+                    if keyword in adapter_info_str:
+                        adapter._score += len(gpu_keywords) - i
+            # Prioritize. For equal scores, the original order is maintained.
+            adapters.sort(key=lambda adapter: -adapter._score)
+            # Pick the first
+            return adapters[0]
+
+        else:
+
+            # Let wgpu-native to select an adapter
+            return self._request_adapter(
+                power_preference=power_preference,
+                force_fallback_adapter=force_fallback_adapter,
+                surface_id=surface_id,
+                backend=backend,
+            )
+
+    def _request_adapter(
+        self, *, power_preference, force_fallback_adapter, surface_id, backend
+    ):
 
         # H: nextInChain: WGPUChainedStruct *, compatibleSurface: WGPUSurface, powerPreference: WGPUPowerPreference, backendType: WGPUBackendType, forceFallbackAdapter: WGPUBool/int
         struct = new_struct_p(
@@ -253,6 +299,46 @@ class GPU(classes.GPU):
             raise RuntimeError(error_msg)
 
         return self._create_adapter(adapter_id)
+
+    async def request_adapter_async(
+        self,
+        *,
+        gpu_preference=None,
+        power_preference=None,
+        force_fallback_adapter=False,
+        canvas=None,
+    ):
+        """Async version of ``request_adapter()``.
+        This is the implementation based on wgpu-native.
+        """
+        return self.request_adapter(
+            gpu_preference=gpu_preference,
+            power_preference=power_preference,
+            force_fallback_adapter=force_fallback_adapter,
+            canvas=canvas,
+        )  # no-cover
+
+    def enumerate_adapter_info(self):
+        adapters = self._enumerate_adapters()
+        lines = []
+        for adapter in adapters:
+            d = adapter.request_adapter_info()
+            lines.append(f"{d['device']} - {d['backend_type']} - ({d['adapter_type']})")
+            # for k in sorted(d):
+            #     lines.append(f"{k}: {d[k]}")
+            # lines.append("")
+        return lines
+
+    def _enumerate_adapters(self):
+        # The first call is to get the number of adapters, and the second
+        # call is to get the actual adapters. Note that the second arg (now
+        # NULL) can be a `WGPUInstanceEnumerateAdapterOptions` to filter
+        # by backend.
+        instance = get_wgpu_instance()
+        count = libf.wgpuInstanceEnumerateAdapters(instance, ffi.NULL, ffi.NULL)
+        adapters = ffi.new("WGPUAdapter[]", count)
+        libf.wgpuInstanceEnumerateAdapters(instance, ffi.NULL, adapters)
+        return [self._create_adapter(adapter) for adapter in adapters]
 
     def _create_adapter(self, adapter_id):
         # ----- Get adapter info
@@ -329,18 +415,6 @@ class GPU(classes.GPU):
         # ----- Done
 
         return GPUAdapter(adapter_id, features, limits, adapter_info)
-
-    async def request_adapter_async(
-        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
-    ):
-        """Async version of ``request_adapter()``.
-        This is the implementation based on wgpu-native.
-        """
-        return self.request_adapter(
-            power_preference=power_preference,
-            force_fallback_adapter=force_fallback_adapter,
-            canvas=canvas,
-        )  # no-cover
 
 
 # Instantiate API entrypoint

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -218,6 +218,8 @@ class GPU(classes.GPU):
             else:
                 logger.warning(f"Forcing backend: {force_backend} ({backend})")
 
+        # ----- Request adapter
+
         # H: nextInChain: WGPUChainedStruct *, compatibleSurface: WGPUSurface, powerPreference: WGPUPowerPreference, backendType: WGPUBackendType, forceFallbackAdapter: WGPUBool/int
         struct = new_struct_p(
             "WGPURequestAdapterOptions *",
@@ -265,10 +267,12 @@ class GPU(classes.GPU):
         )  # no-cover
 
     def enumerate_adapters(self):
-        # The first call is to get the number of adapters, and the second
-        # call is to get the actual adapters. Note that the second arg (now
-        # NULL) can be a `WGPUInstanceEnumerateAdapterOptions` to filter
-        # by backend.
+        """Get a list of adapter objects available on the current system.
+        This is the implementation based on wgpu-native.
+        """
+        # The first call is to get the number of adapters, and the second call
+        # is to get the actual adapters. Note that the second arg (now NULL) can
+        # be a `WGPUInstanceEnumerateAdapterOptions` to filter by backend.
         instance = get_wgpu_instance()
         # H: size_t f(WGPUInstance instance, WGPUInstanceEnumerateAdapterOptions const * options, WGPUAdapter * adapters)
         count = libf.wgpuInstanceEnumerateAdapters(instance, ffi.NULL, ffi.NULL)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -176,11 +176,7 @@ libf = SafeLibCalls(lib, error_handler)
 
 class GPU(classes.GPU):
     def request_adapter(
-        self,
-        *,
-        power_preference=None,
-        force_fallback_adapter=False,
-        canvas=None,
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
@@ -257,11 +253,7 @@ class GPU(classes.GPU):
         return self._create_adapter(adapter_id)
 
     async def request_adapter_async(
-        self,
-        *,
-        power_preference=None,
-        force_fallback_adapter=False,
-        canvas=None,
+        self, *, power_preference=None, force_fallback_adapter=False, canvas=None
     ):
         """Async version of ``request_adapter()``.
         This is the implementation based on wgpu-native.
@@ -278,8 +270,10 @@ class GPU(classes.GPU):
         # NULL) can be a `WGPUInstanceEnumerateAdapterOptions` to filter
         # by backend.
         instance = get_wgpu_instance()
+        # H: size_t f(WGPUInstance instance, WGPUInstanceEnumerateAdapterOptions const * options, WGPUAdapter * adapters)
         count = libf.wgpuInstanceEnumerateAdapters(instance, ffi.NULL, ffi.NULL)
         adapters = ffi.new("WGPUAdapter[]", count)
+        # H: size_t f(WGPUInstance instance, WGPUInstanceEnumerateAdapterOptions const * options, WGPUAdapter * adapters)
         libf.wgpuInstanceEnumerateAdapters(instance, ffi.NULL, adapters)
         return [self._create_adapter(adapter) for adapter in adapters]
 

--- a/wgpu/backends/wgpu_native/extras.py
+++ b/wgpu/backends/wgpu_native/extras.py
@@ -1,7 +1,6 @@
 import os
 
-from ._api import ffi, libf, structs, enums, Dict, logger
-from ._helpers import get_wgpu_instance
+from ._api import structs, enums, Dict, logger
 
 
 # NOTE: these functions represent backend-specific extra API.
@@ -11,10 +10,8 @@ from ._helpers import get_wgpu_instance
 
 
 def enumerate_adapters():
-    """Return a list of all available adapters."""
-    from . import gpu  # noqa
-
-    return gpu._enumerate_adapters()
+    """Deprecated."""
+    raise RuntimeError("Deprecated: use wgpu.gpu.enumerate_adapters() instead.")
 
 
 def request_device_tracing(

--- a/wgpu/backends/wgpu_native/extras.py
+++ b/wgpu/backends/wgpu_native/extras.py
@@ -12,21 +12,9 @@ from ._helpers import get_wgpu_instance
 
 def enumerate_adapters():
     """Return a list of all available adapters."""
-    # The first call is to get the number of adapters, and the second
-    # call is to get the actual adapters. Note that the second arg (now
-    # NULL) can be a `WGPUInstanceEnumerateAdapterOptions` to filter
-    # by backend.
-
-    adapter_count = libf.wgpuInstanceEnumerateAdapters(
-        get_wgpu_instance(), ffi.NULL, ffi.NULL
-    )
-
-    adapters = ffi.new("WGPUAdapter[]", adapter_count)
-    libf.wgpuInstanceEnumerateAdapters(get_wgpu_instance(), ffi.NULL, adapters)
-
     from . import gpu  # noqa
 
-    return [gpu._create_adapter(adapter) for adapter in adapters]
+    return gpu._enumerate_adapters()
 
 
 def request_device_tracing(

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -9,14 +9,14 @@
 * Wrote 33 enums to enums.py
 * Wrote 59 structs to structs.py
 ### Patching API for _classes.py
-* Diffs for GPU: change get_preferred_canvas_format, change request_adapter, change request_adapter_async
+* Diffs for GPU: add enumerate_adapter_info, add enumerate_adapter_info_async, change get_preferred_canvas_format, change request_adapter, change request_adapter_async
 * Diffs for GPUCanvasContext: add get_preferred_format, add present
 * Diffs for GPUDevice: add adapter, add create_buffer_with_data, hide import_external_texture, hide lost, hide onuncapturederror, hide pop_error_scope, hide push_error_scope
 * Diffs for GPUBuffer: add map_read, add map_write, add read_mapped, add write_mapped, hide get_mapped_range
 * Diffs for GPUTexture: add size
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 112 methods, 43 properties
+* Validated 37 classes, 114 methods, 43 properties
 ### Patching API for backends/wgpu_native/_api.py
 * Validated 37 classes, 107 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -9,16 +9,17 @@
 * Wrote 33 enums to enums.py
 * Wrote 59 structs to structs.py
 ### Patching API for _classes.py
-* Diffs for GPU: add enumerate_adapter_info, add enumerate_adapter_info_async, change get_preferred_canvas_format, change request_adapter, change request_adapter_async
+* Diffs for GPU: add enumerate_adapters, add enumerate_adapters_async, change get_preferred_canvas_format, change request_adapter, change request_adapter_async
 * Diffs for GPUCanvasContext: add get_preferred_format, add present
+* Diffs for GPUAdapter: add summary
 * Diffs for GPUDevice: add adapter, add create_buffer_with_data, hide import_external_texture, hide lost, hide onuncapturederror, hide pop_error_scope, hide push_error_scope
 * Diffs for GPUBuffer: add map_read, add map_write, add read_mapped, add write_mapped, hide get_mapped_range
 * Diffs for GPUTexture: add size
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 114 methods, 43 properties
+* Validated 37 classes, 114 methods, 44 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 107 methods, 0 properties
+* Validated 37 classes, 108 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum PipelineErrorReason missing in wgpu.h
 * Enum AutoLayoutMode missing in wgpu.h
@@ -26,6 +27,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 105 C function calls
-* Not using 97 C functions
+* Validated 107 C function calls
+* Not using 96 C functions
 * Validated 75 C structs


### PR DESCRIPTION
## Considerations

The idea is to allow users to specify a specific GPU, which is particularly useful in a multi-GPU setup. The tricky bits are that the kinds of GPU's differ widely between systems, and there's a human choice in the loop. You don't want to prompt the user for input each time a script is run. Instead you want a simple way to present the user with the options on the current system, and do this once. Then in subsequent runs allow the user to specify one of these options using a string.

This PR simply makes it easier to enumerate adapters and get a description of each. The user is responsible for the selection mechanism, because this is always fuzzy, and we don't know the best approach yet, see #482. When we do, we will add a builtin selection mechanism to either pygfx or wgpu.utils.

## Tasks

* [x] Add `gpu.enumerate_adapters()`.
* [x] Add `adapter.summary`, which is a single-line string that describes the adapter.
* [x] Add a unit test.
* [x] Update docs.
