### PR TITLE
Update README.md "OpenGL is...showings its cracks" -> it's/its

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ WebGPU is a JavaScript API with a well-defined
 broader term "wgpu" is used to refer to "desktop" implementations of WebGPU in
 various languages.
 
-OpenGL is old and showing it's cracks. New API's like Vulkan, Metal and DX12
+OpenGL is old and showing its cracks. New API's like Vulkan, Metal and DX12
 provide a modern way to control the GPU, but these are too low-level for general
 use. WebGPU follows the same concepts, but with a simpler (higher level) API.
 With wgpu-py we bring WebGPU to Python.


### PR DESCRIPTION
Let's focus on understanding the difference between it's (means *exactly* "it is": the apostrophe in English elides words together, e.g., /don't/ = "do not", /'n'/ = "and"). "Its" is the pronoun for the thing described (OpenGL), so companions to "its" also don't have apostrophes (his, her, his, hers, their). We're programmers: this syntax should not be hard for programmers to commit to knowledge. Even native English speakesr make this error far too often.