### PR TITLE
Implement destroy

### DIFF
--- a/tests_mem/test_destroy.py
+++ b/tests_mem/test_destroy.py
@@ -1,0 +1,103 @@
+"""
+A few objects have a destroy method. We test its behavior here.
+In practice it does not really affect the lifetime, so these tests look
+a lot like the corresponding release tests :)
+"""
+
+import pytest
+import testutils  # noqa
+from testutils import can_use_wgpu_lib, create_and_release
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need wgpu lib", allow_module_level=True)
+
+
+import wgpu
+
+DEVICE = wgpu.utils.get_default_device()
+
+
+@create_and_release
+def test_destroy_device(n):
+    yield {
+        "expected_counts_after_create": {"Device": (n, n), "Queue": (n, n)},
+    }
+
+    adapter = DEVICE.adapter
+    for i in range(n):
+        d = adapter.request_device()
+        d.destroy()
+        # NOTE: destroy is not yet implemented in wgpu-natice - this does not actually do anything yet
+        yield d
+
+
+@create_and_release
+def test_destroy_query_set(n):
+    yield {}
+    for i in range(n):
+        qs = DEVICE.create_query_set(type=wgpu.QueryType.occlusion, count=2)
+        qs.destroy()
+        # NOTE: destroy is not yet implemented in wgpu-natice - this does not actually do anything yet
+        yield qs
+
+
+@create_and_release
+def test_destroy_buffer(n):
+    yield {}
+    for i in range(n):
+        b = DEVICE.create_buffer(
+            size=128, usage=wgpu.MapMode.READ | wgpu.BufferUsage.COPY_DST
+        )
+        b.destroy()
+        b.destroy()  # fine to call multiple times
+
+        # The buffer is now in a destroyed state (in wgpu-core). It still exists, its size and usage
+        # can still be queries from wgpu-native, but it cannot be used.
+
+        # Uncomment the following lines to see. These are commented because it makes wgpu-core create a command-buffer.
+        # try:
+        #     b.map("READ")
+        # except wgpu.GPUValidationError as err:
+        #     error = err
+        # assert "destroyed" in error.message.lower()
+
+        yield b
+
+
+@create_and_release
+def test_destroy_texture(n):
+    yield {}
+    for i in range(n):
+        t = DEVICE.create_texture(
+            size=(16, 16, 16),
+            usage=wgpu.TextureUsage.TEXTURE_BINDING,
+            format="rgba8unorm",
+        )
+        t.destroy()
+
+        # Uncomment the following lines to see. These are commented because the views are created at the native side, but we never store them, but we also don't release them.
+        # try:
+        #     t.create_view()
+        # except wgpu.GPUValidationError as err:
+        #     error = err
+        # assert "destroyed" in error.message.lower()
+        yield t
+
+
+# %% The end
+
+
+TEST_FUNCS = [
+    ob
+    for name, ob in list(globals().items())
+    if name.startswith("test_") and callable(ob)
+]
+
+if __name__ == "__main__":
+    # testutils.TEST_ITERS = 40  # Uncomment for a mem-usage test run
+
+    test_destroy_device()
+    test_destroy_query_set()
+    test_destroy_buffer()
+    test_destroy_texture()

--- a/tests_mem/test_meta.py
+++ b/tests_mem/test_meta.py
@@ -61,8 +61,8 @@ def test_meta_buffers_1():
 def test_meta_buffers_2():
     """Making sure that the test indeed fails, by disabling the release call."""
 
-    ori = wgpu.backends.wgpu_native.GPUBuffer._destroy
-    wgpu.backends.wgpu_native.GPUBuffer._destroy = lambda self: None
+    ori = wgpu.backends.wgpu_native.GPUBuffer._release
+    wgpu.backends.wgpu_native.GPUBuffer._release = lambda self: None
 
     from test_objects import test_release_buffer  # noqa
 
@@ -71,7 +71,7 @@ def test_meta_buffers_2():
             test_release_buffer()
 
     finally:
-        wgpu.backends.wgpu_native.GPUBuffer._destroy = ori
+        wgpu.backends.wgpu_native.GPUBuffer._release = ori
 
 
 if __name__ == "__main__":

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -353,26 +353,6 @@ def test_release_texture_view(n):
         yield texture.create_view()
 
 
