### PR TITLE
Add args to utils.get_default_device()

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -22,8 +22,7 @@ for a in wgpu.gpu.enumerate_adapters():
 canvas = WgpuCanvas(title="wgpu cube", size=(640, 480))
 
 # Create a wgpu device
-adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
-device = adapter.request_device()
+device = wgpu.utils.get_default_device()
 
 # Prepare present context
 present_context = canvas.get_context()

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -62,8 +62,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
 def main(canvas, power_preference="high-performance", limits=None):
     """Regular function to setup a viz on the given canvas."""
-    adapter = wgpu.gpu.request_adapter(power_preference=power_preference)
-    device = adapter.request_device(required_limits=limits)
+    device = wgpu.utils.get_default_device(required_limits=limits)
     return _main(canvas, device)
 
 

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -47,8 +47,7 @@ void main()
 
 def main(canvas, power_preference="high-performance", limits=None):
     """Regular function to setup a viz on the given canvas."""
-    adapter = wgpu.gpu.request_adapter(power_preference=power_preference)
-    device = adapter.request_device(required_limits=limits)
+    device = wgpu.utils.get_default_device(required_limits=limits)
     return _main(canvas, device)
 
 

--- a/wgpu/utils/device.py
+++ b/wgpu/utils/device.py
@@ -1,11 +1,14 @@
 _default_device = None
 
 
-def get_default_device():
+def get_default_device(required_features=[], required_limits={}):
     """Get a wgpu device object. If this succeeds, it's likely that
     the WGPU lib is usable on this system. If not, this call will
     probably exit (Rust panic). When called multiple times,
     returns the same global device object (useful for e.g. unit tests).
+    Parameters:
+        required_features (list of str|`wgpu.FeatureName`): the features (extensions) that you need. Default [].
+        required_limits (dict): the various limits that you need. Default {}.
     """
     global _default_device
 
@@ -13,5 +16,7 @@ def get_default_device():
         import wgpu.backends.auto  # noqa
 
         adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
-        _default_device = adapter.request_device()
+        _default_device = adapter.request_device(
+            required_features=required_features, required_limits=required_limits
+        )
     return _default_device


### PR DESCRIPTION
### Motivation
The `wgpu.utils.get_default_device()` function is really convenient, especially for the test suite. However it only request the device without any features (or limits). So in cases where a specific feature is always required, it would be nice to use this same function - with features passed to the `request_device()` method. I have a usecase for this in `wgpu-shadertoy` now.

### Issues
Since this sets a global device, it will actually skip if you subsequently request a device with more features. One case being https://github.com/pygfx/wgpu-py/blob/ed9c451fe8eb2f1210df632cae8b7ec1199f982d/examples/compute_timestamps.py#L44-L47 which will work on it's own, but fail during the example tests. 
A possible solution, is likely to discard the current global device, if it is is missing the required features and request a new one.