### PR TITLE
Nitpicky changes flagged by PyCharm

### DIFF
--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -10,10 +10,10 @@ from codegen.files import file_cache
 
 # In wgpu-py, we make some args optional, that are not optional in the
 # IDL. Reasons may be because it makes sense to be able to omit them,
-# or because the WebGPU says its optional while IDL says its not, or
+# or because the WebGPU says its optional while IDL says it's not, or
 # for backwards compatibility. These args have a default value of
 # 'optional'  (which is just None) so we can recognise them. If IDL
-# makes any of these args optional, their presense in this list is
+# makes any of these args optional, their presence in this list is
 # ignored.
 ARGS_TO_MAKE_OPTIONAL = {
     ("compilation_hints", "compilation_hints"),  # idl actually has a default
@@ -91,7 +91,7 @@ class AbstractCommentInjector(Patcher):
     since that is the task of the API patchers.
 
     Also moves decorators just above the def. Doing this here in a
-    post-processing step means we dont have to worry about decorators
+    post-processing step means we don't have to worry about decorators
     in the other patchers, keeping them simpler.
     """
 
@@ -137,7 +137,7 @@ class AbstractApiPatcher(Patcher):
     """The base patcher to update a wgpu API.
 
     This code is generalized, so it can be used both to generate the base API
-    as well as the backends (implementations).
+    and the backends (implementations).
 
     The idea is to walk over all classes, patch it if necessary, then
     walk over each of its properties and methods to patch these too.
@@ -361,7 +361,7 @@ class IdlPatcherMixin:
                 return idl_sync
 
     def name2py_names(self, classname, name_idl):
-        """Map a idl propname/methodname to the python variants.
+        """Map an idl propname/methodname to the python variants.
         Take async into account. Returns a list with one or two names;
         for async props/methods Python has the sync and the async variant.
         """

--- a/codegen/hparser.py
+++ b/codegen/hparser.py
@@ -134,7 +134,7 @@ class HParser:
                 self.flags[name] = self.enums.pop(name)
 
         # Collect structs. This is relatively easy, since we only need the C code.
-        # But we dont deal with union structs.
+        # But we don't deal with union structs.
         i1 = i2 = i3 = i4 = 0
         while True:
             # Find struct

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -143,7 +143,7 @@ class IdlParser:
 
     def _pre_process(self, text):
         """Pre-process the text to make it a bit easier to parse.
-        Beware to keep line numbers the same
+        Be careful to keep line numbers the same
         """
         text = text.replace("\n[\n", "\n\n[").replace("\n]\n", "]\n\n")
         text = text.replace("[    ", "[")
@@ -177,7 +177,7 @@ class IdlParser:
 
     def resolve_type(self, typename):
         """Resolve a type to a suitable name that is also valid so that the linter
-        wont complain when this is used as a type annotation.
+        won't complain when this is used as a type annotation.
         """
 
         name = typename.strip().strip("?")

--- a/codegen/tests/test_codegen_result.py
+++ b/codegen/tests/test_codegen_result.py
@@ -4,7 +4,7 @@ from codegen.files import read_file
 
 
 def test_async_methods_and_props():
-    # Test that only and all aync methods are suffixed with '_async'
+    # Test that only and all async methods are suffixed with '_async'
 
     for fname in ["_classes.py", "backends/wgpu_native/_api.py"]:
         code = read_file(fname)

--- a/codegen/utils.py
+++ b/codegen/utils.py
@@ -44,7 +44,7 @@ _file_objects_to_print_to = [sys.stdout]
 
 
 def print(*args, **kwargs):
-    """Report something (will be printed and added to a file."""
+    """Report something will be printed and added to a file."""
     # __builtins__.print(*args, **kwargs)
     if args and not args[0].lstrip().startswith("#"):
         args = ("*", *args)
@@ -206,7 +206,7 @@ class Patcher:
 
     def insert_line(self, i, line):
         """Insert a new line at the given position. It's ok if there
-        has already been an insertion an line i, but there must not have been
+        has already been an insertion on line i, but there must not have been
         any other actions.
         """
         if i in self._diffs and self._diffs[i][1] == "insert":

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser):
 def predictable_random_numbers():
     """
     Called at start of each test, guarantees that calls to random produce the same output over subsequent tests runs,
-    see http://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.random.seed.html
+    see https://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.random.seed.html
     """
     np.random.seed(0)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # The wgpu Examples
 
-Please note that the examples you see on Github may not be compatible with the
+Please note that the examples you see on GitHub may not be compatible with the
 wgpu version you've installed on your system.
 
 You can:

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -198,7 +198,7 @@ def create_pipeline_layout(device):
         }
     )
 
-    # Create the wgou binding objects
+    # Create the wgpu binding objects
     bind_group_layouts = []
     bind_groups = []
 

--- a/examples/gui_asyncio.py
+++ b/examples/gui_asyncio.py
@@ -2,7 +2,7 @@
 Run the triangle/cube example in as custom event loop based on asyncio.
 It uses the asynchronous path, which calls the async versions of the wgpu API.
 
-Uses glfw as a GUI because its loop-agnostic.
+Uses glfw as a GUI because it's loop-agnostic.
 """
 
 # run_example = false

--- a/examples/gui_trio.py
+++ b/examples/gui_trio.py
@@ -6,10 +6,10 @@ Although asyncio is builtin, it is not the only asynchronous framework
 for Python; there's also e.g. uvloop and Trio. In order not to lock
 people into a specific async framework, wgpu must be framework agnostic.
 In practice this means it must not use anything from the asyncio
-libraray (e.g. asyncio.sleep()). This example makes sure wgpu works
+library (e.g. asyncio.sleep()). This example makes sure wgpu works
 with Trio, although it may not cover all async parts of the API.
 
-Uses glfw as a GUI because its loop-agnostic.
+Uses glfw as a GUI because it's loop-agnostic.
 """
 
 # run_example = false

--- a/examples/imgui_multi_canvas.py
+++ b/examples/imgui_multi_canvas.py
@@ -20,7 +20,7 @@ canvases = [canvas1, canvas2, canvas3]
 adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
 device = adapter.request_device_sync()
 
-# create a imgui renderer for each canvas
+# create an imgui renderer for each canvas
 imgui_renderer1 = ImguiRenderer(device, canvas1)
 imgui_renderer2 = ImguiRenderer(device, canvas2)
 imgui_renderer3 = ImguiRenderer(device, canvas3)

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -31,7 +31,7 @@ if not can_use_wgpu_lib:
     pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
 
 
-# run all tests unless they opt-out
+# run all tests unless they opt out
 examples_to_run = find_examples(
     negative_query="# run_example = false", return_stems=True
 )

--- a/examples/triangle_glsl.py
+++ b/examples/triangle_glsl.py
@@ -46,7 +46,7 @@ void main()
 
 
 def setup_drawing_sync(canvas, power_preference="high-performance", limits=None):
-    """Regular function to setup a viz on the given canvas."""
+    """Regular function to set up a viz on the given canvas."""
 
     adapter = wgpu.gpu.request_adapter_sync(power_preference=power_preference)
     device = adapter.request_device_sync(required_limits=limits)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -131,8 +131,8 @@ def test_that_we_know_how_our_api_differs():
 
 
 def test_that_all_docstrings_are_there():
-    for name, cls in wgpu.classes.__dict__.items():
-        if name.startswith("_"):
+    for class_name, cls in wgpu.classes.__dict__.items():
+        if class_name.startswith("_"):
             continue
         assert isinstance(cls, type)
         assert cls.__doc__, f"No docstring on {cls.__name__}"

--- a/tests/test_set_constant.py
+++ b/tests/test_set_constant.py
@@ -152,11 +152,11 @@ def test_bad_set_push_constants():
         return np.zeros(n, dtype=np.uint32)
 
     with pytest.raises(ValueError):
-        # Buffer is to short
+        # Buffer is too short
         set_push_constants(this_pass, "VERTEX", 0, COUNT * 4, zeros(COUNT - 1))
 
     with pytest.raises(ValueError):
-        # Buffer is to short
+        # Buffer is too short
         set_push_constants(this_pass, "VERTEX", 0, COUNT * 4, zeros(COUNT + 1), 8)
 
 

--- a/tests/test_wgpu_native_render.py
+++ b/tests/test_wgpu_native_render.py
@@ -392,7 +392,7 @@ def test_render_orange_square_color_attachment2(use_render_bundle):
     bg = a.copy()
     bg[16:-16, 16:-16, :] = 0
     # assert np.all(bg == 0)
-    # Actually, it seems unpredictable what the bg is if we dont clear it?
+    # Actually, it seems unpredictable what the bg is if we don't clear it?
 
     # Check the square
     sq = a[16:-16, 16:-16, :]

--- a/tests/test_wgpu_occlusion_query.py
+++ b/tests/test_wgpu_occlusion_query.py
@@ -120,7 +120,7 @@ def test_render_occluding_squares():
     # small square completely outside the clipping area.
     draw_square(False, x_offset=2, y_offset=2)
 
-    # Draw a square that should be visible, but it is culled because it is a rear-
+    # Draw a square that should be visible, but it is culled because it is a rear
     # facing rectangle. And to keep us honest, redraw the example again, but have it
     # face forward.
     draw_square(False, x_offset=0.1, y_offset=0.1, reverse=True)

--- a/tests/test_wgpu_vertex_instance.py
+++ b/tests/test_wgpu_vertex_instance.py
@@ -17,7 +17,7 @@ if not can_use_wgpu_lib:
 
 
 """
-The fundamental informartion about any of the many draw commands is the
+The fundamental information about any of the many draw commands is the
 <vertex_instance, instance_index> pair that is passed to the vertex shader. By using
 point-list topology, each call to the vertex shader turns into a single call to the
 fragment shader, where the pair is recorded.

--- a/tests_mem/test_destroy.py
+++ b/tests_mem/test_destroy.py
@@ -1,6 +1,6 @@
 """
 A few objects have a destroy method. We test its behavior here.
-In practice it does not really affect the lifetime, so these tests look
+In practice, it does not really affect the lifetime, so these tests look
 a lot like the corresponding release tests :)
 """
 

--- a/tests_mem/test_gui_glfw.py
+++ b/tests_mem/test_gui_glfw.py
@@ -35,7 +35,7 @@ def test_release_canvas_context(n):
     # Test with GLFW canvases.
 
     # Note: in a draw, the textureview is obtained (thus creating a
-    # Texture and a TextureView, but these are released in present(),
+    # Texture and a TextureView), but these are released in present(),
     # so we don't see them in the counts.
 
     from wgpu.gui.glfw import WgpuCanvas, poll_glfw_briefly

--- a/tests_mem/test_gui_qt.py
+++ b/tests_mem/test_gui_qt.py
@@ -26,7 +26,7 @@ def test_release_canvas_context(n):
     # Test with PySide canvases.
 
     # Note: in a draw, the textureview is obtained (thus creating a
-    # Texture and a TextureView, but these are released in present(),
+    # Texture and a TextureView), but these are released in present(),
     # so we don't see them in the counts.
 
     import PySide6

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -138,7 +138,7 @@ def create_and_release(create_objects_func):
     """
     This wrapper goes around a test that takes a single argument n. That test should
     be a generator function that yields a descriptor followed
-    n different objects corresponding to the name of the test function.  Hence
+    n different objects corresponding to the name of the test function. Hence,
     a test named `test_release_foo_bar` would yield a descriptor followed by
     n FooBar objects.
 

--- a/wgpu/__pyinstaller/hook-wgpu.py
+++ b/wgpu/__pyinstaller/hook-wgpu.py
@@ -19,7 +19,7 @@ hiddenimports += ["wgpu.backends.auto", "wgpu.backends.wgpu_native"]
 # problematic because PyInstaller cannot follow it to a specific
 # backend. Also, glfw does not have a hook like this, so it does not
 # include the binary when freezing. We can solve both problems with the
-# code below. Makes the binaray a bit larger, but only marginally (less
+# code below. Makes the binary a bit larger, but only marginally (less
 # than 300kb).
 try:
     import glfw  # noqa: F401

--- a/wgpu/_coreutils.py
+++ b/wgpu/_coreutils.py
@@ -158,7 +158,7 @@ def str_flag_to_int(flag, s):
 class ApiDiff:
     """Helper class to define differences in the API by annotating
     methods. This way, these difference are made explicit, plus they're
-    logged so we can automatically included these changes in the docs.
+    logged so we can automatically include these changes in the docs.
     """
 
     def __init__(self):

--- a/wgpu/_diagnostics.py
+++ b/wgpu/_diagnostics.py
@@ -12,7 +12,7 @@ class DiagnosticsRoot:
 
     Per-topic diagnostics can be accessed as attributes on this object.
     These include ``system``, ``wgpu_native_info``, ``versions``,
-    ``object_counts``, ``wgpu_natrive_counts``.
+    ``object_counts``, ``wgpu_native_counts``.
     """
 
     def __init__(self):

--- a/wgpu/gui/auto.py
+++ b/wgpu/gui/auto.py
@@ -51,7 +51,7 @@ def select_backend():
         except Exception as err:
             failed_backends[backend_name] = str(err)
 
-    # Always report failed backeds, because we only try them when it looks like we can.
+    # Always report failed backends, because we only try them when it looks like we can.
     if failed_backends:
         msg = "WGPU could not load some backends:"
         for key, val in failed_backends.items():
@@ -128,7 +128,7 @@ def backends_by_jupyter():
         if gui_module_name in QT_MODULE_NAMES:
             yield "qt", "running on Jupyter with qt gui"
         # elif "wx" in app.__class__.__name__.lower() == "wx":
-        #     yield "wx", "running on Hupyter with wx gui"
+        #     yield "wx", "running on Jupyter with wx gui"
 
     yield "jupyter", "running on Jupyter"
 

--- a/wgpu/gui/jupyter.py
+++ b/wgpu/gui/jupyter.py
@@ -1,6 +1,6 @@
 """
 Support for rendering in a Jupyter widget. Provides a widget subclass that
-can be used as cell output, or embedded in a ipywidgets gui.
+can be used as cell output, or embedded in an ipywidgets gui.
 """
 
 import weakref
@@ -94,7 +94,7 @@ class JupyterWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, RemoteFrameBuffer):
 
     def get_present_info(self):
         # Use a format that maps well to PNG: rgba8norm. Use srgb for
-        # perseptive color mapping. This is the common colorspace for
+        # perceptive color mapping. This is the common colorspace for
         # e.g. png and jpg images. Most tools (browsers included) will
         # blit the png to screen as-is, and a screen wants colors in srgb.
         return {

--- a/wgpu/utils/__init__.py
+++ b/wgpu/utils/__init__.py
@@ -3,7 +3,7 @@ Higher level utilities. Must be explicitly imported from ``wgpu.utils.xx``.
 """
 
 # The purpose of wgpu-py is to provide a Pythonic wrapper around
-# wgpu-native. In principal, a higher-level API is not within the scope
+# wgpu-native. In principle, a higher-level API is not within the scope
 # of the project. However, by providing a few utility functions, other
 # projects can use wgpu without having to keep track of changes in wgpu
 # itself.


### PR DESCRIPTION
Typos and grammar mistakes found by PyCharm. 

With one exception ("name" was used as a loop variable within another loop that also used "name" as a loop variable), there are no changes to code.  

I only took those changes that I thought were really typos or bad grammar.  PyCharm doesn't know how to use a/an before acronyms, and wants more commas than I do.