### PR TITLE
Update the default parameters of "set_bind_group()"

### DIFF
--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -125,7 +125,7 @@ compute_pipeline = device.create_compute_pipeline(
 command_encoder = device.create_command_encoder()
 compute_pass = command_encoder.begin_compute_pass()
 compute_pass.set_pipeline(compute_pipeline)
-compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 elements not used
+compute_pass.set_bind_group(0, bind_group)
 compute_pass.dispatch_workgroups(n, 1, 1)  # x y z
 compute_pass.end()
 device.queue.submit([command_encoder.finish()])

--- a/examples/compute_timestamps.py
+++ b/examples/compute_timestamps.py
@@ -130,7 +130,7 @@ query_buf = device.create_buffer(
     usage=wgpu.BufferUsage.QUERY_RESOLVE | wgpu.BufferUsage.COPY_SRC,
 )
 compute_pass.set_pipeline(compute_pipeline)
-compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 elements not used
+compute_pass.set_bind_group(0, bind_group)
 compute_pass.dispatch_workgroups(*global_size)  # x y z
 compute_pass.end()
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -380,7 +380,7 @@ def draw_frame():
     render_pass.set_index_buffer(index_buffer, wgpu.IndexFormat.uint32)
     render_pass.set_vertex_buffer(0, vertex_buffer)
     for bind_group_id, bind_group in enumerate(bind_groups):
-        render_pass.set_bind_group(bind_group_id, bind_group, [], 0, 99)
+        render_pass.set_bind_group(bind_group_id, bind_group)
     render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
     render_pass.end()
 

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -138,7 +138,7 @@ def setup_draw(context, device):
         )
 
         render_pass.set_pipeline(render_pipeline)
-        # render_pass.set_bind_group(0, no_bind_group, [], 0, 1)
+        # render_pass.set_bind_group(0, no_bind_group)
         render_pass.draw(3, 1, 0, 0)
         render_pass.end()
         device.queue.submit([command_encoder.finish()])

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -126,7 +126,7 @@ def _main(canvas, device):
         )
 
         render_pass.set_pipeline(render_pipeline)
