### PR TITLE
More defaults

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -222,7 +222,10 @@ bind_groups_layout_entries[0].append(
     {
         "binding": 0,
         "visibility": wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT,
-        "buffer": {"type": wgpu.BufferBindingType.uniform},
+        "buffer": {
+            # This is the default value, so we are testing that it can be elided.
+            # "type": wgpu.BufferBindingType.uniform
+        },
     }
 )
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -222,10 +222,7 @@ bind_groups_layout_entries[0].append(
     {
         "binding": 0,
         "visibility": wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT,
-        "buffer": {
-            # This is the default value, so we are testing that it can be elided.
-            # "type": wgpu.BufferBindingType.uniform
-        },
+        "buffer": {},
     }
 )
 
@@ -234,11 +231,7 @@ bind_groups_layout_entries[0].append(
     {
         "binding": 1,
         "visibility": wgpu.ShaderStage.FRAGMENT,
-        "texture": {
-            # These are the default values, and we are testing that they can be elided.
-            # "sample_type": wgpu.TextureSampleType.float,
-            # "view_dimension": wgpu.TextureViewDimension.d2,
-        },
+        "texture": {},
     }
 )
 
@@ -247,10 +240,7 @@ bind_groups_layout_entries[0].append(
     {
         "binding": 2,
         "visibility": wgpu.ShaderStage.FRAGMENT,
-        "sampler": {
-            # This is the default value, and we are testing that it can be elided.
-            # "type": wgpu.SamplerBindingType.filtering
-        },
+        "sampler": {},
     }
 )
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -235,8 +235,9 @@ bind_groups_layout_entries[0].append(
         "binding": 1,
         "visibility": wgpu.ShaderStage.FRAGMENT,
         "texture": {
-            "sample_type": wgpu.TextureSampleType.float,
-            "view_dimension": wgpu.TextureViewDimension.d2,
+            # These are the default values, and we are testing that they can be elided.
+            # "sample_type": wgpu.TextureSampleType.float,
+            # "view_dimension": wgpu.TextureViewDimension.d2,
         },
     }
 )
@@ -246,7 +247,10 @@ bind_groups_layout_entries[0].append(
     {
         "binding": 2,
         "visibility": wgpu.ShaderStage.FRAGMENT,
-        "sampler": {"type": wgpu.SamplerBindingType.filtering},
+        "sampler": {
+            # This is the default value, and we are testing that it can be elided.
+            # "type": wgpu.SamplerBindingType.filtering
+        },
     }
 )
 

