### PR TITLE
Update native

### DIFF
--- a/download-wgpu-native.py
+++ b/download-wgpu-native.py
@@ -52,14 +52,17 @@ def download_file(url, filename):
 
 
 def extract_file(zip_filename, member, path):
+    # Read file from archive, find it no matter the folder structure
     z = ZipFile(zip_filename)
-    os.makedirs(path, exist_ok=True)
-    z.extract(member, path=path)
+    flat_map = {os.path.basename(fi.filename): fi.filename for fi in z.filelist}
+    bb = z.read(flat_map[member])
+    # Make newlines consistent with Git rules etc.
     if member.endswith(".h") and FORCE_SIMPLE_NEWLINES:
-        filename = os.path.join(path, member)
-        bb = open(filename, "rb").read()
-        with open(filename, "wb") as f:
-            f.write(bb.replace(b"\r\n", b"\n"))
+        bb = bb.replace(b"\r\n", b"\n")
+    # Write to disk
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, member), "wb") as f:
+        f.write(bb)
 
 
 def get_os_string():

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -391,7 +391,7 @@ class GPUAdapter:
     def summary(self):
         """A one-line summary of the info of this adapter (description, adapter_type, backend_type)."""
         d = self._adapter_info
-        return f"{d['description']} ({d['adapter_type']}) via {d['backend_type']}"
+        return f"{d['device']} ({d['adapter_type']}) via {d['backend_type']}"
 
 
 class GPUObjectBase:

--- a/wgpu/backends/wgpu_native/__init__.py
+++ b/wgpu/backends/wgpu_native/__init__.py
@@ -9,8 +9,8 @@ from .. import _register_backend
 
 
 # The wgpu-native version that we target/expect
-__version__ = "22.1.0.2"
-__commit_sha__ = "3e18e3d3e5fd433053875464447c36d980625f0b"
+__version__ = "22.1.0.5"
+__commit_sha__ = "fad19f5990d8eb9a6e942eb957344957193fe66d"
 version_info = tuple(map(int, __version__.split(".")))
 _check_expected_version(version_info)  # produces a warning on mismatch
 


### PR DESCRIPTION
Follow-up on #547. This bumps the minor version of wgpu-native. Two things have changed that this PR accounts for:

* A bug in adapter info was fixed that caused the fields to be mingled. 
* The archives have a nested folder structure.