### PR TITLE
Fixed triangle example

### DIFF
--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -89,6 +89,7 @@ def setup_draw(context, device):
         vertex={
             "module": shader,
             "entry_point": "vs_main",
+            "buffers": [],
         },
         depth_stencil=None,
         multisample=None,
@@ -98,10 +99,6 @@ def setup_draw(context, device):
             "targets": [
                 {
                     "format": render_texture_format,
-                    "blend": {
-                        "color": {},
-                        "alpha": {},
-                    },
                 },
             ],
         },


### PR DESCRIPTION
I have copy pasted the triangle example to try the library and it doesn't work. So after some debugging i find that the "create_render_pipeline" methods from GPUDevice, in the vertex attribute want a "buffers" empty list, and in the fragment the alpha is just not required (the library crash if there is something).