### PR TITLE
Implemented mouse, keyboard and window events for WxWgpuWindow

### DIFF
--- a/examples/triangle_wx.py
+++ b/examples/triangle_wx.py
@@ -10,8 +10,14 @@ from wgpu.gui.wx import WgpuCanvas
 from triangle import main  # The function to call to run the visualization
 
 
+class MyCanvas(WgpuCanvas):
+    def handle_event(self, event):
+        if event["event_type"] != "pointer_move":
+            print(event)
+
+
 app = wx.App()
-canvas = WgpuCanvas()
+canvas = MyCanvas()
 
 main(canvas)
 app.MainLoop()

--- a/examples/triangle_wx.py
+++ b/examples/triangle_wx.py
@@ -10,14 +10,8 @@ from wgpu.gui.wx import WgpuCanvas
 from triangle import main  # The function to call to run the visualization
 
 
-class MyCanvas(WgpuCanvas):
-    def handle_event(self, event):
-        if event["event_type"] != "pointer_move":
-            print(event)
-
-
 app = wx.App()
-canvas = MyCanvas()
+canvas = WgpuCanvas()
 
 main(canvas)
 app.MainLoop()

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -146,7 +146,6 @@ class WxWgpuWindow(WgpuAutoGui, WgpuCanvasBase, wx.Window):
 
         self.Bind(wx.EVT_MOUSE_EVENTS, self._on_mouse_events)
         self.Bind(wx.EVT_MOTION, self._on_mouse_move)
-        # self.Bind(wx.EVT_MOUSEWHEEL, self._mouse_wheel_event)
 
     def on_paint(self, event):
         dc = wx.PaintDC(self)  # needed for wx

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -25,27 +25,34 @@ BUTTON_MAP = {
 }
 
 MOUSE_EVENT_MAP = {
-    "pointer_down": (wx.wxEVT_LEFT_DOWN,
-                     wx.wxEVT_MIDDLE_DOWN,
-                     wx.wxEVT_RIGHT_DOWN,
-                     wx.wxEVT_AUX1_DOWN,
-                     wx.wxEVT_AUX2_DOWN),
-    "pointer_up": (wx.wxEVT_LEFT_UP,
-                   wx.wxEVT_MIDDLE_UP,
-                   wx.wxEVT_RIGHT_UP,
-                   wx.wxEVT_AUX1_UP,
-                   wx.wxEVT_AUX2_UP),
-    "double_click": (wx.wxEVT_LEFT_DCLICK,
-                     wx.wxEVT_MIDDLE_DCLICK,
-                     wx.wxEVT_RIGHT_DCLICK,
-                     wx.wxEVT_AUX1_DCLICK,
-                     wx.wxEVT_AUX2_DCLICK),
-    "wheel": (wx.wxEVT_MOUSEWHEEL,
-              wx.wxEVT_MAGNIFY)
+    "pointer_down": [
+        wx.wxEVT_LEFT_DOWN,
+        wx.wxEVT_MIDDLE_DOWN,
+        wx.wxEVT_RIGHT_DOWN,
+        wx.wxEVT_AUX1_DOWN,
+        wx.wxEVT_AUX2_DOWN,
+    ],
+    "pointer_up": [
+        wx.wxEVT_LEFT_UP,
+        wx.wxEVT_MIDDLE_UP,
+        wx.wxEVT_RIGHT_UP,
+        wx.wxEVT_AUX1_UP,
+        wx.wxEVT_AUX2_UP,
+    ],
+    "double_click": [
+        wx.wxEVT_LEFT_DCLICK,
+        wx.wxEVT_MIDDLE_DCLICK,
+        wx.wxEVT_RIGHT_DCLICK,
+        wx.wxEVT_AUX1_DCLICK,
+        wx.wxEVT_AUX2_DCLICK,
+    ],
+    "wheel": [wx.wxEVT_MOUSEWHEEL],
 }
 
 # reverse the mouse event map (from one-to-many to many-to-one)
