### PR TITLE
Imgui multi canvas

### DIFF
--- a/examples/imgui_basic_example.py
+++ b/examples/imgui_basic_example.py
@@ -71,8 +71,12 @@ def update_gui():
     return imgui.get_draw_data()
 
 
+# set the GUI update function that gets called to return the draw data
+imgui_renderer.set_gui(update_gui)
+
+
 def draw_frame():
-    imgui_renderer.render(update_gui())
+    imgui_renderer.render()
     canvas.request_draw()
 
 

--- a/examples/imgui_multi_canvas.py
+++ b/examples/imgui_multi_canvas.py
@@ -1,0 +1,99 @@
+"""
+Example showing how to use multiple imgui contexts to draw to multiple canvases
+
+# run_example = false
+"""
+
+import wgpu
+from imgui_bundle import imgui
+from wgpu.gui.auto import WgpuCanvas, run
+from wgpu.utils.imgui import ImguiRenderer
+
+# Create a canvas to render to
+canvas = WgpuCanvas(title="imgui", size=(512, 256))
+canvas2 = WgpuCanvas(title="imgui", size=(512, 256))
+canvas3 = WgpuCanvas(title="imgui", size=(512, 256))
+
+# Create a wgpu device
+adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
+device = adapter.request_device()
+
+# create a imgui renderer for each canvas
+imgui_renderer = ImguiRenderer(device, canvas)
+imgui_renderer2 = ImguiRenderer(device, canvas2)
+imgui_renderer3 = ImguiRenderer(device, canvas3)
+
+
+# Separate GUIs that are drawn to each canvas
+def update_gui():
+    imgui.new_frame()
+
+    imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
+    imgui.set_next_window_pos((0, 20), imgui.Cond_.appearing)
+
+    imgui.begin("window1", None)
+    imgui.button("b1")
+
+
+    imgui.end()
+
+    imgui.end_frame()
+    imgui.render()
+
+    return imgui.get_draw_data()
+
+
+def update_gui2():
+    imgui.new_frame()
+
+    imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
+    imgui.set_next_window_pos((0, 20), imgui.Cond_.appearing)
+
+    imgui.begin("window2", None)
+    imgui.button("b2")
+
+    imgui.end()
+
+    imgui.end_frame()
+    imgui.render()
+
+    return imgui.get_draw_data()
+
+
+def update_gui3():
+    imgui.new_frame()
+
+    imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
+    imgui.set_next_window_pos((0, 20), imgui.Cond_.appearing)
+
+    imgui.begin("window3", None)
+    imgui.button("b3")
+
+    imgui.end()
+
+    imgui.end_frame()
+    imgui.render()
+
+    return imgui.get_draw_data()
+
+
+def draw_frame():
+    # set corresponding imgui context before rendering
+    imgui.set_current_context(imgui_renderer.imgui_context)
+    imgui_renderer.render(update_gui())
+
+    imgui.set_current_context(imgui_renderer2.imgui_context)
+    imgui_renderer2.render(update_gui2())
+
+    imgui.set_current_context(imgui_renderer3.imgui_context)
+    imgui_renderer3.render(update_gui3())
+
+    # done! request draw
+    canvas.request_draw()
+    canvas2.request_draw()
+    canvas3.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(draw_frame)
+    run()

--- a/examples/imgui_multi_canvas.py
+++ b/examples/imgui_multi_canvas.py
@@ -34,7 +34,6 @@ def update_gui():
     imgui.begin("window1", None)
     imgui.button("b1")
 
-
     imgui.end()
 
     imgui.end_frame()

--- a/examples/imgui_multi_canvas.py
+++ b/examples/imgui_multi_canvas.py
@@ -78,7 +78,7 @@ def update_gui3():
     return imgui.get_draw_data()
 
 
-# give the gui updater functions to the imgui renderer
+# give the corresponding gui updater functions to the imgui renderers
 imgui_renderer1.set_gui(update_gui1)
 imgui_renderer2.set_gui(update_gui2)
 imgui_renderer3.set_gui(update_gui3)

