### PR TITLE
Tweaks to examples

### DIFF
--- a/examples/gui_asyncio.py
+++ b/examples/gui_asyncio.py
@@ -12,36 +12,26 @@ import asyncio
 
 import glfw
 
-from gui_direct import MinimalGlfwCanvas
-from triangle import setup_triangle_async  # noqa: F401, RUF100
-from cube import setup_cube_async  # noqa: F401, RUF100
+from gui_direct import MinimalGlfwCanvas, poll_glfw_briefly
+
+# from triangle import setup_drawing_async
+from cube import setup_drawing_async
 
 
 async def main_loop():
-    # create a window with glfw
-    glfw.init()
-    # disable automatic API selection, we are not using opengl
-    glfw.window_hint(glfw.CLIENT_API, glfw.NO_API)
-    glfw.window_hint(glfw.RESIZABLE, True)
-    window = glfw.create_window(640, 480, "wgpu with asyncio", None, None)
-
     # create canvas
-    canvas = MinimalGlfwCanvas(window)
-    # await setup_triangle_async(canvas)
-    await setup_cube_async(canvas)
+    canvas = MinimalGlfwCanvas("wgpu gui asyncio")
+    draw_frame = await setup_drawing_async(canvas)
 
     last_frame_time = time.perf_counter()
     frame_count = 0
 
-    while True:
+    while not glfw.window_should_close(canvas.window):
         await asyncio.sleep(0.01)
         # process inputs
         glfw.poll_events()
-        # break on close
-        if glfw.window_should_close(window):
-            break
         # draw a frame
-        canvas.draw_frame()
+        await draw_frame()
         # present the frame to the screen
         canvas.context.present()
         # stats
@@ -51,10 +41,9 @@ async def main_loop():
             print(f"{frame_count/etime:0.1f} FPS")
             last_frame_time, frame_count = time.perf_counter(), 0
 
-    # dispose all resources and quit
-    glfw.hide_window(window)
-    glfw.destroy_window(window)
-    glfw.terminate()
+    # dispose resources
+    glfw.destroy_window(canvas.window)
+    poll_glfw_briefly()
 
 
 if __name__ == "__main__":

--- a/examples/gui_auto.py
+++ b/examples/gui_auto.py
@@ -6,12 +6,18 @@ Run triangle/cube example in an automatically selected GUI backend.
 
 from wgpu.gui.auto import WgpuCanvas, run
 
-from triangle import setup_triangle  # noqa: F401, RUF100
-from cube import setup_cube  # noqa: F401, RUF100
+from triangle import setup_drawing_sync
+# from cube import setup_drawing_sync
 
 
 canvas = WgpuCanvas(title=f"Triangle example on {WgpuCanvas.__name__}")
-setup_triangle(canvas)
+draw_frame = setup_drawing_sync(canvas)
+
+
+@canvas.request_draw
+def animate():
+    draw_frame()
+    canvas.request_draw()
 
 
 if __name__ == "__main__":

--- a/examples/gui_glfw.py
+++ b/examples/gui_glfw.py
@@ -6,12 +6,18 @@ Run triangle/cube example in the glfw GUI backend.
 
 from wgpu.gui.glfw import WgpuCanvas, run
 
-from triangle import setup_triangle  # noqa: F401, RUF100
-from cube import setup_cube  # noqa: F401, RUF100
+from triangle import setup_drawing_sync
+# from cube import setup_drawing_sync
 
 
 canvas = WgpuCanvas(title=f"Triangle example on {WgpuCanvas.__name__}")
-setup_triangle(canvas)
+draw_frame = setup_drawing_sync(canvas)
+
+
+@canvas.request_draw
+def animate():
+    draw_frame()
+    canvas.request_draw()
 
 
 if __name__ == "__main__":

--- a/examples/gui_qt.py
+++ b/examples/gui_qt.py
@@ -18,14 +18,20 @@ for lib in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
 
 from wgpu.gui.qt import WgpuCanvas  # noqa: E402
 
-from triangle import setup_triangle  # noqa
-from cube import setup_cube  # noqa
+from triangle import setup_drawing_sync  # noqa: E402
 
 
 app = QtWidgets.QApplication([])
 canvas = WgpuCanvas(title=f"Triangle example on {WgpuCanvas.__name__}")
 
