### PR TITLE
Don't call _tuple_from_tuple_or_dict directly, but got thrown an intermediate function

### DIFF
--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -78,15 +78,7 @@ def test_tuple_from_tuple_or_dict():
     assert func({}, ("width", "height"), (10, 20)) == (10, 20)
 
     # Test that with dictionaries, you can elide values at the beginning, if we have them
-    assert func(
-        {"z": 5},
-        ("x", "y", "z"),
-        (
-            1,
-            2,
-            3,
-        ),
-    ) == (1, 2, 5)
+    assert func({"z": 5}, ("x", "y", "z"), (1, 2, 3)) == (1, 2, 5)
 
     with raises(TypeError):
         func("not tuple/dict", ("x", "y"))

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -78,7 +78,15 @@ def test_tuple_from_tuple_or_dict():
     assert func({}, ("width", "height"), (10, 20)) == (10, 20)
 
     # Test that with dictionaries, you can elide values at the beginning, if we have them
-    assert func({"z": 5}, ("x", "y", "z"), (1, 2, 3,)) == (1, 2, 5)
+    assert func(
+        {"z": 5},
+        ("x", "y", "z"),
+        (
+            1,
+            2,
+            3,
+        ),
+    ) == (1, 2, 5)
 
     with raises(TypeError):
         func("not tuple/dict", ("x", "y"))
@@ -105,8 +113,11 @@ def test_tuple_from_extent3d():
     assert func([10, 20, 30]) == (10, 20, 30)
     assert func([10, 20]) == (10, 20, 1)
     assert func([10]) == (10, 1, 1)
-    assert func({"width": 10, "height": 20, "depth_or_array_layers": 30}
-                ) == (10, 20, 30)
+    assert func({"width": 10, "height": 20, "depth_or_array_layers": 30}) == (
+        10,
+        20,
+        30,
+    )
     assert func({"width": 10, "height": 20}) == (10, 20, 1)
     assert func({"width": 10, "depth_or_array_layers": 30}) == (10, 1, 30)
 

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -63,10 +63,22 @@ def test_override_wgpu_lib_path():
 def test_tuple_from_tuple_or_dict():
     func = wgpu.backends.wgpu_native._api._tuple_from_tuple_or_dict
 
+    # Test all values being required.
     assert func([1, 2, 3], ("x", "y", "z")) == (1, 2, 3)
     assert func({"y": 2, "z": 3, "x": 1}, ("x", "y", "z")) == (1, 2, 3)
     assert func((10, 20), ("width", "height")) == (10, 20)
     assert func({"width": 10, "height": 20}, ("width", "height")) == (10, 20)
+
+    # Test having a default value
+    assert func([1, 2, 3], ("x", "y", "z"), (3,)) == (1, 2, 3)
+    assert func([1, 2], ("x", "y", "z"), (3,)) == (1, 2, 3)
+    assert func({"y": 2, "z": 3, "x": 1}, ("x", "y", "z"), (3,)) == (1, 2, 3)
+    assert func({"y": 2, "x": 1}, ("x", "y", "z"), (3,)) == (1, 2, 3)
+    assert func((), ("width", "height"), (10, 20)) == (10, 20)
+    assert func({}, ("width", "height"), (10, 20)) == (10, 20)
+
+    # Test that with dictionaries, you can elide values at the beginning, if we have them
+    assert func({"z": 5}, ("x", "y", "z"), (1, 2, 3,)) == (1, 2, 5)
 
     with raises(TypeError):
         func("not tuple/dict", ("x", "y"))
@@ -76,6 +88,76 @@ def test_tuple_from_tuple_or_dict():
         func([1, 2, 3], ("x", "y"))
     with raises(ValueError):
         assert func({"x": 1}, ("x", "y"))