-# @create_and_release
-# def test_destroy_device(n):
-#     yield {
-#         "expected_counts_after_create": {"Device": (n, n), "Queue": (n, n)},
-#     }
-#
-#     adapter = DEVICE.adapter
-#     for i in range(n):
-#         d = adapter.request_device()
-#         d.destroy()
-#         yield d
-
-
-@create_and_release
-def test_destroy_buffer(n):
-    yield {}
-    for i in range(n):
-        yield DEVICE.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
-
-
 # %% The end
 
 

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -34,8 +34,6 @@ def test_release_device(n):
     adapter = DEVICE.adapter
     for i in range(n):
         d = adapter.request_device()
-        # d.queue._destroy()
-        # d._queue = None
         yield d
 
 
@@ -353,6 +351,26 @@ def test_release_texture_view(n):
     yield {}
     for i in range(n):
         yield texture.create_view()
+
+
+# @create_and_release
+# def test_destroy_device(n):
+#     yield {
+#         "expected_counts_after_create": {"Device": (n, n), "Queue": (n, n)},
+#     }
+#
+#     adapter = DEVICE.adapter
+#     for i in range(n):
+#         d = adapter.request_device()
+#         d.destroy()
+#         yield d
+
+
+@create_and_release
+def test_destroy_buffer(n):
+    yield {}
+    for i in range(n):
+        yield DEVICE.create_buffer(size=128, usage=wgpu.BufferUsage.COPY_DST)
 
 
 # %% The end

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -132,8 +132,11 @@ def get_excess_counts(counts1, counts2):
 def ob_name_from_test_func(func):
     """Translate test_release_bind_group() to "BindGroup"."""
     func_name = func.__name__
-    prefix = "test_release_"
-    assert func_name.startswith(prefix)
+    prefixes = "test_release_", "test_destroy"
+    assert func_name.startswith(prefixes)
+    for prefix in prefixes:
+        if func_name.startswith(prefix):
+            break
     words = func_name[len(prefix) :].split("_")
     if words[-1].isnumeric():
         words.pop(-1)

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -256,9 +256,9 @@ class GPUCanvasContext:
 
     def __del__(self):
         self._ot.decrease(self.__class__.__name__)
-        self._destroy()
+        self._release()
 
-    def _destroy(self):
+    def _release(self):
         pass
 
 
@@ -364,12 +364,12 @@ class GPUAdapter:
         """Async version of `request_device()`."""
         raise NotImplementedError()
 
-    def _destroy(self):
+    def _release(self):
         pass
 
     def __del__(self):
         self._ot.decrease(self.__class__.__name__)
-        self._destroy()
+        self._release()
 
     # IDL: readonly attribute boolean isFallbackAdapter;
     @property
@@ -419,13 +419,13 @@ class GPUObjectBase:
         """A human-readable name identifying the GPU object."""
         return self._label
 
-    def _destroy(self):
+    def _release(self):
         """Subclasses can implement this to clean up."""
         pass
 
     def __del__(self):
         self._ot.decrease(self.__class__.__name__, self._nbytes)
-        self._destroy()
+        self._release()
 
     # Public destroy() methods are implemented on classes as the WebGPU spec specifies.
 
@@ -499,8 +499,15 @@ class GPUDevice(GPUObjectBase):
 
     # IDL: undefined destroy();
     def destroy(self):
-        """Destroy this device."""
-        return self._destroy()
+        """Destroy this device.
+
+        This cleans up all its resources and puts it in an unusable state.
+        Note that all objects get cleaned up properly automatically; this
+        is only intended to support explicit destroying.
+
+        NOTE: not yet implemented; for the moment this does nothing.
+        """
+        raise NotImplementedError()
 
     # IDL: GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     def create_buffer(
@@ -1146,9 +1153,11 @@ class GPUBuffer(GPUObjectBase):
 
     # IDL: undefined destroy();
     def destroy(self):