-setup_triangle(canvas)
+draw_frame = setup_drawing_sync(canvas)
+
+
+@canvas.request_draw
+def animate():
+    draw_frame()
+    canvas.request_draw()
+
 
 # Enter Qt event loop (compatible with qt5/qt6)
 app.exec() if hasattr(app, "exec") else app.exec_()

--- a/examples/gui_qt_embed.py
+++ b/examples/gui_qt_embed.py
@@ -19,8 +19,7 @@ for lib in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
 
 from wgpu.gui.qt import WgpuWidget  # noqa: E402
 
-from triangle import setup_triangle  # noqa
-from cube import setup_cube  # noqa
+from triangle import setup_drawing_sync  # noqa: E402
 
 
 class ExampleWidget(QtWidgets.QWidget):
@@ -49,8 +48,11 @@ class ExampleWidget(QtWidgets.QWidget):
 app = QtWidgets.QApplication([])
 example = ExampleWidget()
 
-setup_triangle(example.canvas1)
-setup_triangle(example.canvas2)
+draw_frame1 = setup_drawing_sync(example.canvas1)
+draw_frame2 = setup_drawing_sync(example.canvas2)
+
+example.canvas1.request_draw(draw_frame1)
+example.canvas2.request_draw(draw_frame2)
 
 # Enter Qt event loop (compatible with qt5/qt6)
 app.exec() if hasattr(app, "exec") else app.exec_()

--- a/examples/gui_subprocess.py
+++ b/examples/gui_subprocess.py
@@ -18,8 +18,9 @@ import subprocess
 
 from wgpu.gui import WgpuCanvasBase
 
