### PR TITLE
Fix automated tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import re
 import platform
 
 from setuptools import find_packages, setup
-from wheel.bdist_wheel import get_platform, bdist_wheel as _bdist_wheel
-
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+from sysconfig import get_platform
 
 NAME = "wgpu"
 SUMMARY = "Next generation GPU API for Python"
@@ -14,7 +14,7 @@ with open(f"{NAME}/__init__.py") as fh:
 
 class bdist_wheel(_bdist_wheel):  # noqa: N801
     def finalize_options(self):
-        self.plat_name = get_platform(None)  # force a platform tag
+        self.plat_name = get_platform()  # force a platform tag
         _bdist_wheel.finalize_options(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import platform
 
 from setuptools import find_packages, setup
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from sysconfig import get_platform
+from wheel.bdist_wheel.bdist_wheel import get_platform
 
 NAME = "wgpu"
 SUMMARY = "Next generation GPU API for Python"
@@ -14,7 +14,7 @@ with open(f"{NAME}/__init__.py") as fh:
 
 class bdist_wheel(_bdist_wheel):  # noqa: N801
     def finalize_options(self):
-        self.plat_name = get_platform()  # force a platform tag
+        self.plat_name = get_platform(None)  # force a platform tag
         _bdist_wheel.finalize_options(self)
 
 


### PR DESCRIPTION
FIXES #548.

Changed import of `get_platform` to be from `sysconfig`

My one concern is that the original code had `get_platform(None)`, and the new `get_platform` doesn't take an argument.  There is a cryptic comment `force a platform tag`, and I'm not sure if that is referring to the whole statement, or the `None` argument that I had to elide.  Can't find any documentation.