-        """An application that no longer requires a buffer can choose
-        to destroy it. Note that this is automatically called when the
-        Python object is cleaned up by the garbadge collector.
+        """Destroy the buffer.
+
+        Explicitly destroys the buffer, freeing its memory and putting
+        the object in an unusable state. In general its easier (and
+        safer) to just let the garbadhe collector do its thing.
         """
         raise NotImplementedError()
 
@@ -1274,9 +1283,11 @@ class GPUTexture(GPUObjectBase):
 
     # IDL: undefined destroy();
     def destroy(self):
-        """An application that no longer requires a texture can choose
-        to destroy it. Note that this is automatically called when the
-        Python object is cleaned up by the garbadge collector.
+        """Destroy the texture.
+
+        Explicitly destroys the texture, freeing its memory and putting
+        the object in an unusable state. In general its easier (and
+        safer) to just let the garbadhe collector do its thing.
         """
         raise NotImplementedError()
 
@@ -2094,7 +2105,14 @@ class GPUQuerySet(GPUObjectBase):
 
     # IDL: undefined destroy();
     def destroy(self):
-        """Destroy this QuerySet."""
+        """Destroy the QuerySet.
+
+        This cleans up all its resources and puts it in an unusable state.
+        Note that all objects get cleaned up properly automatically; this
+        is only intended to support explicit destroying.
+
+        NOTE: not yet implemented; for the moment this does nothing.
+        """
         raise NotImplementedError()
 
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -1157,7 +1157,7 @@ class GPUBuffer(GPUObjectBase):
 
         Explicitly destroys the buffer, freeing its memory and putting
         the object in an unusable state. In general its easier (and
-        safer) to just let the garbadhe collector do its thing.
+        safer) to just let the garbage collector do its thing.
         """
         raise NotImplementedError()
 
@@ -1287,7 +1287,7 @@ class GPUTexture(GPUObjectBase):
 
         Explicitly destroys the texture, freeing its memory and putting
         the object in an unusable state. In general its easier (and
-        safer) to just let the garbadhe collector do its thing.
+        safer) to just let the garbage collector do its thing.
         """
         raise NotImplementedError()
 

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -508,8 +508,8 @@ class GPUCanvasContext(classes.GPUCanvasContext):
         self._configure(config)
 
     def _configure(self, config):
-        # If a texture is still active, better destroy it first
-        self._destroy_texture()
+        # If a texture is still active, better release it first
+        self._drop_texture()
         # Set the size
         width, height = self._get_canvas().get_physical_size()
         config.width = width
@@ -524,14 +524,14 @@ class GPUCanvasContext(classes.GPUCanvasContext):
         self._config = config
 
     def unconfigure(self):
-        self._destroy_texture()
+        self._drop_texture()
         self._config = None
         # H: void f(WGPUSurface surface)
         libf.wgpuSurfaceUnconfigure(self._get_surface_id())
 
-    def _destroy_texture(self):
+    def _drop_texture(self):
         if self._texture:
-            self._texture.destroy()
+            self._texture._release()  # not destroy, because it may be in use.
             self._texture = None
 
     def get_current_texture(self):
@@ -547,7 +547,7 @@ class GPUCanvasContext(classes.GPUCanvasContext):
         # * raise an error
         # Right now we do the warning, so things still (kinda) keep working
         if self._texture:
-            self._destroy_texture()
+            self._drop_texture()
             logger.warning(
                 "get_current_texture() is called multiple times before pesent()."
             )
@@ -680,7 +680,7 @@ class GPUCanvasContext(classes.GPUCanvasContext):
             # Present the texture, then destroy it
             # H: void f(WGPUSurface surface)
             libf.wgpuSurfacePresent(self._get_surface_id())
-            self._destroy_texture()
+            self._drop_texture()
 
     def get_preferred_format(self, adapter):
         # H: WGPUTextureFormat f(WGPUSurface surface, WGPUAdapter adapter)
@@ -689,8 +689,8 @@ class GPUCanvasContext(classes.GPUCanvasContext):
         )
         return enum_int2str["TextureFormat"][format]
 
-    def _destroy(self):
-        self._destroy_texture()
+    def _release(self):
+        self._drop_texture()
         if self._surface_id is not None and libf is not None:
             self._surface_id, surface_id = None, self._surface_id
             # H: void f(WGPUSurface surface)