+    with raises(ValueError):
+        # not enough defaults
+        func([1], ("x", "y", "z"), (2,))
+    with raises(ValueError):
+        # we can elide y, but we can't elide x
+        func({"y": 2}, ("x", "y"), (1,))
+    with raises(ValueError):
+        # Right number of arguments, but wrong keyword
+        assert func({"y": 2, "x": 1, "w": 10}, ("x", "y", "z"))
+
+
+def test_tuple_from_extent3d():
+    func = wgpu.backends.wgpu_native._api._tuple_from_extent3d
+
+    assert func([10, 20, 30]) == (10, 20, 30)
+    assert func([10, 20]) == (10, 20, 1)
+    assert func([10]) == (10, 1, 1)
+    assert func({"width": 10, "height": 20, "depth_or_array_layers": 30}
+                ) == (10, 20, 30)
+    assert func({"width": 10, "height": 20}) == (10, 20, 1)
+    assert func({"width": 10, "depth_or_array_layers": 30}) == (10, 1, 30)
+
+    with raises(ValueError):
+        func({"height": 20, "depth_or_array_layers": 30})  # width is required
+    with raises(ValueError):
+        func(())
+    with raises(ValueError):
+        # typo in argument
+        func({"width": 10, "height": 20, "depth_or_arrray_layers": 30})
+
+
+def test_tuple_from_blend_components():
+    func = wgpu.backends.wgpu_native._api._tuple_from_blend_component
+
+    assert func(("x", "y", "z")) == ("x", "y", "z")
+    assert func([]) == ("add", "one", "zero")
+    assert func({"operation": "j", "src_factor": 9, "dst_factor": "d"}) == (9, "d", "j")
+    assert func({}) == ("add", "one", "zero")
+
+    with raises(ValueError):
+        func([1, 2, 3, 4, 5])  # too many values
+    with raises(ValueError):
+        func([1, 2, 3, 4, 5])  # too many values
+
+
+def test_tuple_from_origin3d():
+    func = wgpu.backends.wgpu_native._api._tuple_from_origin3d
+
+    assert func({"origin": (1, 2, 3)}) == (1, 2, 3)
+    assert func({"origin": ()}) == (0, 0, 0)
+    assert func({}) == (0, 0, 0)
+    assert func({"origin": {"x": 10, "y": 20, "z": 30}}) == (10, 20, 30)
+    assert func({"origin": {"z": 30}}) == (0, 0, 30)
+
+    with raises(ValueError):
+        func({"origin": {"x": 10, "y": 20, "z": 30, "w": 40}})
+
+
+def test_tuple_from_color():
+    func = wgpu.backends.wgpu_native._api._tuple_from_color
+
+    assert func((0.1, 0.2, 0.3, 0.4)) == (0.1, 0.2, 0.3, 0.4)
+    assert func({"r": 0.1, "g": 0.2, "b": 0.3, "a": 0.4}) == (0.1, 0.2, 0.3, 0.4)
+
+    with raises(ValueError):
+        func((0.1, 0.2, 0.3))
+    with raises(ValueError):
+        func((0.1, 0.2, 0.3, 0.4, 0.5))
+    with raises(ValueError):
+        func({"r": 0.1, "g": 0.2, "b": 0.3, "w": 0.4})
 
 
 compute_shader_wgsl = """

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -114,7 +114,7 @@ def _new_struct_p(ctype, **kwargs):
     return struct_p
 
 
-def _tuple_from_tuple_or_dict(ob, fields):
+def _tuple_from_tuple_or_dict(ob, fields, defaults=()):
     """Given a tuple/list/dict, return a tuple. Also checks tuple size.
 
     >> # E.g.
@@ -122,19 +122,70 @@ def _tuple_from_tuple_or_dict(ob, fields):
     (1, 2)
     >> _tuple_from_tuple_or_dict([1, 2], ("x", "y"))
     (1, 2)
