### PR TITLE
Eliminate warning in test suite

### DIFF
--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -218,13 +218,6 @@ class GPUCanvasContext:
         self._ot.increase(self.__class__.__name__)
         self._canvas_ref = weakref.ref(canvas)
 
-        # The configuration from the canvas, obtained with canvas.get_present_info()
-        self._present_info = canvas.get_present_info()
-        if self._present_info.get("method", None) not in ("screen", "image"):
-            raise RuntimeError(
-                "canvas.get_present_info() must produce a dict with a field 'method' that is either 'screen' or 'image'."
-            )
-
         # Surface capabilities. Stored the first time it is obtained
         self._capabilities = None
 
@@ -233,6 +226,14 @@ class GPUCanvasContext:
 
         # The last used texture
         self._texture = None
+
+        # The configuration from the canvas, obtained with canvas.get_present_info()
+        # The configuration from the canvas, obtained with canvas.get_present_info()
+        self._present_info = canvas.get_present_info()
+        if self._present_info.get("method", None) not in ("screen", "image"):
+            raise RuntimeError(
+                "canvas.get_present_info() must produce a dict with a field 'method' that is either 'screen' or 'image'."
+            )
 
     def _get_canvas(self):
         """Getter method for internal use."""

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -228,7 +228,6 @@ class GPUCanvasContext:
         self._texture = None
 
         # The configuration from the canvas, obtained with canvas.get_present_info()
-        # The configuration from the canvas, obtained with canvas.get_present_info()
         self._present_info = canvas.get_present_info()
         if self._present_info.get("method", None) not in ("screen", "image"):
             raise RuntimeError(


### PR DESCRIPTION
Runnng the test suite from the terminal gives the warning shown below.  This makes this warning go away.

I haven't yet figured out a safe way to get rid of the other warning: ` /Users/fy/Pycharm/wgpu-py/wgpu/gui/glfw.py:557: DeprecationWarning: There is no current event loop`

```
================================================================================================== warnings summary ==================================================================================================
tests/test_gui_base.py::test_base_canvas_context
  /Users/fy/Pycharm/wgpu-py/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:80: PytestUnraisableExceptionWarning: Exception ignored in: <function GPUCanvasContext.__del__ at 0x102d51ee0>
  
  Traceback (most recent call last):
    File "/Users/fy/Pycharm/wgpu-py/wgpu/_classes.py", line 517, in __del__
      self._release()
    File "/Users/fy/Pycharm/wgpu-py/wgpu/_classes.py", line 520, in _release
      self._drop_texture()
    File "/Users/fy/Pycharm/wgpu-py/wgpu/_classes.py", line 442, in _drop_texture
      if self._texture:
         ^^^^^^^^^^^^^
  AttributeError: 'GPUCanvasContext' object has no attribute '_texture'
  
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```
