### PR TITLE
Handling fatal errors

### DIFF
--- a/tests/test_wgpu_error_fatal.py
+++ b/tests/test_wgpu_error_fatal.py
@@ -1,0 +1,108 @@
+import wgpu
+from testutils import run_tests
+from renderutils import render_to_texture
+from pytest import raises
+
+
+# from test_wgpu_native_render.py
+default_vertex_shader = """
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4<f32> {
+    var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
+        vec3<f32>(-0.5, -0.5, 0.1),
+        vec3<f32>(-0.5,  0.5, 0.1),
+        vec3<f32>( 0.5, -0.5, 0.1),
+        vec3<f32>( 0.5,  0.5, 0.1),
+    );
+    let p: vec3<f32> = positions[vertex_index];
+    return vec4<f32>(p, 1.0);
+}
+"""
+
+# from test_wgpu_native_errors.py
+dedent = lambda s: s.replace("\n        ", "\n").strip()
+
+
+def test_unreachable():
+    # panicked at ~\naga\src\back\spv\block.rs:2401:56:
+    # https://github.com/gfx-rs/wgpu/issues/4517
+    # real world occurance: https://www.shadertoy.com/view/NsffD2
+    # unreachable code due to a pointer and swizzling back.
+    # crashes in wgpuDeviceCreateRenderPipeline, not caught in the shader module.
+    # passes naga validation and wgsl translation, panics to spv translation (which can be caught via subprocess).
+    device = wgpu.utils.get_default_device()
+
+    fragment_shader = """
+    fn test(rng: ptr<function, u32>) {}
+
+    fn woops(uv: vec2<u32>) {
+        var rngs = vec3<u32>(1, 2, 3);
+        test(&rngs.x);
+    }
+
+    @fragment
+    fn fs_main() -> @location(0) vec4<f32> {
+        return vec4<f32>(1.0, 0.499, 0.0, 1.0);
+    }
+    """
+    shader_source = default_vertex_shader + fragment_shader
+
+    bind_group = None
+    pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
+    render_args = device, shader_source, pipeline_layout, bind_group
+
+    # would be great to have some kind of error instead of a crash
+    with raises(wgpu.GPUError):
+        render_to_texture(*render_args, size=(64, 64))
+
+
+def test_impossible_loop():
+    # panicked at src\lib.rs:582:5:
+    # should be captured: https://github.com/gfx-rs/wgpu/issues/5926#issuecomment-2216839446
+    # some use cases include the increment var being related to a uniform like iTime.
+    # other cases are generated code that is just wrong.
+    # another case is a translation error from glsl to wgsl where one statement is lost.
+    # https://github.com/gfx-rs/wgpu/issues/6208
+
+    device = wgpu.utils.get_default_device()
+
+    fragment_shader = """
+    @fragment
+    fn fs_main() -> @location(0) vec4<f32> {
+        var a = 0.0;
+        for (var i = 0; i < 10; i -= 1) {
+            a += 0.1;
+        }
+        return vec4<f32>(1.0, a, 0.0, 1.0);
+    }
+    """
+
+    # we do see this error logged, but not captured and raised.
+    # apparently the device gets lost because it takes too long (infinite loop).
+    # Some compilers detect this (DX12) and raise a different error.
+    # the python process crashes.
+    # the additional backtrace might be a bug upstream.
+    expected = """
+        Error in wgpuQueueSubmit: Validation Error
+
+    Caused by:
+    Parent device is lost
+    """
+
+    shader_source = default_vertex_shader + fragment_shader
+    shader_source = dedent(shader_source)
+    expected = dedent(expected)
+
+    bind_group = None
+    pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
+    render_args = device, shader_source, pipeline_layout, bind_group
+
+    with raises(wgpu.GPUError) as err:
+        render_to_texture(*render_args, size=(64, 64))
+
+    error = err.value.message
+    assert error == expected, f"Expected:\n\n{expected}"
+
+
+if __name__ == "__main__":
+    run_tests(globals())


### PR DESCRIPTION
This is a WIP, it's purpose is to fail badly... so don't merge.

I am compiling all failure cases that cause the python process to crash or silently exit, to think about how to handle them as python exceptions. Debuggers will also just exit, so you have to step through the code to figure out which parts breaks it quite a lot.
Where possible I link the appropriate upstream issues and minimal reproducers.
Some cases are dependant on their backend, I usually default to Vulkan - but test DX12 for comparison too.

# Motivation

My main use case is running a large amount of shaders to sort which work and which don't. This is part of my thesis work on evaluating (generated) shadercode. So there can be all kinds of messed up code. I am not interested on how to write working code. This is about being able to handle errors. 

## Previous attempts
* Naga validation (and by extension get_compilation info) will not catch these problems, and it's equivalent to getting a `GPUValidationError` in `create_shader_module``
* Multiprocess/threadding doesn't currently work in wgpu-py but changes for async support might make this possible. Some problems are not being able to pickle the cffi stuff and not really detecting spawned child processes and if they timeout/crash.
* writing to a temp python file and running that with subprocess - this is actually working so far... horrible solution and really slow. On my machine the overhead to request adapter etc is easily 3+ seconds. When trying to test 30k shaders it can take a whole day. [reference to awful code](https://huggingface.co/spaces/Vipitis/shadermatch/blob/main/shadermatch.py#L336-L375)

# Plan

### collect cases
I started a `test_wgpu_errors_fatal.py` file as part of the test suite (reused other test code mostly), now running this will also crash pytests - so maybe we skip it by default. It would be great to add some more cases and also note down how they panic and where in our code (usually calling the c function). Please contribute any kind of crashes you encounter, even if you don't have a minimal reproducer... I spent a few nights hunting bugs really far down so might see something.

WGSL and GLSL doesn't really matter, since it's always translated to WGSL, so I just went with that.

### find a solution
Problems will eventually be fixed upstream and make it to wgpu-py... but that can take months and some issues haven't been 
fixed upstream for nearly a year, but that will be the best solution.

This is the case where I am sorta lost myself. Maybe the changes to the device lost logging could lead to a raised issue, as tried in #547, otherwise changes to how SafeLibCalls to not drop the Python instance when the rust code reaches `panic!`. 
Usually the last row that gets executed is this https://github.com/pygfx/wgpu-py/blob/cf59eb012d87ac384e62744385c3df0ce9dddad4/wgpu/backends/wgpu_native/_helpers.py#L305
