### PR TITLE
Make depth_stencil_attachment follow the spec

### DIFF
--- a/tests/test_wgpu_native_query_set.py
+++ b/tests/test_wgpu_native_query_set.py
@@ -86,7 +86,7 @@ def test_query_set():
     )
     assert query_set.count == query_count
     assert query_set.type == query_type
-    assert query_set._device == device._internal
+    assert query_set._device == device
     assert query_set.label == query_label
 
     query_buf_size = 8 * query_set.count

--- a/tests/test_wgpu_native_render.py
+++ b/tests/test_wgpu_native_render.py
@@ -557,18 +557,6 @@ def _render_orange_square_depth(depth_stencil_tex_format, use_render_bundle):
         format=depth_stencil_tex_format,
         depth_write_enabled=True,
         depth_compare=wgpu.CompareFunction.less_equal,
-        # stencil_front={
-        #     "compare": wgpu.CompareFunction.equal,
-        #     "fail_op": wgpu.StencilOperation.keep,
-        #     "depth_fail_op": wgpu.StencilOperation.keep,
-        #     "pass_op": wgpu.StencilOperation.keep,
-        # },
-        # stencil_back={
-        #     "compare": wgpu.CompareFunction.equal,
-        #     "fail_op": wgpu.StencilOperation.keep,
-        #     "depth_fail_op": wgpu.StencilOperation.keep,
-        #     "pass_op": wgpu.StencilOperation.keep,
-        # },
         stencil_read_mask=0,
         stencil_write_mask=0,
         depth_bias=0,
@@ -581,9 +569,15 @@ def _render_orange_square_depth(depth_stencil_tex_format, use_render_bundle):
         depth_clear_value=0.1,
         depth_load_op=wgpu.LoadOp.clear,
         depth_store_op=wgpu.StoreOp.store,
-        stencil_load_op=wgpu.LoadOp.load,
-        stencil_store_op=wgpu.StoreOp.store,
     )
+
+    if "stencil" in depth_stencil_tex_format:
+        depth_stencil_attachment["stencil_load_op"] = wgpu.LoadOp.load
+        depth_stencil_attachment["stencil_store_op"] = wgpu.StoreOp.store
+
+    if "stencil" in depth_stencil_tex_format:
+        depth_stencil_attachment["stencil_load_op"] = wgpu.LoadOp.load
+        depth_stencil_attachment["stencil_store_op"] = wgpu.StoreOp.store
 
     # Render
     render_args = device, shader_source, pipeline_layout, bind_group

--- a/tests/test_wgpu_native_render.py
+++ b/tests/test_wgpu_native_render.py
@@ -3,6 +3,7 @@ Test render pipeline, by drawing a whole lot of orange squares ...
 """
 
 import ctypes
+
 import numpy as np
 import sys
 
@@ -21,7 +22,7 @@ elif is_ci and sys.platform == "win32":
     skip("These tests fail on dx12 for some reason", allow_module_level=True)
 
 
-default_vertex_shader = """
+DEFAULT_SHADER = """
 @vertex
 fn vs_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4<f32> {
     var positions: array<vec3<f32>, 4> = array<vec3<f32>, 4>(
@@ -33,8 +34,18 @@ fn vs_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4
     let p: vec3<f32> = positions[vertex_index];
     return vec4<f32>(p, 1.0);
 }
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.499, 0.0, 1.0);
+}
 """
 
+DEPTH_STENCIL_TEX_FORMATS = [
+    wgpu.TextureFormat.depth16unorm,
+    wgpu.TextureFormat.depth24plus_stencil8,
+    wgpu.TextureFormat.depth32float,
+]
 
 # %% Simple square
 
