### PR TITLE
Rename wgpu features to be consistent with webgpu features

### DIFF
--- a/codegen/wgpu_native_patcher.py
+++ b/codegen/wgpu_native_patcher.py
@@ -16,7 +16,7 @@ focuses on the API, here we focus on the C library usage.
 import re
 from collections import defaultdict
 
-from codegen.utils import print, blacken, Patcher
+from codegen.utils import print, blacken, Patcher, to_snake_case
 from codegen.hparser import get_h_parser
 from codegen.idlparser import get_idl_parser
 from codegen.files import file_cache
@@ -128,7 +128,15 @@ def write_mappings():
             if key == "Force32":
                 continue
             pylines.append(f'        "{key}": {val},')
-        pylines.append("    }")
+        pylines.append("    },")
+    for name in ["NativeFeature"]:
+        pylines.append(f'    "{name}":' + " {")
+        for key, val in hp.enums[name].items():
+            if key == "Force32":
+                continue
+            xkey = to_snake_case(key).replace("_", "-")
+            pylines.append(f'        "{xkey}": {val},')
+        pylines.append("    },")
     pylines.append("}")
 
     # Write a few native-only mappings: int => key

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -47,15 +47,6 @@ __all__ = classes.__all__.copy()
 # %% Helper functions and objects
 
 
-# Features that wgpu-native supports that are not part of WebGPU
-NATIVE_FEATURES = (
-    "PushConstants",
-    "TextureAdapterSpecificFormatFeatures",
-    "MultiDrawIndirect",
-    "MultiDrawIndirectCount",
-    "VertexWritableStorage",
-)
-
 # Object to be able to bind the lifetime of objects to other objects
 _refs_per_struct = WeakKeyDictionary()
 
@@ -398,11 +389,10 @@ class GPU(classes.GPU):
                 features.add(f)
 
         # Native features
-        for f in NATIVE_FEATURES:
-            i = getattr(lib, f"WGPUNativeFeature_{f}")
+        for name, i in enum_str2int["NativeFeature"].items():
             # H: WGPUBool f(WGPUAdapter adapter, WGPUFeatureName feature)
             if libf.wgpuAdapterHasFeature(adapter_id, i):
-                features.add(f)
+                features.add(name)
 
         # ----- Done
 
@@ -774,12 +764,11 @@ class GPUAdapter(classes.GPUAdapter):
         c_features = set()
         for f in required_features:
             if isinstance(f, str):
-                if "_" in f:
-                    f = "".join(x.title() for x in f.split("_"))
-                i1 = enummap.get(f"FeatureName.{f}", None)
-                i2 = getattr(lib, f"WGPUNativeFeature_{f}", None)
-                i = i2 if i1 is None else i1
-                if i is None:  # pragma: no cover
+                f = f.replace("_", "-")
+                i = enummap.get(f"FeatureName.{f}", None)
+                if i is None:
+                    i = enum_str2int["NativeFeature"].get(f, None)
+                if i is None:
                     raise KeyError(f"Unknown feature: '{f}'")
                 c_features.add(i)
             else:
@@ -905,11 +894,10 @@ class GPUAdapter(classes.GPUAdapter):
                 features.add(f)
 
         # Native features
-        for f in NATIVE_FEATURES:
-            i = getattr(lib, f"WGPUNativeFeature_{f}")
+        for name, i in enum_str2int["NativeFeature"].items():
             # H: WGPUBool f(WGPUDevice device, WGPUFeatureName feature)
             if libf.wgpuDeviceHasFeature(device_id, i):
-                features.add(f)
+                features.add(name)
 
         # ---- Get queue
 

--- a/wgpu/backends/wgpu_native/_mappings.py
+++ b/wgpu/backends/wgpu_native/_mappings.py
@@ -307,7 +307,19 @@ enum_str2int = {
         "Vulkan": 6,
         "OpenGL": 7,
         "OpenGLES": 8,
-    }
+    },
+    "NativeFeature": {
+        "push-constants": 196609,
+        "texture-adapter-specific-format-features": 196610,
+        "multi-draw-indirect": 196611,
+        "multi-draw-indirect-count": 196612,
+        "vertex-writable-storage": 196613,
+        "texture-binding-array": 196614,
+        "sampled-texture-and-storage-buffer-array-non-uniform-indexing": 196615,
+        "pipeline-statistics-query": 196616,
+        "storage-resource-binding-array": 196617,
+        "partially-bound-binding-array": 196618,
+    },
 }
 enum_int2str = {
     "BackendType": {

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -17,11 +17,10 @@
 * Diffs for GPUTexture: add size
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
-* Diffs for GPURenderPassEncoder: add multi_draw_indexed_indirect, add multi_draw_indirect
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 114 methods, 45 properties
+* Validated 37 classes, 112 methods, 45 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 113 methods, 0 properties
+* Validated 37 classes, 111 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.clip-distances missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
@@ -30,6 +29,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 134 C function calls
-* Not using 70 C functions
+* Validated 132 C function calls
+* Not using 72 C functions
 * Validated 77 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -17,10 +17,11 @@
 * Diffs for GPUTexture: add size
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
+* Diffs for GPURenderPassEncoder: add multi_draw_indexed_indirect, add multi_draw_indirect
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 112 methods, 45 properties
+* Validated 37 classes, 114 methods, 45 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 111 methods, 0 properties
+* Validated 37 classes, 113 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.clip-distances missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
@@ -29,6 +30,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum field DeviceLostReason.unknown missing in wgpu.h
 * Wrote 235 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 132 C function calls
-* Not using 72 C functions
+* Validated 134 C function calls
+* Not using 70 C functions
 * Validated 77 C structs


### PR DESCRIPTION
FIX #553 

Name wgpu features using hyphenated lowercase, just as webgpu features are named.

Automatically generate wgpu features from wgpu.h rather than having a static list.