### PR TITLE
Fix some small errors

### DIFF
--- a/tests/test_set_override.py
+++ b/tests/test_set_override.py
@@ -2,7 +2,7 @@ import pytest
 
 import wgpu.utils
 from tests.testutils import can_use_wgpu_lib, run_tests
-from wgpu import GPUValidationError, TextureFormat
+from wgpu import TextureFormat
 
 if not can_use_wgpu_lib:
     pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
@@ -196,17 +196,19 @@ def test_override_compute_constants(runner):
 
 
 def test_numbered_constants_must_be_overridden_by_number(runner):
+    # Note.  The naga implementation ignores unknown constants passed as an override.
+    # The JS implementation throws an exception. The JS implementation matches the
+    # specification,
+    #
+    # We will test for current naga behavior, but if this test fails in the future,
+    # it should be replaced with something like the following:
+    #
+    #     with pytest.raises(GPUValidationError):
+    #         runner.run_test(....)
     overrides = {"c": 23, "d": 24}
-    try:
-        # In naga, the bad constant is ignored.
-        # In the JS implementation, this throws an exception, which I think is the
-        # correct behavior.  So just in case this ever gets fixed, we accept either.
-        result = runner.run_test(
-            render=True, vertex_constants=overrides, fragment_constants=overrides
-        )
-    except GPUValidationError:
-        return
-    assert [1, 2, 3, 0, 1, 2, 3, 0] == result
+    assert [1, 2, 3, 0, 1, 2, 3, 0] == runner.run_test(
+        render=True, vertex_constants=overrides, fragment_constants=overrides
+    )
 
 
 if __name__ == "__main__":

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -3031,12 +3031,6 @@ class GPURenderPassEncoder(
             self._internal, buffer._internal, int(offset), int(count)
         )
 
-    def _release(self):
-        if self._internal is not None and libf is not None:
-            self._internal, internal = None, self._internal
-            # H: void f(WGPURenderPassEncoder renderPassEncoder)
-            libf.wgpuRenderPassEncoderRelease(internal)
-
 
 class GPURenderBundleEncoder(
     classes.GPURenderBundleEncoder,

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 112 methods, 45 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 101 methods, 0 properties
+* Validated 37 classes, 100 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.texture-compression-bc-sliced-3d missing in wgpu.h
 * Enum field FeatureName.clip-distances missing in wgpu.h
@@ -35,6 +35,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum CanvasToneMappingMode missing in wgpu.h
 * Wrote 236 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 134 C function calls
+* Validated 133 C function calls
 * Not using 70 C functions
 * Validated 81 C structs


### PR DESCRIPTION
Forgot to delete one _release

Allow most of tests in test_wgpu_vertex_instance to run even if multi-draw-indirect isn't available.  This will be useful in the future as we add more features. Also simplified the code a little bit.

Fixed one test where I believe naga's behavior is incorrect.  I updated the test to accept either naga's current behavior or the behavior of the JS implementation.