+
+    If defaults are given, it will be the default values.  If the length of defaults is
+    shorter than the length of fields, it gives the default values for the final args.
+    Other arguments are still required.
+
+    >> _tuple_from_tuple_or_dict({"x": 1}, ("x", "y"), (2,))
+    (1, 2)
+    >> _tuple_from_tuple_or_dict([], ("x", "y"), (1, 2))
+    (1, 2)
+
     """
     error_msg = "Expected tuple/key/dict with fields: {}"
+    required = len(fields) - len(defaults)
     if isinstance(ob, (list, tuple)):
-        if len(ob) != len(fields):
+        fields_len = len(fields)
+        ob_len = len(ob)
+        if ob_len == fields_len:
+            # Optimize for this fast case
+            return tuple(ob)
+        elif required <= ob_len < fields_len:
+            defaults_needed = fields_len - ob_len
+            return tuple((*ob, *defaults[-defaults_needed:]))
+        else:
             raise ValueError(error_msg.format(", ".join(fields)))
-        return tuple(ob)
     elif isinstance(ob, dict):
+        if any(key not in fields for key in ob):
+            raise ValueError("Unexpected key in {}".format(ob))
         try:
-            return tuple(ob[key] for key in fields)
+            return tuple(
+                (ob.get(key, defaults[index - required])
+                 if index >= required else ob[key])
+                for index, key in enumerate(fields)
+            )
         except KeyError:
             raise ValueError(error_msg.format(", ".join(fields)))
     else:
         raise TypeError(error_msg.format(", ".join(fields)))
+
+
+def _tuple_from_extent3d(size):
+    return _tuple_from_tuple_or_dict(
+        # required, 1, 1
+        size,
+        ("width", "height", "depth_or_array_layers"),
+        (1, 1),
+    )
+
+
+def _tuple_from_blend_component(components):
+    return _tuple_from_tuple_or_dict(
+        # defaults to "add", "one", "zero"
+        components, ("src_factor", "dst_factor", "operation"),
+        ("add", "one", "zero"),
+    )
+
+
+def _tuple_from_origin3d(destination):
+    fields = destination.get("origin", (0, 0, 0))
+    # Each field individually is 0 if not specified
+    return _tuple_from_tuple_or_dict(fields, "xyz", (0, 0, 0))
+
+
+def _tuple_from_color(rgba):
+    return _tuple_from_tuple_or_dict(rgba, "rgba")
 
 
 _empty_label = ffi.new("char []", b"")
@@ -975,9 +1026,8 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         if isinstance(usage, str):
             usage = str_flag_to_int(flags.TextureUsage, usage)
         usage = int(usage)
-        size = _tuple_from_tuple_or_dict(
-            size, ("width", "height", "depth_or_array_layers")
-        )
+        size = _tuple_from_extent3d(size)
+
         # H: width: int, height: int, depthOrArrayLayers: int
         c_size = new_struct(
             "WGPUExtent3D",
@@ -1526,10 +1576,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                 if not target.get("blend", None):
                     c_blend = ffi.NULL
                 else:
-                    alpha_blend = _tuple_from_tuple_or_dict(
-                        target["blend"]["alpha"],
-                        ("src_factor", "dst_factor", "operation"),
-                    )
+                    alpha_blend = _tuple_from_blend_component(target["blend"]["alpha"])
                     # H: operation: WGPUBlendOperation, srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor
                     c_alpha_blend = new_struct(
                         "WGPUBlendComponent",
@@ -1537,10 +1584,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                         dstFactor=alpha_blend[1],
                         operation=alpha_blend[2],
                     )
-                    color_blend = _tuple_from_tuple_or_dict(
-                        target["blend"]["color"],
-                        ("src_factor", "dst_factor", "operation"),
-                    )
+                    color_blend = _tuple_from_blend_component(target["blend"]["color"])
                     # H: operation: WGPUBlendOperation, srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor
                     c_color_blend = new_struct(
                         "WGPUBlendComponent",
@@ -2322,7 +2366,7 @@ class GPUCommandEncoder(
             clear_value = color_attachment.get("clear_value", (0, 0, 0, 0))
             if isinstance(clear_value, dict):
                 check_struct("Color", clear_value)
-                clear_value = _tuple_from_tuple_or_dict(clear_value, "rgba")
+                clear_value = _tuple_from_color(clear_value)
             # H: r: float, g: float, b: float, a: float
             c_clear_value = new_struct(
                 "WGPUColor",
@@ -2438,9 +2482,7 @@ class GPUCommandEncoder(
         if isinstance(destination["texture"], GPUTextureView):
             raise ValueError("copy destination texture must be a texture, not a view")
 
-        size = _tuple_from_tuple_or_dict(
-            copy_size, ("width", "height", "depth_or_array_layers")
-        )
+        size = _tuple_from_extent3d(copy_size)
 
         c_source = new_struct_p(
             "WGPUImageCopyBuffer *",
@@ -2455,7 +2497,7 @@ class GPUCommandEncoder(
             ),
         )
 
-        ori = _tuple_from_tuple_or_dict(destination.get("origin", (0, 0, 0)), "xyz")
+        ori = _tuple_from_origin3d(destination)
         # H: x: int, y: int, z: int
         c_origin = new_struct(
             "WGPUOrigin3D",
@@ -2499,11 +2541,9 @@ class GPUCommandEncoder(
         if isinstance(source["texture"], GPUTextureView):
             raise ValueError("copy source texture must be a texture, not a view")
 
-        size = _tuple_from_tuple_or_dict(
-            copy_size, ("width", "height", "depth_or_array_layers")
-        )
+        size = _tuple_from_extent3d(copy_size)
 
-        ori = _tuple_from_tuple_or_dict(source.get("origin", (0, 0, 0)), "xyz")
+        ori = _tuple_from_origin3d(source)
         # H: x: int, y: int, z: int
         c_origin = new_struct(
             "WGPUOrigin3D",
@@ -2556,7 +2596,7 @@ class GPUCommandEncoder(
         if isinstance(destination["texture"], GPUTextureView):
             raise ValueError("copy destination texture must be a texture, not a view")
 
-        ori = _tuple_from_tuple_or_dict(source.get("origin", (0, 0, 0)), "xyz")
+        ori = _tuple_from_origin3d(source)
         # H: x: int, y: int, z: int
         c_origin1 = new_struct(
             "WGPUOrigin3D",
@@ -2574,7 +2614,7 @@ class GPUCommandEncoder(
             # not used: aspect
         )
 
-        ori = _tuple_from_tuple_or_dict(destination.get("origin", (0, 0, 0)), "xyz")
+        ori = _tuple_from_origin3d(destination)
         # H: x: int, y: int, z: int
         c_origin2 = new_struct(
             "WGPUOrigin3D",
@@ -2592,9 +2632,7 @@ class GPUCommandEncoder(
             # not used: aspect
         )
 
-        size = _tuple_from_tuple_or_dict(
-            copy_size, ("width", "height", "depth_or_array_layers")
-        )
+        size = _tuple_from_extent3d(copy_size)
         # H: width: int, height: int, depthOrArrayLayers: int
         c_copy_size = new_struct_p(
             "WGPUExtent3D *",
@@ -2711,7 +2749,7 @@ class GPURenderPassEncoder(
         )
 
     def set_blend_constant(self, color):
-        color = _tuple_from_tuple_or_dict(color, "rgba")
+        color = _tuple_from_color(color)
         # H: r: float, g: float, b: float, a: float
         c_color = new_struct_p(
             "WGPUColor *",
@@ -2861,11 +2899,9 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         # data_size = list(reversed(m.shape)) + [1, 1, 1]
         # data_size = data_size[:3]
 
-        size = _tuple_from_tuple_or_dict(
-            size, ("width", "height", "depth_or_array_layers")
-        )
+        size = _tuple_from_extent3d(size)
 
-        ori = _tuple_from_tuple_or_dict(destination.get("origin", (0, 0, 0)), "xyz")
+        ori = _tuple_from_origin3d(destination)
         # H: x: int, y: int, z: int
         c_origin = new_struct(
             "WGPUOrigin3D",
@@ -2917,9 +2953,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         extra_stride = (256 - ori_stride % 256) % 256
         full_stride = ori_stride + extra_stride
 
-        size = _tuple_from_tuple_or_dict(
-            size, ("width", "height", "depth_or_array_layers")
-        )
+        size = _tuple_from_extent3d(size)
 
         # Create temporary buffer
         data_length = full_stride * size[1] * size[2]

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -151,8 +151,11 @@ def _tuple_from_tuple_or_dict(ob, fields, defaults=()):
             raise ValueError("Unexpected key in {}".format(ob))
         try:
             return tuple(
-                (ob.get(key, defaults[index - required])
-                 if index >= required else ob[key])
+                (
+                    ob.get(key, defaults[index - required])
+                    if index >= required
+                    else ob[key]
+                )
                 for index, key in enumerate(fields)
             )
         except KeyError:
@@ -173,7 +176,8 @@ def _tuple_from_extent3d(size):
 def _tuple_from_blend_component(components):
     return _tuple_from_tuple_or_dict(
         # defaults to "add", "one", "zero"
-        components, ("src_factor", "dst_factor", "operation"),
+        components,
+        ("src_factor", "dst_factor", "operation"),
         ("add", "one", "zero"),
     )
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 112 methods, 45 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 108 methods, 0 properties
+* Validated 37 classes, 111 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.clip-distances missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
@@ -29,6 +29,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 107 C function calls
-* Not using 96 C functions
-* Validated 75 C structs
+* Validated 113 C function calls
+* Not using 91 C functions
+* Validated 76 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 112 methods, 45 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 111 methods, 0 properties
+* Validated 37 classes, 108 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.clip-distances missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
@@ -29,6 +29,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 113 C function calls
-* Not using 91 C functions
-* Validated 76 C structs
+* Validated 107 C function calls
+* Not using 96 C functions
+* Validated 75 C structs


### PR DESCRIPTION
Don't call _tuple_from_tuple_or_dict, but go through an intermediate function for each possible type that knows the names of the arguments and what their defaults are.  No need to duplicate code. This fixes default arguments for Extend3d, Blend, and Origin3D.  Color (which requires all four components) is handled, too.  

Update _tuple_from_tuple_or_dict so that it can handle a list of default results.

Add lots of tests.

Fix one typo that is user visible.

Partial fix for #526.  