@@ -889,7 +889,7 @@ class GPUAdapter(classes.GPUAdapter):
             label, required_features, required_limits, default_queue, ""
         )  # no-cover
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUAdapter adapter)
@@ -1661,15 +1661,21 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         query_id = libf.wgpuDeviceCreateQuerySet(self._internal, query_set_descriptor)
         return GPUQuerySet(label, query_id, self._internal, type, count)
 
-    def _destroy(self):
+    def destroy(self):
+        # Note: not yet implemented in wgpu-core, the wgpu-native func is a noop
+        internal = self._internal
+        if internal is not None:
+            # H: void f(WGPUDevice device)
+            libf.wgpuDeviceDestroy(internal)
+
+    def _release(self):
         if self._queue is not None:
-            self._queue._destroy()
+            self._queue._release()
             self._queue = None
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUDevice device)
             libf.wgpuDeviceRelease(internal)
-            # wgpuDeviceDestroy(internal) is also an option
 
 
 class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
@@ -1681,6 +1687,10 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
         # If mapped at creation, set to write mode (no point in reading zeros)
         if self._map_state == enums.BufferMapState.mapped:
             self._mapped_status = 0, self.size, flags.MapMode.WRITE
+
+    def _get_size(self):
+        # H: WGPUBufferUsageFlags f(WGPUBuffer buffer)
+        return libf.wgpuBufferGetUsage(self._internal)
 
     def _check_range(self, offset, size):
         # Apply defaults
@@ -1854,9 +1864,15 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
         src_m[:] = data
 
     def destroy(self):
-        self._destroy()  # no-cover
+        # NOTE: destroy means that the wgpu-core object gets into a destroyed
+        # state. The wgpu-core object still exists. So destroying is quite
+        # different from releasing.
+        internal = self._internal
+        if internal is not None:
+            # H: void f(WGPUBuffer buffer)
+            libf.wgpuBufferDestroy(internal)
 
-    def _destroy(self):
+    def _release(self):
         self._release_memoryviews()
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
@@ -1907,14 +1923,18 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
             arrayLayerCount=array_layer_count,
             # not used: nextInChain
         )
+
         # H: WGPUTextureView f(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor)
         id = libf.wgpuTextureCreateView(self._internal, struct)
         return GPUTextureView(label, id, self._device, self, self.size)
 
     def destroy(self):
-        self._destroy()  # no-cover
+        internal = self._internal
+        if internal is not None:
+            # H: void f(WGPUTexture texture)
+            libf.wgpuTextureDestroy(internal)
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUTexture texture)
@@ -1922,7 +1942,7 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
 
 
 class GPUTextureView(classes.GPUTextureView, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUTextureView textureView)
@@ -1930,7 +1950,7 @@ class GPUTextureView(classes.GPUTextureView, GPUObjectBase):
 
 
 class GPUSampler(classes.GPUSampler, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUSampler sampler)
@@ -1938,7 +1958,7 @@ class GPUSampler(classes.GPUSampler, GPUObjectBase):
 
 
 class GPUBindGroupLayout(classes.GPUBindGroupLayout, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUBindGroupLayout bindGroupLayout)
@@ -1946,7 +1966,7 @@ class GPUBindGroupLayout(classes.GPUBindGroupLayout, GPUObjectBase):
 
 
 class GPUBindGroup(classes.GPUBindGroup, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUBindGroup bindGroup)
@@ -1954,7 +1974,7 @@ class GPUBindGroup(classes.GPUBindGroup, GPUObjectBase):
 
 
 class GPUPipelineLayout(classes.GPUPipelineLayout, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUPipelineLayout pipelineLayout)
@@ -1993,7 +2013,7 @@ class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
 
         return []
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUShaderModule shaderModule)
@@ -2015,7 +2035,7 @@ class GPUPipelineBase(classes.GPUPipelineBase):
 
 
 class GPUComputePipeline(classes.GPUComputePipeline, GPUPipelineBase, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePipeline computePipeline)
