### PR TITLE
Deal better with missing size and missing query index arguments

### DIFF
--- a/tests/test_util_compute.py
+++ b/tests/test_util_compute.py
@@ -332,11 +332,15 @@ def test_compute_default_layout1():
     bindings = [
         {
             "binding": 0,
-            "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
+            "resource": {
+                "buffer": buffer1,
+            },
         },
         {
             "binding": 1,
-            "resource": {"buffer": buffer2, "offset": 0, "size": buffer2.size},
+            "resource": {
+                "buffer": buffer2,
+            },
         },
     ]
 
@@ -415,13 +419,17 @@ def test_compute_default_layout2():
     bindings0 = [
         {
             "binding": 0,
-            "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
+            "resource": {
+                "buffer": buffer1,
+            },
         },
     ]
     bindings1 = [
         {
             "binding": 0,
-            "resource": {"buffer": buffer2, "offset": 0, "size": buffer2.size},
+            "resource": {
+                "buffer": buffer2,
+            },
         },
     ]
 

--- a/tests/test_util_compute.py
+++ b/tests/test_util_compute.py
@@ -239,14 +239,8 @@ def test_compute_indirect():
         },
     ]
     bindings = [
-        {
-            "binding": 0,
-            "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
-        },
-        {
-            "binding": 1,
-            "resource": {"buffer": buffer2, "offset": 0, "size": buffer2.size},
-        },
+        {"binding": 0, "resource": {"buffer": buffer1}},
+        {"binding": 1, "resource": {"buffer": buffer2}},
     ]
 
     # Put everything together
@@ -330,18 +324,8 @@ def test_compute_default_layout1():
 
     # Setup bindings info
     bindings = [
-        {
-            "binding": 0,
-            "resource": {
-                "buffer": buffer1,
-            },
-        },
-        {
-            "binding": 1,
-            "resource": {
-                "buffer": buffer2,
-            },
-        },
+        {"binding": 0, "resource": {"buffer": buffer1}},
+        {"binding": 1, "resource": {"buffer": buffer2}},
     ]
 
     # Create a pipeline using "auto" layout mode

--- a/tests/test_wgpu_native_buffer.py
+++ b/tests/test_wgpu_native_buffer.py
@@ -91,7 +91,9 @@ def test_buffer_init3():
     # Option 1: write via queue (i.e. temp buffer), read via queue
 
     # Create buffer
-    buf = device.create_buffer(size=len(data1), usage="COPY_DST|COPY_SRC")
+    buf = device.create_buffer(
+        size=len(data1), usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.COPY_SRC
+    )
 
     # Write data to it
     device.queue.write_buffer(buf, 0, data1)

--- a/tests/test_wgpu_native_query_set.py
+++ b/tests/test_wgpu_native_query_set.py
@@ -63,14 +63,8 @@ def test_query_set():
         },
     ]
     bindings = [
-        {
-            "binding": 0,
-            "resource": {"buffer": buffer1, "offset": 0, "size": buffer1.size},
-        },
-        {
-            "binding": 1,
-            "resource": {"buffer": buffer2, "offset": 0, "size": buffer2.size},
-        },
+        {"binding": 0, "resource": {"buffer": buffer1}},
+        {"binding": 1, "resource": {"buffer": buffer2}},
     ]
 
     bind_group_layout = device.create_bind_group_layout(entries=binding_layouts)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -37,9 +37,6 @@ from ._helpers import (
     SafeLibCalls,
 )
 
-WGPU_WHOLE_SIZE = 0xFFFF_FFFF_FFFF_FFFF  # 2**64 - 1
-WGPU_QUERY_SET_INDEX_UNDEFINED = 0xFFFF_FFFF
-
 logger = logging.getLogger("wgpu")  # noqa
 
 
@@ -1266,7 +1263,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                     binding=int(entry["binding"]),
                     buffer=resource["buffer"]._internal,
                     offset=resource.get("offset", 0),
-                    size=resource.get("size", WGPU_WHOLE_SIZE),
+                    size=resource.get("size", lib.WGPU_WHOLE_SIZE),
                     sampler=ffi.NULL,
                     textureView=ffi.NULL,
                     # not used: nextInChain
@@ -2246,7 +2243,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
 
     def set_index_buffer(self, buffer, index_format, offset=0, size=None):
         if not size:
-            size = WGPU_WHOLE_SIZE
+            size = lib.WGPU_WHOLE_SIZE
         c_index_format = enummap[f"IndexFormat.{index_format}"]
         # H: void f(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size)
         libf.wgpuRenderPassEncoderSetIndexBuffer(
@@ -2255,7 +2252,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
 
     def set_vertex_buffer(self, slot, buffer, offset=0, size=None):
         if not size:
-            size = WGPU_WHOLE_SIZE
+            size = lib.WGPU_WHOLE_SIZE
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t slot, WGPUBuffer buffer, uint64_t offset, uint64_t size)
         libf.wgpuRenderPassEncoderSetVertexBuffer(
             self._internal, int(slot), buffer._internal, int(offset), int(size)
@@ -2314,10 +2311,10 @@ class GPUCommandEncoder(
                 "WGPUComputePassTimestampWrites *",
                 querySet=timestamp_writes["query_set"]._internal,
                 beginningOfPassWriteIndex=timestamp_writes.get(
-                    "beginning_of_pass_write_index", WGPU_QUERY_SET_INDEX_UNDEFINED
+                    "beginning_of_pass_write_index", lib.WGPU_QUERY_SET_INDEX_UNDEFINED
                 ),
                 endOfPassWriteIndex=timestamp_writes.get(
-                    "end_of_pass_write_index", WGPU_QUERY_SET_INDEX_UNDEFINED
+                    "end_of_pass_write_index", lib.WGPU_QUERY_SET_INDEX_UNDEFINED
                 ),
             )
         # H: nextInChain: WGPUChainedStruct *, label: char *, timestampWrites: WGPUComputePassTimestampWrites *
@@ -2351,10 +2348,10 @@ class GPUCommandEncoder(
                 "WGPURenderPassTimestampWrites *",
                 querySet=timestamp_writes["query_set"]._internal,
                 beginningOfPassWriteIndex=timestamp_writes.get(
-                    "beginning_of_pass_write_index", WGPU_QUERY_SET_INDEX_UNDEFINED
+                    "beginning_of_pass_write_index", lib.WGPU_QUERY_SET_INDEX_UNDEFINED
                 ),
                 endOfPassWriteIndex=timestamp_writes.get(
-                    "end_of_pass_write_index", WGPU_QUERY_SET_INDEX_UNDEFINED
+                    "end_of_pass_write_index", lib.WGPU_QUERY_SET_INDEX_UNDEFINED
                 ),
             )
 
@@ -2454,7 +2451,7 @@ class GPUCommandEncoder(
             if offset + size > buffer.size:  # pragma: no cover
                 raise ValueError("buffer size out of range")
         else:
-            size = WGPU_WHOLE_SIZE
+            size = lib.WGPU_WHOLE_SIZE
             if offset > buffer.size:
                 raise ValueError("offset is too large")
         # H: void f(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -2444,18 +2444,22 @@ class GPUCommandEncoder(
         offset = int(offset)
         if offset % 4 != 0:  # pragma: no cover
             raise ValueError("offset must be a multiple of 4")
-        if size is None:  # pragma: no cover
-            size = buffer.size - offset
-        size = int(size)
-        if size <= 0:  # pragma: no cover
-            raise ValueError("clear_buffer size must be > 0")
-        if size % 4 != 0:  # pragma: no cover
-            raise ValueError("size must be a multiple of 4")
-        if offset + size > buffer.size:  # pragma: no cover
-            raise ValueError("buffer size out of range")
+
+        if size is not None:
+            size = int(size)
+            if size <= 0:  # pragma: no cover
+                raise ValueError("size must be > 0")
+            if size % 4 != 0:  # pragma: no cover
+                raise ValueError("size must be a multiple of 4")
+            if offset + size > buffer.size:  # pragma: no cover
+                raise ValueError("buffer size out of range")
+        else:
+            size = WGPU_WHOLE_SIZE
+            if offset > buffer.size:
+                raise ValueError("offset is too large")
         # H: void f(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size)
         libf.wgpuCommandEncoderClearBuffer(
-            self._internal, buffer._internal, int(offset), size
+            self._internal, buffer._internal, offset, size
         )
 
     def copy_buffer_to_buffer(


### PR DESCRIPTION
Second (and final part) of bug fix for #526 

Modify `create_bind_group` to handle missing `offset` and `size.
Modify `timestamp=` argument in `create_xxxx_pipeline` so that either timestamp index can be missing.

More controversially (and I'll delete this if you want me to):

Modify `set_vertex_buffer`, `set_index_buffer`, and `clear_buffer` to mark the size as "not given by user" rather than making a guess as to what the size actually is.  

This doesn't fix any bugs, but seemed to be the right thing to do. In the normal cases, the current code works correctly. But if we ever end up with arrays of vertexes or the like, the current code won't work.

Added tests: 
Deleted `offset` and `size` from both compute and render pipelines.  
Added half-indexed timestamp arguments to make sure they gave correct results.
Tested all sorts of iterations of clear_buffer.