-MOUSE_EVENT_MAP_REVERSED = {value: key for key, values in MOUSE_EVENT_MAP.items() for value in values}
+MOUSE_EVENT_MAP_REVERSED = {
+    value: key for key, values in MOUSE_EVENT_MAP.items() for value in values
+}
 
 MODIFIERS_MAP = {
     wx.MOD_SHIFT: "Shift",
@@ -269,20 +276,19 @@ class WxWgpuWindow(WgpuAutoGui, WgpuCanvasBase, wx.Window):
             elif axis == wx.MOUSE_WHEEL_VERTICAL:
                 dy = delta * rotation
 
-            ev.update(
-                {
-                    "dx": -dx,
-                    "dy": -dy
-                }
-            )
+            ev.update({"dx": -dx, "dy": -dy})
 
             match_keys = {"modifiers"}
             accum_keys = {"dx", "dy"}
-            self._handle_event_rate_limited(ev, self._call_later, match_keys, accum_keys)
+            self._handle_event_rate_limited(
+                ev, self._call_later, match_keys, accum_keys
+            )
         elif event_type == "pointer_move":
             match_keys = {"buttons", "modifiers", "ntouches"}
             accum_keys = {}
-            self._handle_event_rate_limited(ev, self._call_later, match_keys, accum_keys)
+            self._handle_event_rate_limited(
+                ev, self._call_later, match_keys, accum_keys
+            )
         else:
             self._handle_event_and_flush(ev)
 

--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -8,7 +8,6 @@ import sys
 from typing import Optional
 
 import wx
-from wx import MouseEvent
 
 from ._gui_utils import get_alt_x11_display, get_alt_wayland_display, weakbind
 from .base import WgpuCanvasBase, WgpuAutoGui
@@ -235,7 +234,7 @@ class WxWgpuWindow(WgpuAutoGui, WgpuCanvasBase, wx.Window):
 
         return None
 
-    def _mouse_event(self, event_type: str, event: MouseEvent, touches: bool = True):
+    def _mouse_event(self, event_type: str, event: wx.MouseEvent, touches: bool = True):
         button = BUTTON_MAP.get(event.GetButton(), 0)
         buttons = (button,)  # in wx only one button is pressed per event
 
@@ -300,7 +299,7 @@ class WxWgpuWindow(WgpuAutoGui, WgpuCanvasBase, wx.Window):
 
         self._mouse_event(event_type_name, event)
 
-    def _on_mouse_move(self, event: MouseEvent):
+    def _on_mouse_move(self, event: wx.MouseEvent):
         self._mouse_event("pointer_move", event)
 
     # Methods that we add from wgpu


### PR DESCRIPTION
As discussed in #485, the `WxWgpuWindow` does not implement event handlers. Because of this, many features such as camera control and mesh picking will not work when pygfx is embedded in Wx.

This PR implements the keyboard, mouse, window resize and closed events. The implementation uses the Qt implementation as a template. However, there are some shortcomings:

- There is no pre-implemented method to convert a `keycode` to its string representation in Wx. I had to implement it myself. Some keys may not be mapped correctly. But it works with lower/upper keys using the modifiers and some special keys.
- At least on MacOS, the `wx.EVT_MOTION` event only fires on the canvas when a mouse button is pressed (like a drag motion). This might be a problem for FPS games. Perhaps it's possible to investigate and fix this in a future story. On a standard `Panel` the motion event works as expected.

To test it, you can adjust the [triangle_wx.py](https://github.com/pygfx/wgpu-py/blob/main/examples/triangle_wx.py). Mouse move events do not seem to propagate to `handle_event` (maybe because of the delay), but they work as well.

```python
import wx
from wgpu.gui.wx import WgpuCanvas

from triangle import main  # The function to call to run the visualization


class MyCanvas(WgpuCanvas):
    def handle_event(self, event):
        if event["event_type"] != "pointer_move":
            print(event)


app = wx.App()
canvas = MyCanvas()

main(canvas)
app.MainLoop()
```

Or use [pygfx](https://github.com/pygfx/pygfx) and adjust the [cube_wx.py](https://github.com/pygfx/pygfx/blob/main/examples/other/cube_wx.py) example to include a camera controller.

<details>
  <summary>cube_wx Example</summary>

```python
import wx
from wgpu.gui.wx import WgpuCanvas

import pygfx as gfx

app = wx.App()

canvas = WgpuCanvas()
renderer = gfx.renderers.WgpuRenderer(canvas)
scene = gfx.Scene()

cube = gfx.Mesh(
    gfx.box_geometry(200, 200, 200),
    gfx.MeshPhongMaterial(color=(0.2, 0.4, 0.6, 1.0)),
)
scene.add(cube)

scene.add(gfx.AmbientLight())

directional_light = gfx.DirectionalLight()
directional_light.world.position = (0, 0, 1)
scene.add(directional_light)

camera = gfx.PerspectiveCamera(70, 16 / 9)
camera.world.position = (0, 0, 400)

controller = gfx.OrbitController(camera, register_events=renderer)


@renderer.add_event_handler("key_down")
def key_down(event: gfx.KeyboardEvent):
    print(event.key)


def animate():
    renderer.render(scene, camera)
    canvas.request_draw()


if __name__ == "__main__":
    canvas.request_draw(animate)
    app.MainLoop()
```

</details>