--- a/examples/imgui_multi_canvas.py
+++ b/examples/imgui_multi_canvas.py
@@ -10,22 +10,24 @@ from wgpu.gui.auto import WgpuCanvas, run
 from wgpu.utils.imgui import ImguiRenderer
 
 # Create a canvas to render to
-canvas = WgpuCanvas(title="imgui", size=(512, 256))
+canvas1 = WgpuCanvas(title="imgui", size=(512, 256))
 canvas2 = WgpuCanvas(title="imgui", size=(512, 256))
 canvas3 = WgpuCanvas(title="imgui", size=(512, 256))
+
+canvases = [canvas1, canvas2, canvas3]
 
 # Create a wgpu device
 adapter = wgpu.gpu.request_adapter(power_preference="high-performance")
 device = adapter.request_device()
 
 # create a imgui renderer for each canvas
-imgui_renderer = ImguiRenderer(device, canvas)
+imgui_renderer1 = ImguiRenderer(device, canvas1)
 imgui_renderer2 = ImguiRenderer(device, canvas2)
 imgui_renderer3 = ImguiRenderer(device, canvas3)
 
 
 # Separate GUIs that are drawn to each canvas
-def update_gui():
+def update_gui1():
     imgui.new_frame()
 
     imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
@@ -76,23 +78,31 @@ def update_gui3():
     return imgui.get_draw_data()
 
 
-def draw_frame():
-    # set corresponding imgui context before rendering
-    imgui.set_current_context(imgui_renderer.imgui_context)
-    imgui_renderer.render(update_gui())
+# give the gui updater functions to the imgui renderer
+imgui_renderer1.set_gui(update_gui1)
+imgui_renderer2.set_gui(update_gui2)
+imgui_renderer3.set_gui(update_gui3)
 
-    imgui.set_current_context(imgui_renderer2.imgui_context)
-    imgui_renderer2.render(update_gui2())
 
-    imgui.set_current_context(imgui_renderer3.imgui_context)
-    imgui_renderer3.render(update_gui3())
+# draw function for each canvas
+def draw1():
+    imgui_renderer1.render()
+    canvas1.request_draw()
 
-    # done! request draw
-    canvas.request_draw()
+
+def draw2():
+    imgui_renderer2.render()
     canvas2.request_draw()
+
+
+def draw3():
+    imgui_renderer3.render()
     canvas3.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.request_draw(draw_frame)
+    canvas1.request_draw(draw1)
+    canvas2.request_draw(draw2)
+    canvas3.request_draw(draw3)
+
     run()

--- a/examples/imgui_renderer_sea.py
+++ b/examples/imgui_renderer_sea.py
@@ -375,9 +375,13 @@ def render():
     device.queue.submit([command_encoder.finish()])
 
 
+# set the GUI update function that gets called to return the draw data
+imgui_renderer.set_gui(lambda: gui(app_state))
+
+
 def loop():
     render()
-    imgui_renderer.render(gui(app_state))
+    imgui_renderer.render()
     canvas.request_draw()
 
 

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -68,7 +68,8 @@ class ImguiRenderer:
         if self._canvas_context._config is None:
             self._canvas_context.configure(device=device, format=render_target_format)
 
-        imgui.create_context()
+        self._imgui_context = imgui.create_context()
+        imgui.set_current_context(self._imgui_context)
 
         self._backend = ImguiWgpuBackend(device, render_target_format)
 
@@ -82,6 +83,11 @@ class ImguiRenderer:
         canvas.add_event_handler(self._on_key, "key_up", "key_down")
         canvas.add_event_handler(self._on_wheel, "wheel")
         canvas.add_event_handler(self._on_char_input, "char")
+
+    @property
+    def imgui_context(self) -> imgui.internal.Context:
+        """imgui context for this renderer"""
+        return self._imgui_context
 
     @property
     def backend(self):


### PR DESCRIPTION
Exposes the context of `ImguiRenderer` so that it can be used for context switching. As far as I understand, this is required for rendering different UIs to multiple different canvases (added an example). Not sure if there's a better way to do this, welcome to suggestions! @panxinmiao 

tested in glfw & qt