--- a/examples/imgui_backend_sea.py
+++ b/examples/imgui_backend_sea.py
@@ -240,7 +240,6 @@ pipeline = device.create_render_pipeline(
     vertex={
         "module": module,
         "entry_point": "vs_main",
-        "buffers": [],
     },
     fragment={
         "module": module,

--- a/examples/imgui_renderer_sea.py
+++ b/examples/imgui_renderer_sea.py
@@ -240,7 +240,6 @@ pipeline = device.create_render_pipeline(
     vertex={
         "module": module,
         "entry_point": "vs_main",
-        "buffers": [],
     },
     fragment={
         "module": module,

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -90,12 +90,6 @@ def setup_draw(context, device):
             "module": shader,
             "entry_point": "vs_main",
         },
-        # primitive elided, since we are using its default value and want to test that.
-        # primitive={
-        #     "topology": wgpu.PrimitiveTopology.triangle_list,
-        #     "front_face": wgpu.FrontFace.ccw,
-        #     "cull_mode": wgpu.CullMode.none,
-        # },
         depth_stencil=None,
         multisample=None,
         fragment={

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -89,13 +89,13 @@ def setup_draw(context, device):
         vertex={
             "module": shader,
             "entry_point": "vs_main",
-            "buffers": [],
         },
-        primitive={
-            "topology": wgpu.PrimitiveTopology.triangle_list,
-            "front_face": wgpu.FrontFace.ccw,
-            "cull_mode": wgpu.CullMode.none,
-        },
+        # primitive elided, since we are using its default value and want to test that.
+        # primitive={
+        #     "topology": wgpu.PrimitiveTopology.triangle_list,
+        #     "front_face": wgpu.FrontFace.ccw,
+        #     "cull_mode": wgpu.CullMode.none,
+        # },
         depth_stencil=None,
         multisample=None,
         fragment={

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -77,7 +77,6 @@ def _main(canvas, device):
         vertex={
             "module": vert_shader,
             "entry_point": "main",
-            "buffers": [],
         },
         primitive={
             "topology": wgpu.PrimitiveTopology.triangle_list,

--- a/tests/test_wgpu_native_compute_tex.py
+++ b/tests/test_wgpu_native_compute_tex.py
@@ -509,7 +509,6 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
             "binding": 1,
             "visibility": wgpu.ShaderStage.COMPUTE,
             "storage_texture": {
-                # Eliding "access: write-only" as it is the default.
                 "format": texture_format,
                 "view_dimension": texture_dim,
             },

--- a/tests/test_wgpu_native_compute_tex.py
+++ b/tests/test_wgpu_native_compute_tex.py
@@ -509,7 +509,7 @@ def _compute_texture(compute_shader, texture_format, texture_dim, texture_size, 
             "binding": 1,
             "visibility": wgpu.ShaderStage.COMPUTE,
             "storage_texture": {
-                "access": wgpu.StorageTextureAccess.write_only,
+                # Eliding "access: write-only" as it is the default.
                 "format": texture_format,
                 "view_dimension": texture_dim,
             },

--- a/tests_mem/test_objects.py
+++ b/tests_mem/test_objects.py
@@ -277,7 +277,6 @@ def test_release_render_pipeline(n):
             vertex={
                 "module": shader,
                 "entry_point": "vs_main",
-                "buffers": [],
             },
             primitive={
                 "topology": wgpu.PrimitiveTopology.triangle_list,

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1133,7 +1133,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                 # H: nextInChain: WGPUChainedStruct *, type: WGPUBufferBindingType, hasDynamicOffset: WGPUBool/int, minBindingSize: int
                 buffer = new_struct(
                     "WGPUBufferBindingLayout",
-                    type=info["type"],
+                    type=info.get("type", "uniform"),
                     hasDynamicOffset=info.get("has_dynamic_offset", False),
                     minBindingSize=min_binding_size,
                     # not used: nextInChain
@@ -1164,7 +1164,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                 # H: nextInChain: WGPUChainedStruct *, access: WGPUStorageTextureAccess, format: WGPUTextureFormat, viewDimension: WGPUTextureViewDimension
                 storage_texture = new_struct(
                     "WGPUStorageTextureBindingLayout",
-                    access=info["access"],
+                    access=info.get("access", "write-only"),
                     viewDimension=info.get("view_dimension", "2d"),
                     format=info["format"],
                     # not used: nextInChain
@@ -1474,7 +1474,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         check_struct("PrimitiveState", primitive)
 
         c_vertex_buffer_layout_list = []
-        for buffer_des in vertex["buffers"]:
+        for buffer_des in vertex.get("buffers", ()):
             c_attributes_list = []
             for attribute in buffer_des["attributes"]:
                 # H: format: WGPUVertexFormat, offset: int, shaderLocation: int

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1138,16 +1138,16 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                     minBindingSize=min_binding_size,
                     # not used: nextInChain
                 )
-            elif entry.get("sampler"):
+            elif "sampler" in entry:  # It may be an empty dictionary
                 info = entry["sampler"]
                 check_struct("SamplerBindingLayout", info)
                 # H: nextInChain: WGPUChainedStruct *, type: WGPUSamplerBindingType
                 sampler = new_struct(
                     "WGPUSamplerBindingLayout",
-                    type=info["type"],
+                    type=info.get("type", "filtering"),
                     # not used: nextInChain
                 )
-            elif entry.get("texture"):
+            elif "texture" in entry:  # It may be an empty dictionary
                 info = entry["texture"]
                 check_struct("TextureBindingLayout", info)
                 # H: nextInChain: WGPUChainedStruct *, sampleType: WGPUTextureSampleType, viewDimension: WGPUTextureViewDimension, multisampled: WGPUBool/int
@@ -1158,7 +1158,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
                     multisampled=info.get("multisampled", False),
                     # not used: nextInChain
                 )
-            elif entry.get("storage_texture"):
+            elif "storage_texture" in entry:  # format is required, so not empty
                 info = entry["storage_texture"]
                 check_struct("StorageTextureBindingLayout", info)
                 # H: nextInChain: WGPUChainedStruct *, access: WGPUStorageTextureAccess, format: WGPUTextureFormat, viewDimension: WGPUTextureViewDimension

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1124,7 +1124,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
             sampler = {}
             texture = {}
             storage_texture = {}
-            if entry.get("buffer"):
+            if "buffer" in entry:  # Note, it might be an empty dictionary
                 info = entry["buffer"]
                 check_struct("BufferBindingLayout", info)
                 min_binding_size = info.get("min_binding_size", None)


### PR DESCRIPTION
My final removal of unnecessary arguments.  Note that for each case, I've also removed the field from at least one test so that we can verify that the code is working correctly.

In the four [`BindGroupLayoutEntry`](https://www.w3.org/TR/webgpu/#dictdef-gpubindgrouplayoutentry)s that wgpu supports, three of them can can take an empty dictionary as its argument: 

1. In a [`BufferBindingLayout`]( https://www.w3.org/TR/webgpu/#dictdef-gpubufferbindinglayout), all three fields are optional, and so the dictionary can be the empty dictionary.  The "type" field defaults to "uniform".  

 2. In a [`SamplerBindingLayout`](https://www.w3.org/TR/webgpu/#dictdef-gpusamplerbindinglayout) the single field `type` defaults to `"filtering"`.
 
 3. In a [`TextureBindingLayout`](https://www.w3.org/TR/webgpu/#dictdef-gputexturebindinglayout) all fields can have default values.  We did not recognize `"texture": {}` as valid.
 
 4.  A [`StorageTextureBindingLayout`](https://www.w3.org/TR/webgpu/#dictdef-gpustoragetexturebindinglayout) has required fields.  But the access defaults to `write-only`.

In a [`VertexState`](https://www.w3.org/TR/webgpu/#dictdef-gpuvertexstate), the list of buffers defaults to the empty list.