@@ -2023,7 +2043,7 @@ class GPUComputePipeline(classes.GPUComputePipeline, GPUPipelineBase, GPUObjectB
 
 
 class GPURenderPipeline(classes.GPURenderPipeline, GPUPipelineBase, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPipeline renderPipeline)
@@ -2031,7 +2051,7 @@ class GPURenderPipeline(classes.GPURenderPipeline, GPUPipelineBase, GPUObjectBas
 
 
 class GPUCommandBuffer(classes.GPUCommandBuffer, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         # Note that command buffers get destroyed when they are submitted.
         # In earlier versions we had to take this into account by setting
         # _internal to None. That seems not necessary anymore.
@@ -2585,9 +2605,9 @@ class GPUCommandEncoder(
             int(destination_offset),
         )
 
-    def _destroy(self):
+    def _release(self):
         # Note that the native object gets destroyed on finish.
-        # Also see GPUCommandBuffer._destroy()
+        # Also see GPUCommandBuffer._release()
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUCommandEncoder commandEncoder)
@@ -2627,7 +2647,7 @@ class GPUComputePassEncoder(
         # H: void f(WGPUComputePassEncoder computePassEncoder)
         libf.wgpuComputePassEncoderEnd(self._internal)
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUComputePassEncoder computePassEncoder)
@@ -2690,7 +2710,7 @@ class GPURenderPassEncoder(
     def end_occlusion_query(self):
         raise NotImplementedError()
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderPassEncoder renderPassEncoder)
@@ -2708,7 +2728,7 @@ class GPURenderBundleEncoder(
     def finish(self, *, label=""):
         raise NotImplementedError()
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderBundleEncoder renderBundleEncoder)
@@ -2784,6 +2804,8 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         # Download from mappable buffer
         tmp_buffer.map("READ_NOSYNC")
         data = tmp_buffer.read_mapped()
+
+        # Explicit drop.
         tmp_buffer.destroy()
 
         return data
@@ -2890,6 +2912,8 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         # Download from mappable buffer
         tmp_buffer.map("READ_NOSYNC")
         data = tmp_buffer.read_mapped()
+
+        # Explicit drop.
         tmp_buffer.destroy()
 
         # Fix data strides if necessary
@@ -2913,7 +2937,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
     def on_submitted_work_done(self):
         raise NotImplementedError()
 
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUQueue queue)
@@ -2921,7 +2945,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
 
 
 class GPURenderBundle(classes.GPURenderBundle, GPUObjectBase):
-    def _destroy(self):
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPURenderBundle renderBundle)
@@ -2929,14 +2953,18 @@ class GPURenderBundle(classes.GPURenderBundle, GPUObjectBase):
 
 
 class GPUQuerySet(classes.GPUQuerySet, GPUObjectBase):
-    def _destroy(self):
+    def destroy(self):
+        # Note: not yet implemented in wgpu-core, the wgpu-native func is a noop
+        internal = self._internal
+        if internal is not None:
+            # H: void f(WGPUQuerySet querySet)
+            libf.wgpuQuerySetDestroy(internal)
+
+    def _release(self):
         if self._internal is not None and libf is not None:
             self._internal, internal = None, self._internal
             # H: void f(WGPUQuerySet querySet)
             libf.wgpuQuerySetRelease(internal)
-
-    def destroy(self):
-        self._destroy()
 
 
 # %% Subclasses that don't need anything else

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 114 methods, 44 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 108 methods, 0 properties
+* Validated 37 classes, 110 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum PipelineErrorReason missing in wgpu.h
 * Enum AutoLayoutMode missing in wgpu.h
@@ -28,6 +28,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 107 C function calls
-* Not using 96 C functions
+* Validated 112 C function calls
+* Not using 91 C functions
 * Validated 76 C structs


### PR DESCRIPTION
* [x] Rename the `_destroy()`  methods to `_release()`, becauase that's what they do.
* [x] Make the public `destroy()` methods do the actual destroy call.
     * Only device, queryset, buffer, and texture have these.
     * Only actually does something for buffer and texture. But when wgpu-native implements it for device, we will do so automatically.
    * See https://github.com/gfx-rs/wgpu-native/blob/33133da4ec5a0174cb21539ef2d3346f75200411/src/lib.rs#L2491-L2493  
* [x] Improve docsrings for `destroy()`.
* [x] Tests. 