-# Import the (async) function that we must call to run the visualization
-from triangle import setup_triangle
+# Import the function that we must call to run the visualization
+from triangle import setup_drawing_sync
+# from cube import setup_drawing_sync
 
 
 code = """
@@ -81,5 +82,6 @@ p = subprocess.Popen([sys.executable, "-c", code], stdout=subprocess.PIPE)
 canvas = ProxyCanvas()
 
 # Go!
-setup_triangle(canvas)
+draw_frame = setup_drawing_sync(canvas)
+canvas.request_draw(draw_frame)
 time.sleep(3)

--- a/examples/gui_wx.py
+++ b/examples/gui_wx.py
@@ -7,12 +7,14 @@ Run the triangle/cube example in the wx GUI backend.
 import wx
 from wgpu.gui.wx import WgpuCanvas
 
-from triangle import setup_triangle  # noqa: F401, RUF100
-from cube import setup_cube  # noqa: F401, RUF100
+from triangle import setup_drawing_sync
+# from cube import setup_drawing_sync
 
 
 app = wx.App()
 canvas = WgpuCanvas(title=f"Triangle example on {WgpuCanvas.__name__}")
 
-setup_triangle(canvas)
+draw_func = setup_drawing_sync(canvas)
+canvas.request_draw(draw_func)
+
 app.MainLoop()

--- a/examples/gui_wx_embed.py
+++ b/examples/gui_wx_embed.py
@@ -7,8 +7,7 @@ An example demonstrating a wx app with a wgpu viz inside.
 import wx
 from wgpu.gui.wx import WgpuWidget
 
-from triangle import setup_triangle  # noqa: F401, RUF100
-from cube import setup_cube  # noqa: F401, RUF100
+from triangle import setup_drawing_sync
 
 
 class Example(wx.Frame):
@@ -36,7 +35,10 @@ class Example(wx.Frame):
 app = wx.App()
 example = Example()
 
-setup_triangle(example.canvas1)
-setup_triangle(example.canvas2)
+draw_frame1 = setup_drawing_sync(example.canvas1)
+draw_frame2 = setup_drawing_sync(example.canvas2)
+
+example.canvas1.request_draw(draw_frame1)
+example.canvas2.request_draw(draw_frame2)
 
 app.MainLoop()

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -45,16 +45,14 @@ void main()
 # %% The wgpu calls
 
 
-def setup_triangle(canvas, power_preference="high-performance", limits=None):
+def setup_drawing_sync(canvas, power_preference="high-performance", limits=None):
     """Regular function to setup a viz on the given canvas."""
 
     adapter = wgpu.gpu.request_adapter_sync(power_preference=power_preference)
     device = adapter.request_device_sync(required_limits=limits)
 
     render_pipeline = get_render_pipeline(canvas, device)
-    draw_function = get_draw_function(canvas, device, render_pipeline)
-
-    canvas.request_draw(draw_function)
+    return get_draw_function(canvas, device, render_pipeline)
 
 
 def get_render_pipeline(canvas, device):
@@ -129,5 +127,6 @@ if __name__ == "__main__":
     from wgpu.gui.auto import WgpuCanvas, run
 
     canvas = WgpuCanvas(size=(640, 480), title="wgpu triangle glsl example")
-    setup_triangle(canvas)
+    draw_frame = setup_drawing_sync(canvas)
+    canvas.request_draw(draw_frame)
     run()

--- a/tests/test_gui_glfw.py
+++ b/tests/test_gui_glfw.py
@@ -26,6 +26,9 @@ def setup_module():
 
 
 def teardown_module():
+    from wgpu.gui.glfw import poll_glfw_briefly
+
+    poll_glfw_briefly()
     pass  # Do not glfw.terminate() because other tests may still need glfw
 
 

--- a/tests_mem/test_gui_glfw.py
+++ b/tests_mem/test_gui_glfw.py
@@ -38,7 +38,7 @@ def test_release_canvas_context(n):
     # Texture and a TextureView, but these are released in present(),
     # so we don't see them in the counts.
 
-    from wgpu.gui.glfw import WgpuCanvas
+    from wgpu.gui.glfw import WgpuCanvas, poll_glfw_briefly
 
     yield {
         "ignore": {"CommandBuffer"},
@@ -59,6 +59,8 @@ def test_release_canvas_context(n):
     gc.collect()
     loop.run_until_complete(stub_event_loop())
     gc.collect()
+
+    poll_glfw_briefly()  # removes all windows from screen
 
     # Check that the canvas objects are really deleted
     assert not canvases, f"Still {len(canvases)} canvases"

--- a/wgpu/gui/glfw.py
+++ b/wgpu/gui/glfw.py
@@ -597,6 +597,21 @@ async def keep_glfw_alive():
             loop.stop()
 
 
+def poll_glfw_briefly(poll_time=0.1):
+    """Briefly poll glfw for a set amount of time.
+
+    Intended to work around the bug that destroyed windows sometimes hang
+    around if the mainloop exits: https://github.com/glfw/glfw/issues/1766
+
+    I found that 10ms is enough, but make it 100ms just in case. You should
+    only run this right after your mainloop stops.
+
+    """
+    end_time = time.perf_counter() + poll_time
+    while time.perf_counter() < end_time:
+        glfw.wait_events_timeout(end_time - time.perf_counter())
+
+
 def call_later(delay, callback, *args):
     loop = app.get_loop()
     loop.call_later(delay, callback, *args)
@@ -610,3 +625,4 @@ def run():
     app.stop_if_no_more_canvases = True
     loop.run_forever()
     app.stop_if_no_more_canvases = False
+    poll_glfw_briefly()


### PR DESCRIPTION
* [x] Refactor `triangle.py`  and `cube.py`  so that they return the draw function. This means that the canvas needs nothing more than `WgpuCanvasInterface`, which is nice and clean.
* [x] The examples that use `triangle` or `cube`, call `canvas.request_draw()` or call the draw function on their own terms. 
* [x] The draw function returned by the async setup-method, is also async.
* [x] Tweaked `cube.py` so it used `buffer.map()`, so we can run something that is actually async.
* [x] Implemented a workaround for a bug that left destroyed glfw windows on screen on macos.

### Side note 

I observed the following warning when using glfw:
```
2024-10-02 16:13:41.233 python[40243:5114401] +[IMKClient subclass]: chose IMKClient_Legacy
2024-10-02 16:13:41.233 python[40243:5114401] +[IMKInputSession subclass]: chose IMKInputSession_Legacy
```

I checked that this happens inside `glfw.poll_events` and a quick Google suggests it is related to the latest MacOS Sequoia update. So nothing we can do on our end.