### PR TITLE
Final fix to cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,7 +130,9 @@ jobs:
       with:
         path: dist
     - name: Flatten dist dir
-      run: find dist -mindepth 2 -type f -exec mv -f '{}' dist/ ';'
+      run: |
+        find dist -mindepth 2 -type f -exec mv -f '{}' dist/ ';'
+        rm -rf dist/*/
     - name: Set version from git ref
       run: echo "WGPU_PY_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Upload Release Assets


### PR DESCRIPTION
Also remove the empty subdirs after moving the files out. This will prevent `twine` from failing.

(I already did the pypi release manually, this is for next release :) )