### PR TITLE
Fix bugs.  Defaults were listed in the order given by GPUBlendCompone…

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -302,16 +302,8 @@ render_pipeline = device.create_render_pipeline(
             {
                 "format": render_texture_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.zero,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.zero,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": {},
+                    "color": {},
                 },
             }
         ],

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -105,16 +105,8 @@ def setup_draw(context, device):
                 {
                     "format": render_texture_format,
                     "blend": {
-                        "color": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
-                        "alpha": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
+                        "color": {},
+                        "alpha": {},
                     },
                 },
             ],

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -93,16 +93,8 @@ def _main(canvas, device):
                 {
                     "format": render_texture_format,
                     "blend": {
-                        "color": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
-                        "alpha": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
+                        "color": {},
+                        "alpha": {},
                     },
                 },
             ],

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -250,16 +250,8 @@ def render_to_screen(
                 {
                     "format": wgpu.TextureFormat.bgra8unorm_srgb,
                     "blend": {
-                        "color": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
-                        "alpha": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
+                        "color": {},
+                        "alpha": {},
                     },
                     "write_mask": wgpu.ColorWrite.ALL,
                 },

--- a/tests/renderutils.py
+++ b/tests/renderutils.py
@@ -124,16 +124,8 @@ def render_to_texture(
                 {
                     "format": texture_format,
                     "blend": {
-                        "color": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
-                        "alpha": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
+                        "color": {},
+                        "alpha": {},
                     },
                     "write_mask": wgpu.ColorWrite.ALL,
                 },

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -265,16 +265,8 @@ def _get_draw_function(device, canvas):
                 {
                     "format": render_texture_format,
                     "blend": {
-                        "color": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
-                        "alpha": (
-                            wgpu.BlendFactor.one,
-                            wgpu.BlendFactor.zero,
-                            wgpu.BlendOperation.add,
-                        ),
+                        "color": {},  # use defaults
+                        "alpha": {},  # use defaults
                     },
                 },
             ],

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -126,9 +126,9 @@ def test_tuple_from_blend_components():
     func = wgpu.backends.wgpu_native._api._tuple_from_blend_component
 
     assert func(("x", "y", "z")) == ("x", "y", "z")
-    assert func([]) == ("add", "one", "zero")
+    assert func([]) == ("one", "zero", "add")
     assert func({"operation": "j", "src_factor": 9, "dst_factor": "d"}) == (9, "d", "j")
-    assert func({}) == ("add", "one", "zero")
+    assert func({}) == ("one", "zero", "add")
 
     with raises(ValueError):
         func([1, 2, 3, 4, 5])  # too many values

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -122,20 +122,6 @@ def test_tuple_from_extent3d():
         func({"width": 10, "height": 20, "depth_or_arrray_layers": 30})
 
 
-def test_tuple_from_blend_components():
-    func = wgpu.backends.wgpu_native._api._tuple_from_blend_component
-
-    assert func(("x", "y", "z")) == ("x", "y", "z")
-    assert func([]) == ("one", "zero", "add")
-    assert func({"operation": "j", "src_factor": 9, "dst_factor": "d"}) == (9, "d", "j")
-    assert func({}) == ("one", "zero", "add")
-
-    with raises(ValueError):
-        func([1, 2, 3, 4, 5])  # too many values
-    with raises(ValueError):
-        func([1, 2, 3, 4, 5])  # too many values
-
-
 def test_tuple_from_origin3d():
     func = wgpu.backends.wgpu_native._api._tuple_from_origin3d
 

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -293,16 +293,8 @@ def test_release_render_pipeline(n):
                     {
                         "format": "bgra8unorm-srgb",
                         "blend": {
-                            "color": (
-                                wgpu.BlendFactor.one,
-                                wgpu.BlendFactor.zero,
-                                wgpu.BlendOperation.add,
-                            ),
-                            "alpha": (
-                                wgpu.BlendFactor.one,
-                                wgpu.BlendFactor.zero,
-                                wgpu.BlendOperation.add,
-                            ),
+                            "color": {},
+                            "alpha": {},
                         },
                     },
                 ],

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -842,7 +842,7 @@ class GPUDevice(GPUObjectBase):
         .. code-block:: py
 
             {
-                "topology": wgpu.PrimitiveTopology.triangle_list,
+                "topology": wgpu.PrimitiveTopology.triangle_list, # optional
                 "strip_index_format": wgpu.IndexFormat.uint32,  # see note
                 "front_face": wgpu.FrontFace.ccw,  # optional
                 "cull_mode": wgpu.CullMode.none,  # optional
@@ -897,16 +897,16 @@ class GPUDevice(GPUObjectBase):
                     {
                         "format": wgpu.TextureFormat.bgra8unorm_srgb,
                         "blend": {
-                            "color": (
-                                wgpu.BlendFactor.One,
-                                wgpu.BlendFactor.zero,
-                                gpu.BlendOperation.add,
-                            ),
-                            "alpha": (
-                                wgpu.BlendFactor.One,
-                                wgpu.BlendFactor.zero,
-                                wgpu.BlendOperation.add,
-                            ),
+                            "color": {
+                                "src_target": wgpu.BlendFactor.one,  # optional
+                                "dst_target": wgpu.BlendFactor.zero,  # optional
+                                "operation": gpu.BlendOperation.add, # optional
+                            },
+                            "alpha": {
+                                "src_target": wgpu.BlendFactor.one, # optional
+                                "dst_target": wgpu.BlendFactor.zero, # optional
+                                "operation": wgpu.BlendOperation.add, # optional
+                            },
                         }
                         "write_mask": wgpu.ColorWrite.ALL  # optional
                     },

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1124,7 +1124,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                 # H: nextInChain: WGPUChainedStruct *, type: WGPUBufferBindingType, hasDynamicOffset: WGPUBool/int, minBindingSize: int
                 buffer = new_struct(
                     "WGPUBufferBindingLayout",
-                    type=info.get("type", "uniform"),
+                    type=info["type"],
                     hasDynamicOffset=info.get("has_dynamic_offset", False),
                     minBindingSize=min_binding_size,
                     # not used: nextInChain

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1571,11 +1571,11 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                         # H: operation: WGPUBlendOperation, srcFactor: WGPUBlendFactor, dstFactor: WGPUBlendFactor
                         new_struct(
                             "WGPUBlendComponent",
-                            srcFactor=component.get("src_factor", "one"),
-                            dstFactor=component.get("dst_factor", "zero"),
-                            operation=component.get("operation", "add"),
+                            srcFactor=blend.get("src_factor", "one"),
+                            dstFactor=blend.get("dst_factor", "zero"),
+                            operation=blend.get("operation", "add"),
                         )
-                        for component in (
+                        for blend in (
                             target["blend"]["alpha"],
                             target["blend"]["color"],
                         )

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -177,7 +177,7 @@ def _tuple_from_blend_component(components):
         # defaults to "add", "one", "zero"
         components,
         ("src_factor", "dst_factor", "operation"),
-        ("add", "one", "zero"),
+        ("one", "zero", "add"),
     )
 
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -31,4 +31,4 @@
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
 * Validated 113 C function calls
 * Not using 91 C functions
-* Validated 76 C structs
+* Validated 75 C structs

--- a/wgpu/utils/imgui/imgui_backend.py
+++ b/wgpu/utils/imgui/imgui_backend.py
@@ -271,16 +271,16 @@ class ImguiWgpuBackend:
                     {
                         "format": self._target_format,
                         "blend": {
-                            "color": (
-                                wgpu.BlendFactor.src_alpha,
-                                wgpu.BlendFactor.one_minus_src_alpha,
-                                wgpu.BlendOperation.add,
-                            ),
-                            "alpha": (
-                                wgpu.BlendFactor.one,
-                                wgpu.BlendFactor.one_minus_src_alpha,
-                                wgpu.BlendOperation.add,
-                            ),
+                            "color": {
+                                "src_factor": wgpu.BlendFactor.src_alpha,
+                                "dst_factor": wgpu.BlendFactor.one_minus_src_alpha,
+                                "operation": wgpu.BlendOperation.add,
+                            },
+                            "alpha": {
+                                "src_factor": wgpu.BlendFactor.one,
+                                "dst_factor": wgpu.BlendFactor.one_minus_src_alpha,
+                                "operation": wgpu.BlendOperation.add,
+                            },
                         },
                     },
                 ],


### PR DESCRIPTION
Fix bug #532.  I accidentally listed defaults in the order given by the spec in GPUBlendComponent rather than in the order they were actually being used.

Fix tests for this code.

In one test, have it actually elide the blend components, so that we can see that the default values are doing the right thing.

## API changes

* xx can no longer be a tuple; use a dict instead. (AK: @fyellin could you fill this in?)