@@ -48,20 +59,12 @@ def test_render_orange_square(use_render_bundle):
     # NOTE: the 0.499 instead of 0.5 is to make sure the resulting value is 127.
     # With 0.5 some drivers would produce 127 and others 128.
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     # Bindings and layout
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args)
     a = render_to_texture(
         *render_args, size=(64, 64), use_render_bundle=use_render_bundle
@@ -89,14 +92,6 @@ def test_render_orange_square_indexed(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     # Bindings and layout
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
@@ -109,7 +104,7 @@ def test_render_orange_square_indexed(use_render_bundle):
     )
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, topology=wgpu.PrimitiveTopology.triangle_list, ibo=ibo)
     a = render_to_texture(
         *render_args,
@@ -138,14 +133,6 @@ def test_render_orange_square_indirect(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     # Bindings and layout
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
@@ -158,7 +145,7 @@ def test_render_orange_square_indirect(use_render_bundle):
     )
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, indirect_buffer=indirect_buffer)
     a = render_to_texture(
         *render_args,
@@ -186,14 +173,6 @@ def test_render_orange_square_indexed_indirect(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     # Bindings and layout
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
@@ -213,7 +192,7 @@ def test_render_orange_square_indexed_indirect(use_render_bundle):
     )
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, topology=wgpu.PrimitiveTopology.triangle_list, ibo=ibo, indirect_buffer=indirect_buffer)
     a = render_to_texture(
         *render_args,
@@ -309,14 +288,6 @@ def test_render_orange_square_color_attachment1(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     # Bindings and layout
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
@@ -329,7 +300,7 @@ def test_render_orange_square_color_attachment1(use_render_bundle):
     }
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, color_attachment=ca)
     a = render_to_texture(
         *render_args,
@@ -360,14 +331,6 @@ def test_render_orange_square_color_attachment2(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     # Bindings and layout
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
@@ -379,7 +342,7 @@ def test_render_orange_square_color_attachment2(use_render_bundle):
     }
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, color_attachment=ca)
     a = render_to_texture(
         *render_args,
@@ -411,14 +374,6 @@ def test_render_orange_square_viewport(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     def cb(renderpass):
         renderpass.set_viewport(10, 20, 32, 32, 0, 1)
 
@@ -427,7 +382,7 @@ def test_render_orange_square_viewport(use_render_bundle):
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, renderpass_callback=cb)
     a = render_to_texture(
         *render_args,
@@ -455,14 +410,6 @@ def test_render_orange_square_scissor(use_render_bundle):
 
     device = get_default_device()
 
-    fragment_shader = """
-        @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-            return vec4<f32>(1.0, 0.499, 0.0, 1.0);
-        }
-    """
-    shader_source = default_vertex_shader + fragment_shader
-
     def cb(renderpass):
         renderpass.set_scissor_rect(0, 0, 32, 32)
         # Else set blend color. Does not change output, but covers the call.
@@ -473,7 +420,7 @@ def test_render_orange_square_scissor(use_render_bundle):
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
 
     # Render
-    render_args = device, shader_source, pipeline_layout, bind_group
+    render_args = device, DEFAULT_SHADER, pipeline_layout, bind_group
     # render_to_screen(*render_args, renderpass_callback=cb)
     a = render_to_texture(
         *render_args,
@@ -496,26 +443,9 @@ def test_render_orange_square_scissor(use_render_bundle):
 
 
 @pytest.mark.parametrize("use_render_bundle", [True, False])
-def test_render_orange_square_depth16unorm(use_render_bundle):
+@pytest.mark.parametrize("depth_stencil_tex_format", DEPTH_STENCIL_TEX_FORMATS)
+def test_render_orange_square_with_depth(depth_stencil_tex_format, use_render_bundle):
     """Render an orange square, but disable half of it using a depth test using 16 bits."""
-    _render_orange_square_depth(wgpu.TextureFormat.depth16unorm, use_render_bundle)
-
-
-@pytest.mark.parametrize("use_render_bundle", [True, False])
-def test_render_orange_square_depth24plus_stencil8(use_render_bundle):
-    """Render an orange square, but disable half of it using a depth test using 24 bits."""
-    _render_orange_square_depth(
-        wgpu.TextureFormat.depth24plus_stencil8, use_render_bundle
-    )
-
-
-@pytest.mark.parametrize("use_render_bundle", [True, False])
-def test_render_orange_square_depth32float(use_render_bundle):
-    """Render an orange square, but disable half of it using a depth test using 32 bits."""
-    _render_orange_square_depth(wgpu.TextureFormat.depth32float, use_render_bundle)
-
-
-def _render_orange_square_depth(depth_stencil_tex_format, use_render_bundle):
     device = get_default_device()
 
     shader_source = """
@@ -544,7 +474,7 @@ def _render_orange_square_depth(depth_stencil_tex_format, use_render_bundle):
     bind_group = None
     pipeline_layout = device.create_pipeline_layout(bind_group_layouts=[])
 
-    # Create dept-stencil texture
+    # Create depth-stencil texture
     depth_stencil_texture = device.create_texture(
         size=(64, 64, 1),  # when rendering to texture
         # size=(640, 480, 1),  # when rendering to screen
@@ -557,11 +487,6 @@ def _render_orange_square_depth(depth_stencil_tex_format, use_render_bundle):
         format=depth_stencil_tex_format,
         depth_write_enabled=True,
         depth_compare=wgpu.CompareFunction.less_equal,
-        stencil_read_mask=0,
-        stencil_write_mask=0,
-        depth_bias=0,
-        depth_bias_slope_scale=0.0,
-        depth_bias_clamp=0.0,
     )
 
     depth_stencil_attachment = dict(
@@ -574,10 +499,7 @@ def _render_orange_square_depth(depth_stencil_tex_format, use_render_bundle):
     if "stencil" in depth_stencil_tex_format:
         depth_stencil_attachment["stencil_load_op"] = wgpu.LoadOp.load
         depth_stencil_attachment["stencil_store_op"] = wgpu.StoreOp.store
-
-    if "stencil" in depth_stencil_tex_format:
-        depth_stencil_attachment["stencil_load_op"] = wgpu.LoadOp.load
-        depth_stencil_attachment["stencil_store_op"] = wgpu.StoreOp.store
+        # The default values of depth_stencil_state are fine.
 
     # Render
     render_args = device, shader_source, pipeline_layout, bind_group
@@ -673,6 +595,60 @@ def test_render_orange_dots(use_render_bundle):
         assert np.all(dot[:, :, 1] == 127)  # green
         assert np.all(dot[:, :, 2] == 0)  # blue
         assert np.all(dot[:, :, 3] == 255)  # alpha
+
+
+@pytest.mark.parametrize("depth_stencil_tex_format", DEPTH_STENCIL_TEX_FORMATS)
+def test_stencil_depth_warning(depth_stencil_tex_format, monkeypatch):
+    # Verify that when you use stencil_load_op or stencil_store_op, and there is
+    # no stencil, you'll get a warning.  But only once.
+
+    # The only way we can see warnings is by monkeypatching wgpu.logger.warning
+    warnings = []
+    monkeypatch.setattr(wgpu.logger, "warning", lambda msg: warnings.append(msg))
+
+    # We need a new device for each run, since each device keeps track of which warnings
+    # it's issued.
+    adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+    device = adapter.request_device_sync()
+
+    # Create depth-stencil texture
+    depth_stencil_texture = device.create_texture(
+        size=(64, 64, 1),  # when rendering to texture
+        format=depth_stencil_tex_format,
+        usage=wgpu.TextureUsage.RENDER_ATTACHMENT,
+    )
+
+    depth_stencil_attachment = dict(
+        view=depth_stencil_texture.create_view(),
+        depth_clear_value=0.1,
+        depth_load_op=wgpu.LoadOp.clear,
+        depth_store_op=wgpu.StoreOp.store,
+        stencil_load_op=wgpu.LoadOp.clear,
+        stencil_store_op=wgpu.StoreOp.store,
+    )
+
+    command_encoder = device.create_command_encoder()
+    # This call to begin_render_pass may create warnings.
+    render_pass = command_encoder.begin_render_pass(
+        color_attachments=[], depth_stencil_attachment=depth_stencil_attachment
+    )
+    render_pass.end()
+
+    if "stencil" in depth_stencil_tex_format:
+        assert not warnings
+    else:
+        assert len(warnings) == 2
+        warnings.sort()
+        assert "stencil_load_op" in warnings[0]
+        assert "stencil_store_op" in warnings[1]
+        warnings.clear()
+
+    # The warnings are issued only once.
+    render_pass = command_encoder.begin_render_pass(
+        color_attachments=[], depth_stencil_attachment=depth_stencil_attachment
+    )
+    render_pass.end()
+    assert not warnings
 
 
 if __name__ == "__main__":

--- a/tests/test_wgpu_occlusion_query.py
+++ b/tests/test_wgpu_occlusion_query.py
@@ -141,9 +141,6 @@ def test_render_occluding_squares():
         "depth_clear_value": 1.0,
         "depth_load_op": "clear",
         "depth_store_op": "store",
-        "stencil_clear_value": 1.0,
-        "stencil_load_op": "clear",
-        "stencil_store_op": "store",
     }
 
     render_pass = command_encoder.begin_render_pass(

--- a/tests_mem/test_destroy.py
+++ b/tests_mem/test_destroy.py
@@ -28,7 +28,7 @@ def test_destroy_device(n):
     for i in range(n):
         d = adapter.request_device_sync()
         d.destroy()
-        # NOTE: destroy is not yet implemented in wgpu-natice - this does not actually do anything yet
+        # NOTE: destroy is not yet implemented in wgpu-native - this does not actually do anything yet
         yield d
 
 
@@ -38,7 +38,7 @@ def test_destroy_query_set(n):
     for i in range(n):
         qs = DEVICE.create_query_set(type=wgpu.QueryType.occlusion, count=2)
         qs.destroy()
-        # NOTE: destroy is not yet implemented in wgpu-natice - this does not actually do anything yet
+        # NOTE: destroy is not yet implemented in wgpu-native - this does not actually do anything yet
         yield qs
 
 

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -218,13 +218,10 @@ def create_and_release(create_objects_func):
             # Test that everything that's a subclass of GPUObjectBase has a device
             # in its _device field.
             if issubclass(cls, GPUObjectBase):
-                if issubclass(cls, GPUDevice):
-                    assert all(objects[i]._device is None for i in range(len(objects)))
-                else:
-                    assert all(
-                        isinstance(objects[i]._device, GPUDevice)
-                        for i in range(len(objects))
-                    )
+                assert all(
+                    isinstance(objects[i]._device, GPUDevice)
+                    for i in range(len(objects))
+                )
 
             # Test that class matches function name (should prevent a group of copy-paste errors)
             assert ob_name == cls.__name__[3:]

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -218,10 +218,13 @@ def create_and_release(create_objects_func):
             # Test that everything that's a subclass of GPUObjectBase has a device
             # in its _device field.
             if issubclass(cls, GPUObjectBase):
-                assert all(
-                    isinstance(objects[i]._device, GPUDevice)
-                    for i in range(len(objects))
-                )
+                if issubclass(cls, GPUDevice):
+                    assert all(objects[i]._device is None for i in range(len(objects)))
+                else:
+                    assert all(
+                        isinstance(objects[i]._device, GPUDevice)
+                        for i in range(len(objects))
+                    )
 
             # Test that class matches function name (should prevent a group of copy-paste errors)
             assert ob_name == cls.__name__[3:]

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -215,17 +215,13 @@ def create_and_release(create_objects_func):
             cls = objects[0].__class__
             assert all(isinstance(objects[i], cls) for i in range(len(objects)))
 
-            # Test that everything that's a subclass of GPUObjectBase is either a
-            # GPUDevice and has None it its _device field, or is something else and has
-            # a GPUDevice in the _device field.
+            # Test that everything that's a subclass of GPUObjectBase has a device
+            # in its _device field.
             if issubclass(cls, GPUObjectBase):
-                if issubclass(cls, GPUDevice):
-                    assert all(objects[i]._device is None for i in range(len(objects)))
-                else:
-                    assert all(
-                        isinstance(objects[i]._device, GPUDevice)
-                        for i in range(len(objects))
-                    )
+                assert all(
+                    isinstance(objects[i]._device, GPUDevice)
+                    for i in range(len(objects))
+                )
 
             # Test that class matches function name (should prevent a group of copy-paste errors)
             assert ob_name == cls.__name__[3:]

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -701,7 +701,7 @@ class GPUDevice(GPUObjectBase):
     """
 
     def __init__(self, label, internal, adapter, features, limits, queue):
-        super().__init__(label, internal, self)
+        super().__init__(label, internal, None)
 
         assert isinstance(adapter, GPUAdapter)
         assert isinstance(features, set)

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -701,7 +701,7 @@ class GPUDevice(GPUObjectBase):
     """
 
     def __init__(self, label, internal, adapter, features, limits, queue):
-        super().__init__(label, internal, None)
+        super().__init__(label, internal, self)
 
         assert isinstance(adapter, GPUAdapter)
         assert isinstance(features, set)

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -73,8 +73,8 @@ apidiff = ApiDiff()
 object_tracker = diagnostics.object_counts.tracker
 
 # The 'optional' value is used as the default value for optional arguments in the following two cases:
-# * The method accepts a descriptior that is optional, so we make all arguments (i.e. descriptor fields) optional, and this one does not have a default value.
-# * In wgpu-py we decided that this argument should be optonal, even though it's currently not according to the WebGPU spec.
+# * The method accepts a descriptor that is optional, so we make all arguments (i.e. descriptor fields) optional, and this one does not have a default value.
+# * In wgpu-py we decided that this argument should be optional, even though it's currently not according to the WebGPU spec.
 optional = None
 
 
@@ -618,7 +618,7 @@ class GPUAdapter:
         """Request a `GPUDevice` from the adapter.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             required_features (list of str): the features (extensions) that you need. Default [].
             required_limits (dict): the various limits that you need. Default {}.
             default_queue (structs.QueueDescriptor): Descriptor for the default queue. Optional.
@@ -800,7 +800,7 @@ class GPUDevice(GPUObjectBase):
         """Create a `GPUBuffer` object.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             size (int): The size of the buffer in bytes.
             usage (flags.BufferUsage): The ways in which this buffer will be used.
             mapped_at_creation (bool): Whether the buffer is initially mapped.
@@ -815,7 +815,7 @@ class GPUDevice(GPUObjectBase):
         writes the given data to it, and then unmaps the buffer.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             data: Any object supporting the Python buffer protocol (this
                 includes bytes, bytearray, ctypes arrays, numpy arrays, etc.).
             usage (flags.BufferUsage): The ways in which this buffer will be used.
@@ -858,7 +858,7 @@ class GPUDevice(GPUObjectBase):
         """Create a `GPUTexture` object.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             size (tuple or dict): The texture size as a 3-tuple or a `structs.Extent3D`.
             mip_level_count (int): The number of mip leveles. Default 1.
             sample_count (int): The number of samples. Default 1.
@@ -870,7 +870,7 @@ class GPUDevice(GPUObjectBase):
               a performance penalty.
 
         See https://gpuweb.github.io/gpuweb/#texture-format-caps for a
-        list of available texture formats. Note that less formats are
+        list of available texture formats. Note that fewer formats are
         available for storage usage.
         """
         raise NotImplementedError()
@@ -894,7 +894,7 @@ class GPUDevice(GPUObjectBase):
         """Create a `GPUSampler` object. Samplers specify how a texture is sampled.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             address_mode_u (enums.AddressMode): What happens when sampling beyond the x edge.
                 Default "clamp-to-edge".
             address_mode_v (enums.AddressMode): What happens when sampling beyond the y edge.
@@ -923,7 +923,7 @@ class GPUDevice(GPUObjectBase):
         docs on bind groups for details.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             entries (list): A list of `structs.BindGroupLayoutEntry` dicts.
                 Each contains either a `structs.BufferBindingLayout`,
                 `structs.SamplerBindingLayout`, `structs.TextureBindingLayout`,
@@ -962,7 +962,7 @@ class GPUDevice(GPUObjectBase):
         `pass.set_bind_group()` to attach a group of resources.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             layout (GPUBindGroupLayout): The layout (abstract representation)
                 for this bind group.
             entries (list): A list of `structs.BindGroupEntry` dicts. The ``resource`` field
@@ -1002,7 +1002,7 @@ class GPUDevice(GPUObjectBase):
         used in `create_render_pipeline()` or `create_compute_pipeline()`.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             bind_group_layouts (list): A list of `GPUBindGroupLayout` objects.
         """
         raise NotImplementedError()
@@ -1022,7 +1022,7 @@ class GPUDevice(GPUObjectBase):
         as well as GLSL (experimental).
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             code (str | bytes): The shader code, as WGSL, GLSL or SpirV.
                 For GLSL code, the label must be given and contain the word
                 'comp', 'vert' or 'frag'. For SpirV the code must be bytes.
@@ -1041,7 +1041,7 @@ class GPUDevice(GPUObjectBase):
         """Create a `GPUComputePipeline` object.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             layout (GPUPipelineLayout): object created with `create_pipeline_layout()`.
             compute (structs.ProgrammableStage): Binds shader module and entrypoint.
         """
@@ -1075,7 +1075,7 @@ class GPUDevice(GPUObjectBase):
         """Create a `GPURenderPipeline` object.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             layout (GPUPipelineLayout): The layout for the new pipeline.
             vertex (structs.VertexState): Describes the vertex shader entry point of the
                 pipeline and its input buffer layouts.
@@ -1228,7 +1228,7 @@ class GPUDevice(GPUObjectBase):
         at once to the GPU.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
         """
         raise NotImplementedError()
 
@@ -1250,7 +1250,7 @@ class GPUDevice(GPUObjectBase):
         performance by removing the overhead of repeating the commands.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             color_formats (list): A list of the `GPUTextureFormats` of the color attachments for this pass or bundle.
             depth_stencil_format (GPUTextureFormat): The format of the depth/stencil attachment for this pass or bundle.
             sample_count (int): The number of samples per pixel in the attachments for this pass or bundle. Default 1.
@@ -1389,7 +1389,7 @@ class GPUBuffer(GPUObjectBase):
     def unmap(self):
         """Unmaps the buffer.
 
-        Unmaps the mapped range of the GPUBuffer and makes it's contents
+        Unmaps the mapped range of the GPUBuffer and makes its contents
         available for use by the GPU again.
         """
         raise NotImplementedError()
@@ -1574,7 +1574,7 @@ class GPUTexture(GPUObjectBase):
         same format and dimension as the texture.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             format (enums.TextureFormat): What channels it stores and how.
             dimension (enums.TextureViewDimension): The dimensionality of the texture view.
             aspect (enums.TextureAspect): Whether this view is used for depth, stencil, or all.
@@ -1920,7 +1920,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         `GPUComputePassEncoder` object.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             timestamp_writes: unused
         """
         raise NotImplementedError()
@@ -1940,7 +1940,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         `GPURenderPassEncoder` object.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
             color_attachments (list): List of `structs.RenderPassColorAttachment` dicts.
             depth_stencil_attachment (structs.RenderPassDepthStencilAttachment): Describes the depth stencil attachment. Default None.
             occlusion_query_set (GPUQuerySet): Default None.
@@ -2043,7 +2043,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         submit to a `GPUQueue`.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
         """
         raise NotImplementedError()
 
@@ -2242,7 +2242,7 @@ class GPURenderBundleEncoder(
         """Finish recording and return a `GPURenderBundle`.
 
         Arguments:
-            label (str): A human readable label. Optional.
+            label (str): A human-readable label. Optional.
         """
         raise NotImplementedError()
 
@@ -2609,7 +2609,7 @@ def _set_compat_methods_for_async_methods():
             return getattr(self, name)(*args, **kwargs)
 
         proxy_method.__name__ = name + "_backwards_compat_proxy"
-        proxy_method.__doc__ = f"Backwards compatibile method for {name}()"
+        proxy_method.__doc__ = f"Backwards compatible method for {name}()"
         return proxy_method
 
     m = globals()

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1946,10 +1946,10 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
             # not used: nextInChain
         )
         # H: WGPURenderBundleEncoder f(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor)
-        render_bundle_id = libf.wgpuDeviceCreateRenderBundleEncoder(
+        render_bundle_encoder_id = libf.wgpuDeviceCreateRenderBundleEncoder(
             self._internal, render_bundle_encoder_descriptor
         )
-        return GPURenderBundleEncoder(label, render_bundle_id, self._device)
+        return GPURenderBundleEncoder(label, render_bundle_encoder_id, self)
 
     def create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
         return self._create_query_set(label, type, count, None)
@@ -1994,7 +1994,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
 
         # H: WGPUQuerySet f(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor)
         query_id = libf.wgpuDeviceCreateQuerySet(self._internal, query_set_descriptor)
-        return GPUQuerySet(label, query_id, self._device, type, count)
+        return GPUQuerySet(label, query_id, self, type, count)
 
     def _get_lost_sync(self):
         check_can_use_sync_variants()
@@ -2619,7 +2619,7 @@ class GPUCommandEncoder(
         )
         # H: WGPUComputePassEncoder f(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor)
         raw_encoder = libf.wgpuCommandEncoderBeginComputePass(self._internal, struct)
-        encoder = GPUComputePassEncoder(label, raw_encoder, self)
+        encoder = GPUComputePassEncoder(label, raw_encoder, self._device)
         return encoder
 
     def begin_render_pass(

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -43,7 +43,7 @@ from ._helpers import (
 logger = logging.getLogger("wgpu")
 
 
-# The API is prettu well defined
+# The API is pretty well defined
 __all__ = classes.__all__.copy()
 
 
@@ -323,7 +323,7 @@ class GPU(classes.GPU):
         force_fallback_adapter: bool = False,
         canvas=None,
     ):
-        """Async version of ``request_adapter_async()``.
+        """Sync version of ``request_adapter_async()``.
         This is the implementation based on wgpu-native.
         """
         check_can_use_sync_variants()
@@ -753,7 +753,7 @@ class GPUCanvasContext(classes.GPUCanvasContext):
                 # Or if this is the second attempt.
                 raise RuntimeError(f"Cannot get surface texture ({status}).")
 
-        # I don't expect this to happen, but lets check just in case.
+        # I don't expect this to happen, but let's check just in case.
         if not texture_id:
             raise RuntimeError("Cannot get surface texture (no texture)")
 
@@ -2109,7 +2109,7 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
             awaitable_result["result"] = status
 
         def poll_func():
-            # Doing nothing here will result in timeouts. I.e. unlike request_device, this method is truely async.
+            # Doing nothing here will result in timeouts. I.e. unlike request_device, this method is truly async.
             # H: WGPUBool f(WGPUDevice device, WGPUBool wait, WGPUWrappedSubmissionIndex const * wrappedSubmissionIndex)
             libf.wgpuDevicePoll(self._device._internal, False, ffi.NULL)
 
@@ -2467,7 +2467,7 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
 
 
 class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
-    # whole class is likely going to solved better: https://github.com/pygfx/wgpu-py/pull/546
+    # whole class is likely going to be solved better: https://github.com/pygfx/wgpu-py/pull/546
     def push_debug_group(self, group_label: str):
         c_group_label = to_c_string(group_label)
         # H: void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, char const * groupLabel)

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 124 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 112 methods, 0 properties
+* Validated 37 classes, 113 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.texture-compression-bc-sliced-3d missing in wgpu.h
 * Enum field FeatureName.clip-distances missing in wgpu.h


### PR DESCRIPTION
https://www.w3.org/TR/webgpu/#depth-stencil-attachments

Make depth_stencil_attachment more closely follow the specification.  No longer do we need to specify stencil_xxx if it's a depth, and no need to specify depth_xxx if it's a stencil.  We only need to specify "color" if it's a "clear".  