### PR TITLE
More binary builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,34 +9,34 @@ on:
     branches:
       - main
 
+env:
+    # Only build on one python version since the wheels are not bound to it
+    CIBW_BUILD: 'cp312-*''
+    # Cannot list requests under build-system requires because that step happens _after_ the before-build command
+    CIBW_BEFORE_BUILD: 'pip install requests && python download-wgpu-native.py'
+    # This is sufficient to trigger an install of the built wheel
+    CIBW_TEST_COMMAND: 'echo Wheel installed'
+
+
 jobs:
 
-  # The release builds are done for the platforms that we want to build wheels for.
-  # We build wheels, test them, and then upload the wheel as an artifact.
-  release-builds:
-    name: Build wheels on ${{ matrix.os }}
+
+  windows:
+    name: Build wheels on Windows
     timeout-minutes: 10
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.12'
     - name: Install dev dependencies
       run: |
           python -m pip install --upgrade pip wheel setuptools twine
     - name: Build wheels
-      # Use v2.16, v2.20 fails the osx builds
-      uses: pypa/cibuildwheel@v2.16
+      uses: pypa/cibuildwheel@v2
       env:
-        CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-        CIBW_ARCHS_LINUX: x86_64
-        CIBW_SKIP: cp39-musllinux_x86_64
+        CIBW_ARCHS: AMD64,ARM64,x86
       with:
         output-dir: dist
     - name: Twine check
@@ -46,42 +46,104 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         path: dist
-        name: ${{ matrix.os }}-build
+        name: windows-build
 
-  # These release builds uses QEMU so that we can build wheels for arm64.
-  # We build wheels and upload the wheel as an artifact, but we don't test them here.
-  qemu-release-builds:
-    name: Build wheels on ubuntu-latest with QEMU
+
+  macos:
+    name: Build wheels on MacOS
     timeout-minutes: 10
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+    - uses: actions/setup-python@v5
       with:
-        platforms: arm64
+        python-version: '3.12'
+    - name: Install dev dependencies
+      run: |
+         python -m pip install --upgrade pip wheel setuptools twine
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.20
+      # Use v2.16, v2.20 fails the osx builds
+      uses: pypa/cibuildwheel@v2.16
       env:
-        CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-        CIBW_ARCHS_LINUX: aarch64
-        CIBW_SKIP: cp39-musllinux_aarch64
+        CIBW_ARCHS: x86_64,aarch64
       with:
         output-dir: dist
+    - name: Twine check
+      run: |
+          twine check dist/*
     - name: Upload distributions
       uses: actions/upload-artifact@v4
       with:
         path: dist
-        name: qemu-build
+        name: windows-build
 
-  sdist-build:
+
+  linux:
+    name: Build wheels on Linux
+    timeout-minutes: 10
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dev dependencies
+      run: |
+          python -m pip install --upgrade pip wheel setuptools twine
+    - name: Build wheels
+      # wgpu-native builds using manylinux
+      # wgpu-native does not provide builds for musllinux yet
+      uses: pypa/cibuildwheel@v2
+      env:
+        CIBW_ARCHS: x86_64,aarch64
+        CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+        CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+        CIBW_SKIP: '*musllinux*'
+      with:
+        output-dir: dist
+    - name: Twine check
+      run: |
+          twine check dist/*
+    - name: Upload distributions
+      uses: actions/upload-artifact@v4
+      with:
+        path: dist
+        name: linux-build
+
+
+  # These release builds uses QEMU so that we can build wheels for arm64.
+  # We build wheels and upload the wheel as an artifact, but we don't test them here.
+  # qemu-release-builds:
+  #   name: Build wheels on ubuntu-latest with QEMU
+  #   timeout-minutes: 10
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Set up QEMU
+  #     uses: docker/setup-qemu-action@v3
+  #     with:
+  #       platforms: arm64
+  #   - name: Build wheels
+  #     uses: pypa/cibuildwheel@v2.20
+  #     env:
+  #       CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+  #       CIBW_ARCHS_LINUX: aarch64
+  #       CIBW_SKIP: cp39-musllinux_aarch64
+  #     with:
+  #       output-dir: dist
+  #   - name: Upload distributions
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       path: dist
+  #       name: qemu-build
+
+
+  sdist:
     name: Build sdist
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -114,10 +176,15 @@ jobs:
         path: dist
         name: sdist-build
 
+
   publish:
     name: Publish to Github and Pypi
     runs-on: ubuntu-latest
-    needs: [release-builds, qemu-release-builds, sdist-build]
+    needs:
+      - windows
+      - macos
+      - linux
+      - sdist
     if: success() && startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-srequires = ["setuptools>=42"]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,3 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-]
+srequires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
-
-[tool.cibuildwheel]
-# we only build on one python version since the wheels are not bound to it
-build = "cp39-*"
-
-# we can't list requests under build-system.requires because
-# that step happens _after_ the before-build command
-before-build = "pip install requests && python download-wgpu-native.py"
-
-# this is sufficient to trigger an install of the built wheel
-test-command = "echo Wheel installed"
-
-# this is the minimum supported manylinux version
-manylinux-x86_64-image = "manylinux_2_24"
-manylinux-i686-image = "manylinux_2_24"
-manylinux-aarch64-image = "manylinux_2_24"
-manylinux-ppc64le-image = "manylinux_2_24"
-manylinux-s390x-image = "manylinux_2_24"
-manylinux-pypy_x86_64-image = "manylinux_2_24"
-manylinux-pypy_i686-image = "manylinux_2_24"
-manylinux-pypy_aarch64-image = "manylinux_2_24"
-
-[tool.cibuildwheel.macos]
-# also create apple silicon wheels
-archs = ["x86_64", "arm64"]
-
-# the upstream binaries are not universal yet
-# archs = ["x86_64", "universal2", "arm64"]


### PR DESCRIPTION
* [x] Include Windows aarch64 and 32bit builds, closes #536
* [x] Musllinux would be nice, but still an open issue at wgpu-native https://github.com/gfx-rs/wgpu-native/issues/414
* [x] Refactor cd a bit to have simpler per-os config (in exchange for more code duplication).
* [x] Put all cibuildwheel config inside the cd.yaml, so (almost) everything is in one place. 