### PR TITLE
Support timestamp queryset for begin_render_pass()

### DIFF
--- a/examples/compute_timestamps.py
+++ b/examples/compute_timestamps.py
@@ -127,10 +127,7 @@ as we will use this buffer in a resolve_query_set call later.
 """
 query_buf = device.create_buffer(
     size=8 * query_set.count,
-    usage=wgpu.BufferUsage.QUERY_RESOLVE
-    | wgpu.BufferUsage.STORAGE
-    | wgpu.BufferUsage.COPY_SRC
-    | wgpu.BufferUsage.COPY_DST,
+    usage=wgpu.BufferUsage.QUERY_RESOLVE | wgpu.BufferUsage.COPY_SRC,
 )
 compute_pass.set_pipeline(compute_pipeline)
 compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 elements not used

--- a/tests/test_wgpu_native_query_set.py
+++ b/tests/test_wgpu_native_query_set.py
@@ -1,8 +1,7 @@
 import wgpu.utils
 import gc
 
-from testutils import run_tests, can_use_wgpu_lib
-from tests_mem.testutils import is_pypy
+from testutils import run_tests, can_use_wgpu_lib, is_pypy
 from pytest import mark
 
 
@@ -107,12 +106,7 @@ def test_query_set():
     )
 
     query_buf_size = 8 * query_set.count
-    query_usage = (
-        wgpu.BufferUsage.QUERY_RESOLVE
-        | wgpu.BufferUsage.STORAGE
-        | wgpu.BufferUsage.COPY_SRC
-        | wgpu.BufferUsage.COPY_DST
-    )
+    query_usage = wgpu.BufferUsage.QUERY_RESOLVE | wgpu.BufferUsage.COPY_SRC
     query_buf = device.create_buffer(
         size=query_buf_size,
         usage=query_usage,

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -29,4 +29,4 @@
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
 * Validated 107 C function calls
 * Not using 96 C functions
-* Validated 75 C structs
+* Validated 76 C structs


### PR DESCRIPTION
Implementing this because I'm looking into benchmarking. See #450 for the initial implementation for compute passes.