### PR TITLE
Fix snake case for 1d/2d/3d suffix

### DIFF
--- a/codegen/tests/test_codegen_utils.py
+++ b/codegen/tests/test_codegen_utils.py
@@ -22,7 +22,8 @@ def test_to_snake_case():
     assert to_snake_case("_foo_bar_spam") == "_foo_bar_spam"
     assert to_snake_case("fooBarSpam") == "foo_bar_spam"
     assert to_snake_case("_fooBarSpam") == "_foo_bar_spam"
-    assert to_snake_case("maxTextureDimension1D") == "max_texture_dimension1d"
+    assert to_snake_case("maxTextureDimension1D") == "max_texture_dimension_1d"
+    assert to_snake_case("max_texture_dimension_1d") == "max_texture_dimension_1d"
 
 
 def test_to_camel_case():
@@ -30,7 +31,11 @@ def test_to_camel_case():
     assert to_camel_case("_foo_bar_spam") == "_fooBarSpam"
     assert to_camel_case("fooBarSpam") == "fooBarSpam"
     assert to_camel_case("_fooBarSpam") == "_fooBarSpam"
+    assert to_camel_case("max_texture_dimension_1d") == "maxTextureDimension1D"
     assert to_camel_case("max_texture_dimension1d") == "maxTextureDimension1D"
+    assert to_camel_case("max-texture-dimension1d") == "maxTextureDimension1D"
+    assert to_camel_case("max-texture-dimension-1d") == "maxTextureDimension1D"
+    assert to_camel_case("maxTextureDimension1D") == "maxTextureDimension1D"
 
 
 def test_remove_c_comments():

--- a/codegen/utils.py
+++ b/codegen/utils.py
@@ -8,15 +8,19 @@ import tempfile
 import subprocess
 
 
-def to_snake_case(name):
+def to_snake_case(name, separator="_"):
     """Convert a name from camelCase to snake_case. Names that already are
     snake_case remain the same.
     """
     name2 = ""
     for c in name:
         c2 = c.lower()
-        if c2 != c and len(name2) > 0 and name2[-1] not in "_123":
-            name2 += "_"
+        if c2 != c and len(name2) > 0:
+            prev = name2[-1]
+            if c2 == "d" and prev in "123":
+                name2 = name2[:-1] + separator + prev
+            elif prev != separator:
+                name2 += separator
         name2 += c2
     return name2
 
@@ -28,7 +32,7 @@ def to_camel_case(name):
     is_capital = False
     name2 = ""
     for c in name:
-        if c == "_" and name2:
+        if c in "_-" and name2:
             is_capital = True
         elif is_capital:
             name2 += c.upper()

--- a/wgpu/backends/wgpu_native/_helpers.py
+++ b/wgpu/backends/wgpu_native/_helpers.py
@@ -188,7 +188,7 @@ def get_surface_id_from_info(present_info):
     return lib.wgpuInstanceCreateSurface(get_wgpu_instance(), surface_descriptor)
 
 
-# The functions below are copied from codegen/utils.py
+# The functions below are copied from codegen/utils.py - let's keep these in sync!
 
 
 def to_snake_case(name, separator="_"):
@@ -200,7 +200,9 @@ def to_snake_case(name, separator="_"):
         c2 = c.lower()
         if c2 != c and len(name2) > 0:
             prev = name2[-1]
-            if prev not in "123" and prev != separator:
+            if c2 == "d" and prev in "123":
+                name2 = name2[:-1] + separator + prev
+            elif prev != separator:
                 name2 += separator
         name2 += c2
     return name2
@@ -213,7 +215,7 @@ def to_camel_case(name):
     is_capital = False
     name2 = ""
     for c in name:
-        if c == "_" and name2:
+        if c in "_-" and name2:
             is_capital = True
         elif is_capital:
             name2 += c.upper()


### PR DESCRIPTION
In responding to https://github.com/pygfx/pygfx/issues/863, I realized that `
gfx.renderers.wgpu.set_wgpu_limits(max_texture_dimension_3d=...)`  does not work, but `
gfx.renderers.wgpu.set_wgpu_limits(max_texture_dimension3d=...)` does. While in fact wgpu uses the former notation, as is shown in the error message:
Caused by:
  Limit 'max_texture_dimension_3d' value 3000 is better than allowed 2048
```


This PR fixes that, and keeps the old notation working too: `max_texture_dimension3d` still resolves to `maxTextureDimension3D`. 

We have two implementations of `to_snake_case()` and `to_camel_case()`, because the codegen does not import from wgpu. This PR also makes them the same again (the diverged a little.

The codegen is actually not affected. Only the way that custom limits and such are handled.