### PR TITLE
Add experimental support for get_mapped_range

### DIFF
--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1759,7 +1759,8 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
             self._internal, map_mode, offset, size, callback, ffi.NULL
         )
 
-        # Let it do some cycles
+        # Wait for the queue to process all tasks (including the mapping of the buffer).
+        # Also see WebGPU's onSubmittedWorkDone() and C's WGPUQueueWorkDoneCallback.
         self._device._poll()
 
         if status != 0:  # no-cover
@@ -1862,6 +1863,31 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
 
         # Copy data
         src_m[:] = data
+
+    def _experimental_get_mapped_range(self, buffer_offset=None, size=None):
+        """Undocumented and experimental. This API can change or be
+        removed without notice. Just here so we can benchmark this
+        approach. Returns a mapped memoryview object that can be written
+        to. Note that once the buffer unmaps, this memoryview object
+        becomes unusable, and accessing it may result in a segfault.
+        """
+        # Can we even write?
+        if self._map_state != enums.BufferMapState.mapped:
+            raise RuntimeError("Can only write to a buffer if its mapped.")
+
+        offset, size = self._check_range(buffer_offset, size)
+        if offset < self._mapped_status[0] or (offset + size) > self._mapped_status[1]:
+            raise ValueError(
+                "The range for buffer writing is not contained in the currently mapped range."
+            )
+
+        # Get mapped memoryview
+        # H: void * f(WGPUBuffer buffer, size_t offset, size_t size)
+        src_ptr = libf.wgpuBufferGetMappedRange(self._internal, offset, size)
+        src_address = int(ffi.cast("intptr_t", src_ptr))
+        src_m = get_memoryview_from_address(src_address, size)
+
+        return src_m
 
     def destroy(self):
         # NOTE: destroy means that the wgpu-core object gets into a destroyed

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 114 methods, 44 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 110 methods, 0 properties
+* Validated 37 classes, 111 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum PipelineErrorReason missing in wgpu.h
 * Enum AutoLayoutMode missing in wgpu.h
@@ -28,6 +28,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 112 C function calls
+* Validated 113 C function calls
 * Not using 91 C functions
 * Validated 76 C structs


### PR DESCRIPTION
Relates to #513 

This adds the API that I was reluctant to add, because its prone to the user (accidentally) using the mapped array after it becomes unmapped. However, there are potential performance benefits. I want us (and others) to be able to investigate its use. 

My proposal is to add it as an experimental and undocumented method. In time, when we know more about how useful it is, we can think about a public API for (something like) this.

Also adds an unrelated comment to `_poll()`.