-        # render_pass.set_bind_group(0, no_bind_group, [], 0, 1)
+        # render_pass.set_bind_group(0, no_bind_group)
         render_pass.draw(3, 1, 0, 0)
         render_pass.end()
         device.queue.submit([command_encoder.finish()])

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -166,9 +166,7 @@ def render_to_texture(
     render_pass.set_pipeline(render_pipeline)
     render_pass.insert_debug_marker("setting bind group")
     if bind_group:
-        render_pass.set_bind_group(
-            0, bind_group, [], 0, 999999
-        )  # last 2 elements not used
+        render_pass.set_bind_group(0, bind_group)
     for slot, vbo in enumerate(vbos):
         render_pass.insert_debug_marker(f"setting vbo {slot}")
         render_pass.set_vertex_buffer(slot, vbo, 0, 0)
@@ -301,9 +299,7 @@ def render_to_screen(
         render_pass.insert_debug_marker("setting pipeline")
         render_pass.set_pipeline(render_pipeline)
         render_pass.insert_debug_marker("setting bind group")
-        render_pass.set_bind_group(
-            0, bind_group, [], 0, 999999
-        )  # last 2 elements not used
+        render_pass.set_bind_group(0, bind_group)
         for slot, vbo in enumerate(vbos):
             render_pass.insert_debug_marker(f"setting vbo {slot}")
             render_pass.set_vertex_buffer(slot, vbo, 0, vbo.size)

--- a/tests/test_util_compute.py
+++ b/tests/test_util_compute.py
@@ -271,7 +271,7 @@ def test_compute_indirect():
     command_encoder = device.create_command_encoder()
     compute_pass = command_encoder.begin_compute_pass()
     compute_pass.set_pipeline(compute_pipeline)
-    compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 args not used
+    compute_pass.set_bind_group(0, bind_group)
     compute_pass.dispatch_workgroups_indirect(buffer3, 0)
     compute_pass.end()
     device.queue.submit([command_encoder.finish()])
@@ -352,7 +352,7 @@ def test_compute_default_layout1():
     command_encoder = device.create_command_encoder()
     compute_pass = command_encoder.begin_compute_pass()
     compute_pass.set_pipeline(compute_pipeline)
-    compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 args not used
+    compute_pass.set_bind_group(0, bind_group)
     compute_pass.dispatch_workgroups_indirect(buffer3, 0)
     compute_pass.end()
     device.queue.submit([command_encoder.finish()])
@@ -440,8 +440,8 @@ def test_compute_default_layout2():
     command_encoder = device.create_command_encoder()
     compute_pass = command_encoder.begin_compute_pass()
     compute_pass.set_pipeline(compute_pipeline)
-    compute_pass.set_bind_group(0, bind_group0, [], 0, 999999)
-    compute_pass.set_bind_group(1, bind_group1, [], 0, 999999)
+    compute_pass.set_bind_group(0, bind_group0)
+    compute_pass.set_bind_group(1, bind_group1)
     compute_pass.dispatch_workgroups_indirect(buffer3, 0)
     compute_pass.end()
     device.queue.submit([command_encoder.finish()])

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -165,7 +165,7 @@ def run_compute_shader(device, shader):
     command_encoder = device.create_command_encoder()
     compute_pass = command_encoder.begin_compute_pass()
     compute_pass.set_pipeline(compute_pipeline)
-    compute_pass.set_bind_group(0, bind_group, [], 0, 999999)
+    compute_pass.set_bind_group(0, bind_group)
     compute_pass.dispatch_workgroups(n, 1, 1)  # x y z
     compute_pass.end()
     device.queue.submit([command_encoder.finish()])

--- a/tests/test_wgpu_native_compute_tex.py
+++ b/tests/test_wgpu_native_compute_tex.py
@@ -551,9 +551,7 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
     compute_pass.insert_debug_marker("setting pipeline")
     compute_pass.set_pipeline(compute_pipeline)
     compute_pass.insert_debug_marker("setting bind group")
-    compute_pass.set_bind_group(
-        0, bind_group, [], 0, 999999
-    )  # last 2 elements not used
+    compute_pass.set_bind_group(0, bind_group)
     compute_pass.insert_debug_marker("dispatch!")
     compute_pass.dispatch_workgroups(nx, ny, nz)
     compute_pass.pop_debug_group()

--- a/tests/test_wgpu_native_query_set.py
+++ b/tests/test_wgpu_native_query_set.py
@@ -116,9 +116,7 @@ def test_query_set():
     assert query_buf.usage == query_usage
 
     compute_pass.set_pipeline(compute_pipeline)
-    compute_pass.set_bind_group(
-        0, bind_group, [], 0, 999999
-    )  # last 2 elements not used
+    compute_pass.set_bind_group(0, bind_group)
     compute_pass.dispatch_workgroups(n, 1, 1)  # x y z
     compute_pass.end()
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -1424,9 +1424,9 @@ class GPUBindingCommandsMixin:
         self,
         index,
         bind_group,
-        dynamic_offsets_data,
-        dynamic_offsets_data_start,
-        dynamic_offsets_data_length,
+        dynamic_offsets_data=[],
+        dynamic_offsets_data_start=None,
+        dynamic_offsets_data_length=None,
     ):
         """Associate the given bind group (i.e. group or resources) with the
         given slot/index.

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -1437,9 +1437,9 @@ class GPUBindingCommandsMixin:
         Arguments:
             index (int): The slot to bind at.
             bind_group (GPUBindGroup): The bind group to bind.
-            dynamic_offsets_data (list of int): A list of offsets (one for each bind group).
-            dynamic_offsets_data_start (int): Not used.
-            dynamic_offsets_data_length (int): Not used.
+            dynamic_offsets_data (list of int): A list of offsets (one for each entry in bind group marked as buffer.has_dynamic_offset).Default [].
+            dynamic_offsets_data_start (int): Offset in elements into dynamic_offsets_data where the buffer offset data begins.Default None.
+            dynamic_offsets_data_length (int): Number of buffer offsets to read from dynamic_offsets_data.Default None.
         """
         raise NotImplementedError()
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -1420,6 +1420,9 @@ class GPUBindingCommandsMixin:
     """Mixin for classes that defines bindings."""
 
     # IDL: undefined setBindGroup(GPUIndex32 index, GPUBindGroup? bindGroup, Uint32Array dynamicOffsetsData, GPUSize64 dynamicOffsetsDataStart, GPUSize32 dynamicOffsetsDataLength);
+    @apidiff.change(
+        "In the WebGPU specification, this method has two different signatures."
+    )
     def set_bind_group(
         self,
         index,

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -1437,9 +1437,9 @@ class GPUBindingCommandsMixin:
         Arguments:
             index (int): The slot to bind at.
             bind_group (GPUBindGroup): The bind group to bind.
-            dynamic_offsets_data (list of int): A list of offsets (one for each entry in bind group marked as buffer.has_dynamic_offset).Default [].
-            dynamic_offsets_data_start (int): Offset in elements into dynamic_offsets_data where the buffer offset data begins.Default None.
-            dynamic_offsets_data_length (int): Number of buffer offsets to read from dynamic_offsets_data.Default None.
+            dynamic_offsets_data (list of int): A list of offsets (one for each entry in bind group marked as ``buffer.has_dynamic_offset``). Default ``[]``.
+            dynamic_offsets_data_start (int): Offset in elements into dynamic_offsets_data where the buffer offset data begins. Default None.
+            dynamic_offsets_data_length (int): Number of buffer offsets to read from dynamic_offsets_data. Default None.
         """
         raise NotImplementedError()
 

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2067,6 +2067,10 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
                 and dynamic_offsets_data_start + dynamic_offsets_data_length
                 <= len(dynamic_offsets_data)
             )
+            dynamic_offsets_data = dynamic_offsets_data[
+                dynamic_offsets_data_start : dynamic_offsets_data_start
+                + dynamic_offsets_data_length
+            ]
 
         offsets = list(dynamic_offsets_data)
         c_offsets = ffi.new("uint32_t []", offsets)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2067,10 +2067,6 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
                 and dynamic_offsets_data_start + dynamic_offsets_data_length
                 <= len(dynamic_offsets_data)
             )
-            dynamic_offsets_data = dynamic_offsets_data[
-                dynamic_offsets_data_start : dynamic_offsets_data_start
-                + dynamic_offsets_data_length
-            ]
 
         offsets = list(dynamic_offsets_data)
         c_offsets = ffi.new("uint32_t []", offsets)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2065,10 +2065,10 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
                 raise ValueError(
                     "Dynamic offsets start and length must be both set or both None."
                 )
-            if dynamic_offsets_data_start < 0 or dynamic_offsets_data_length < 0:
-                raise ValueError(
-                    "Dynamic offsets start and length must be non-negative."
-                )
+            if dynamic_offsets_data_start < 0:
+                raise ValueError("Dynamic offsets start must be non-negative.")
+            if dynamic_offsets_data_length < 0:
+                raise ValueError("Dynamic offsets length must be non-negative.")
 
             dynamic_offsets_data = dynamic_offsets_data[
                 dynamic_offsets_data_start : dynamic_offsets_data_start

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2058,15 +2058,18 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
             dynamic_offsets_data_start is not None
             or dynamic_offsets_data_length is not None
         ):
-            assert (
-                dynamic_offsets_data_start is not None
-                and dynamic_offsets_data_start >= 0
-            )
-            assert (
-                dynamic_offsets_data_length is not None
-                and dynamic_offsets_data_start + dynamic_offsets_data_length
-                <= len(dynamic_offsets_data)
-            )
+            if (
+                dynamic_offsets_data_start is None
+                or dynamic_offsets_data_length is None
+            ):
+                raise ValueError(
+                    "Dynamic offsets start and length must be both set or both None."
+                )
+            if dynamic_offsets_data_start < 0 or dynamic_offsets_data_length < 0:
+                raise ValueError(
+                    "Dynamic offsets start and length must be non-negative."
+                )
+
             dynamic_offsets_data = dynamic_offsets_data[
                 dynamic_offsets_data_start : dynamic_offsets_data_start
                 + dynamic_offsets_data_length

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2050,10 +2050,28 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
         self,
         index,
         bind_group,
-        dynamic_offsets_data,
-        dynamic_offsets_data_start,
-        dynamic_offsets_data_length,
+        dynamic_offsets_data=[],
+        dynamic_offsets_data_start=None,
+        dynamic_offsets_data_length=None,
     ):
+        if (
+            dynamic_offsets_data_start is not None
+            or dynamic_offsets_data_length is not None
+        ):
+            assert (
+                dynamic_offsets_data_start is not None
+                and dynamic_offsets_data_start >= 0
+            )
+            assert (
+                dynamic_offsets_data_length is not None
+                and dynamic_offsets_data_start + dynamic_offsets_data_length
+                <= len(dynamic_offsets_data)
+            )
+            dynamic_offsets_data = dynamic_offsets_data[
+                dynamic_offsets_data_start : dynamic_offsets_data_start
+                + dynamic_offsets_data_length
+            ]
+
         offsets = list(dynamic_offsets_data)
         c_offsets = ffi.new("uint32_t []", offsets)
         bind_group_id = bind_group._internal

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -16,6 +16,7 @@
 * Diffs for GPUBuffer: add map_read, add map_write, add read_mapped, add write_mapped, hide get_mapped_range
 * Diffs for GPUTexture: add size
 * Diffs for GPUTextureView: add size, add texture
+* Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 114 methods, 44 properties
 ### Patching API for backends/wgpu_native/_api.py

--- a/wgpu/utils/compute.py
+++ b/wgpu/utils/compute.py
@@ -170,7 +170,7 @@ def compute_with_buffers(input_arrays, output_arrays, shader, n=None):
     command_encoder = device.create_command_encoder()
     compute_pass = command_encoder.begin_compute_pass()
     compute_pass.set_pipeline(compute_pipeline)
-    compute_pass.set_bind_group(0, bind_group, [], 0, 999999)  # last 2 args not used
+    compute_pass.set_bind_group(0, bind_group)
     compute_pass.dispatch_workgroups(nx, ny, nz)
     compute_pass.end()
     device.queue.submit([command_encoder.finish()])


### PR DESCRIPTION
When setting bind groups, we often have code like this:
`render_pass.set_bind_group(0, bind_group, [], 0, 99)`

According to the WebGPU specification, this method has two overloaded different method signatures. 
The `dynamic_offsets` parameter has a default value of `[]`, and the last two parameters can also be omitted, indicate to direct passing of an array of dynamic offsets without copy.

The current usage is quite odd, as it requires users to provide parameters that are not actually used, which can cause confusion.

See: https://www.w3.org/TR/webgpu/#gpubindingcommandsmixin-setbindgroup

When setting a bind group, we can simplify the code to:
`render_pass.set_bind_group(0, bind_group)`