### PR TITLE
Only keep alive those objects that are necessary.

### DIFF
--- a/tests_mem/test_object_retention.py
+++ b/tests_mem/test_object_retention.py
@@ -24,12 +24,12 @@ SHADER_SOURCE = """
     fn vertex_main( @location(0) position: vec2f ) -> @builtin(position) vec4f {
         return vec4f(position + offset, 0, 1.0);
     }
-    
+
     @fragment
-    fn fragment_main() -> @location(0) vec4f { 
-        return vec4f(); 
+    fn fragment_main() -> @location(0) vec4f {
+        return vec4f();
     }
-    
+
     @compute
     @workgroup_size(1)
     fn main(@builtin(global_invocation_id) index: vec3<u32>) {

--- a/tests_mem/test_object_retention.py
+++ b/tests_mem/test_object_retention.py
@@ -1,0 +1,362 @@
+import struct
+
+import pytest
+
+import wgpu
+from tests.testutils import run_tests
+from wgpu.backends.wgpu_native.extras import (
+    PipelineStatisticName,
+    begin_pipeline_statistics_query,
+    create_statistics_query_set,
+    end_pipeline_statistics_query,
+)
+
+SHADER_SOURCE = """
+    @group(0) @binding(0) var<uniform> offset: vec2f;
+
+    @vertex
+    fn vertex_main( @location(0) position: vec2f ) -> @builtin(position) vec4f {
+        return vec4f(position + offset, 0, 1.0);
+    }
+    
+    @fragment
+    fn fragment_main() -> @location(0) vec4f { 
+        return vec4f(); 
+    }
+    
+    @compute
+    @workgroup_size(1)
+    fn main(@builtin(global_invocation_id) index: vec3<u32>) {
+        _ = offset;
+    }
+"""
+
+VERTEX_BUFFER_LAYOUT = {
+    "array_stride": 4 * 2,
+    "attributes": [
+        {
+            "format": wgpu.VertexFormat.float32x2,
+            "offset": 0,
+            "shader_location": 0,
+        },
+    ],
+}
+
+BIND_GROUP_ENTRIES = [
+    {
+        "binding": 0,
+        "visibility": wgpu.flags.ShaderStage.VERTEX | wgpu.flags.ShaderStage.COMPUTE,
+        "buffer": {},
+    }
+]
+
+
+@pytest.mark.parametrize("use_render_bundle", [False, True])
+def test_object_retention_in_render(use_render_bundle, capsys):
+    with capsys.disabled():
+        adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+        desired_features = ["timestamp-query", "pipeline-statistics-query"]
+        features = [x for x in desired_features if x in adapter.features]
+        device = adapter.request_device_sync(required_features=features)
+        has_timestamps = "timestamp-query" in features
+        has_statistics = "pipeline-statistics-query" in features
+
+        output_texture_format = wgpu.TextureFormat.rgba8unorm
+        depth_texture_format = wgpu.TextureFormat.depth32float
+
+        shader = device.create_shader_module(code=SHADER_SOURCE)
+
+        bind_group_entries = BIND_GROUP_ENTRIES.copy()
+        bind_group_layout = device.create_bind_group_layout(entries=bind_group_entries)
+        del bind_group_entries
+
+        pipeline_layout = device.create_pipeline_layout(
+            bind_group_layouts=[bind_group_layout]
+        )
+        del bind_group_layout
+
+        pipeline = device.create_render_pipeline(
+            layout=pipeline_layout,
+            vertex={
+                "module": shader,
+                "buffers": [VERTEX_BUFFER_LAYOUT],
+            },
+            fragment={
+                "module": shader,
+                "targets": [{"format": output_texture_format}],
+            },
+            depth_stencil={"format": depth_texture_format},
+            primitive={"topology": "triangle-strip"},
+        )
+        del pipeline_layout
+
+        vertex_buffer = device.create_buffer_with_data(
+            data=struct.pack("8f", -0.5, -0.5, -0.5, +0.5, +0.5, -0.5, +0.5, +0.5),
+            usage=wgpu.BufferUsage.VERTEX,
+        )
+
+        indirect_buffer = device.create_buffer_with_data(
+            # Used for both indexed and non-indexed draws.
+            data=struct.pack("5i", 4, 1, 0, 0, 0),
+            usage=wgpu.BufferUsage.INDIRECT,
+        )
+
+        index_buffer = device.create_buffer_with_data(
+            data=struct.pack("4i", 0, 1, 2, 3),
+            usage=wgpu.BufferUsage.INDEX,
+        )
+
+        data_buffer = device.create_buffer(size=2 * 4, usage="UNIFORM")
+        bind_group = device.create_bind_group(
+            layout=pipeline.get_bind_group_layout(0),
+            entries=[
+                {"binding": 0, "resource": {"buffer": data_buffer}},
+            ],
+        )
+        del data_buffer
+
+        output_texture = device.create_texture(
+            size=[128, 128],
+            format=output_texture_format,
+            usage="RENDER_ATTACHMENT",
+        )
+        depth_texture = device.create_texture(
+            size=[128, 128],
+            format=depth_texture_format,
+            usage="RENDER_ATTACHMENT",
+        )
+        occlusion_query_set = device.create_query_set(type="occlusion", count=2)
+        timestamp_query_set = None
+        if has_timestamps:
+            timestamp_query_set = device.create_query_set(type="timestamp", count=2)
+
+        render_pass_descriptor = {
+            "color_attachments": [
+                {
+                    "clear_value": (0, 0, 0, 0),
+                    "load_op": wgpu.LoadOp.clear,
+                    "store_op": wgpu.StoreOp.store,
+                    "view": output_texture.create_view(),
+                }
+            ],
+            "depth_stencil_attachment": {
+                "view": depth_texture.create_view(),
+                "depth_clear_value": 0.1,
+                "depth_load_op": wgpu.LoadOp.clear,
+                "depth_store_op": wgpu.StoreOp.store,
+            },
+            "occlusion_query_set": occlusion_query_set,
+        }
+        if has_timestamps:
+            render_pass_descriptor["timestamp_writes"] = {
+                "query_set": timestamp_query_set,
+                "beginning_of_pass_write_index": 0,
+                "end_of_pass_write_index": 1,
+            }
+
+        del output_texture
+        del depth_texture
+        del occlusion_query_set
+        del timestamp_query_set
+
+        def do_draw(encoder):
+            nonlocal pipeline, bind_group, vertex_buffer, index_buffer, indirect_buffer
+            encoder.set_pipeline(pipeline)
+            encoder.set_bind_group(0, bind_group)
+            encoder.set_vertex_buffer(0, vertex_buffer)
+            encoder.set_index_buffer(index_buffer, "uint32")
+            encoder.draw(4, 1, 0, 0)
+            encoder.draw_indexed(4, 1, 0, 0)
+            encoder.draw_indirect(indirect_buffer, 0)
+            encoder.draw_indexed_indirect(indirect_buffer, 0)
+            pipeline = bind_group = vertex_buffer = index_buffer = indirect_buffer = (
+                None
+            )
+
+        command_encoder = device.create_command_encoder()
+        render_pass = command_encoder.begin_render_pass(**render_pass_descriptor)
+        del render_pass_descriptor
+
+        if use_render_bundle:
+            render_bundle_encoder = device.create_render_bundle_encoder(
+                color_formats=[output_texture_format],
+                depth_stencil_format=depth_texture_format,
+            )
+            do_draw(render_bundle_encoder)
+
+            render_bundle = render_bundle_encoder.finish()
+            render_pass.execute_bundles([render_bundle])
+        else:
+            if has_statistics:
+                statistics_query_set = create_statistics_query_set(
+                    device,
+                    count=2,
+                    statistics=[PipelineStatisticName.FragmentShaderInvocations],
+                )
+                begin_pipeline_statistics_query(render_pass, statistics_query_set, 0)
+                del statistics_query_set
+            do_draw(render_pass)
+            if has_statistics:
+                end_pipeline_statistics_query(render_pass)
+
+        render_pass.end()
+
+        device.queue.submit([command_encoder.finish()])
+
+
+def test_object_retention_in_compute():
+    adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+    desired_features = ["timestamp-query", "pipeline-statistics-query"]
+    features = [x for x in desired_features if x in adapter.features]
+    device = adapter.request_device_sync(required_features=features)
+    has_timestamps = "timestamp-query" in features
+    has_statistics = "pipeline-statistics-query" in features
+
+    shader = device.create_shader_module(code=SHADER_SOURCE)
+
+    bind_group_entries = BIND_GROUP_ENTRIES.copy()
+    bind_group_layout = device.create_bind_group_layout(entries=bind_group_entries)
+    del bind_group_entries
+
+    pipeline_layout = device.create_pipeline_layout(
+        bind_group_layouts=[bind_group_layout]
+    )
+    del bind_group_layout
+
+    pipeline = device.create_compute_pipeline(
+        layout=pipeline_layout,
+        compute={
+            "module": shader,
+        },
+    )
+    del pipeline_layout
+
+    data_buffer = device.create_buffer(size=2 * 4, usage="UNIFORM")
+
+    bind_group = device.create_bind_group(
+        layout=pipeline.get_bind_group_layout(0),
+        entries=[
+            {"binding": 0, "resource": {"buffer": data_buffer}},
+        ],
+    )
+    del data_buffer
+
+    timestamp_query_set = None
+    if has_timestamps:
+        timestamp_query_set = device.create_query_set(type="timestamp", count=2)
+
+    compute_pass_descriptor = {}
+    if has_timestamps:
+        compute_pass_descriptor["timestamp_writes"] = {
+            "query_set": timestamp_query_set,
+            "beginning_of_pass_write_index": 0,
+            "end_of_pass_write_index": 1,
+        }
+
+    del timestamp_query_set
+
+    def setup_compute(encoder):
+        indirect_buffer = device.create_buffer_with_data(
+            # Used for both indexed and non-indexed draws.
+            data=struct.pack("3i", 1, 1, 1),
+            usage=wgpu.BufferUsage.INDIRECT,
+        )
+        nonlocal pipeline, bind_group
+        encoder.set_pipeline(pipeline)
+        encoder.set_bind_group(0, bind_group)
+        encoder.dispatch_workgroups(1, 1, 1)
+        encoder.dispatch_workgroups_indirect(indirect_buffer, 0)
+        pipeline = bind_group = None
+
+    command_encoder = device.create_command_encoder()
+    compute_pass = command_encoder.begin_compute_pass(**compute_pass_descriptor)
+    del compute_pass_descriptor
+
+    if has_statistics:
+        statistics_query_set = create_statistics_query_set(
+            device,
+            count=2,
+            statistics=[PipelineStatisticName.ComputeShaderInvocations],
+        )
+        begin_pipeline_statistics_query(compute_pass, statistics_query_set, 0)
+        del statistics_query_set
+    setup_compute(compute_pass)
+    if has_statistics:
+        end_pipeline_statistics_query(compute_pass)
+
+    compute_pass.end()
+    device.queue.submit([command_encoder.finish()])
+
+
+def test_clear_buffer():
+    device = wgpu.utils.get_default_device()
+
+    buffer = device.create_buffer(size=100, usage=wgpu.BufferUsage.COPY_DST)
+    command_encoder = device.create_command_encoder()
+    command_encoder.clear_buffer(buffer)
+    del buffer
+    device.queue.submit([command_encoder.finish()])
+
+
+def test_copy_buffer_to_buffer():
+    device = wgpu.utils.get_default_device()
+
+    buffer1 = device.create_buffer(size=100, usage=wgpu.BufferUsage.COPY_SRC)
+    buffer2 = device.create_buffer(size=100, usage=wgpu.BufferUsage.COPY_DST)
+    command_encoder = device.create_command_encoder()
+    command_encoder.copy_buffer_to_buffer(buffer1, 0, buffer2, 0, 100)
+    del buffer1
+    del buffer2
+    device.queue.submit([command_encoder.finish()])
+
+
+def test_copy_buffer_to_texture():
+    device = wgpu.utils.get_default_device()
+
+    texture = device.create_texture(size=[64, 64], format="r32uint", usage="COPY_DST")
+    buffer = device.create_buffer(size=texture._nbytes, usage=wgpu.BufferUsage.COPY_SRC)
+    command_encoder = device.create_command_encoder()
+    command_encoder.copy_buffer_to_texture(
+        {"buffer": buffer, "offset": 0, "bytes_per_row": 64 * 4, "rows_per_image": 64},
+        {"texture": texture, "mip_level": 0, "origin": (0, 0, 0)},
+        (64, 64),
+    )
+    del buffer
+    del texture
+    device.queue.submit([command_encoder.finish()])
+
+
+def test_copy_texture_to_buffer():
+    device = wgpu.utils.get_default_device()
+
+    texture = device.create_texture(size=[64, 64], format="r32uint", usage="COPY_SRC")
+    buffer = device.create_buffer(size=texture._nbytes, usage=wgpu.BufferUsage.COPY_DST)
+    command_encoder = device.create_command_encoder()
+    command_encoder.copy_texture_to_buffer(
+        {"texture": texture, "mip_level": 0, "origin": (0, 0, 0)},
+        {"buffer": buffer, "offset": 0, "bytes_per_row": 64 * 4, "rows_per_image": 64},
+        (64, 64),
+    )
+    del buffer
+    del texture
+    device.queue.submit([command_encoder.finish()])
+
+
+def test_copy_texture_to_texture():
+    device = wgpu.utils.get_default_device()
+
+    texture1 = device.create_texture(size=[64, 64], format="r32uint", usage="COPY_SRC")
+    texture2 = device.create_texture(size=[64, 64], format="r32uint", usage="COPY_DST")
+    command_encoder = device.create_command_encoder()
+    command_encoder.copy_texture_to_texture(
+        {"texture": texture1, "mip_level": 0, "origin": (0, 0, 0)},
+        {"texture": texture2, "mip_level": 0, "origin": (0, 0, 0)},
+        (64, 64),
+    )
+    del texture1
+    del texture2
+    device.queue.submit([command_encoder.finish()])
+
+
+if __name__ == "__main__":
+    run_tests(globals())

--- a/tests_mem/test_object_retention.py
+++ b/tests_mem/test_object_retention.py
@@ -11,6 +11,12 @@ from wgpu.backends.wgpu_native.extras import (
     end_pipeline_statistics_query,
 )
 
+#
+# wgpu is generally good at keeping alive those objects that it needs to complete a
+# GPU operation.  This file has tests that agressively deletes objects (so that their
+# release method will be called) even though the GPU has pending operations on them.
+# We confirm that the operations complete successfully.
+
 SHADER_SOURCE = """
     @group(0) @binding(0) var<uniform> offset: vec2f;
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -676,6 +676,12 @@ class GPUObjectBase:
         """A human-readable name identifying the GPU object."""
         return self._label
 
+    def __str__(self):
+        if self._label:
+            return f'<{self.__class__.__name__} "{self._label}">'
+        else:
+            return f"<{self.__class__.__name__} id(self)>"
+
     def _release(self):
         """Subclasses can implement this to clean up."""
         pass
@@ -1639,9 +1645,7 @@ class GPUBindGroupLayout(GPUObjectBase):
     Create a bind group layout using `GPUDevice.create_bind_group_layout()`.
     """
 
-    def __init__(self, label, internal, device, bindings):
-        super().__init__(label, internal, device)
-        self._bindings = tuple(bindings)
+    pass
 
 
 class GPUBindGroup(GPUObjectBase):
@@ -1653,9 +1657,7 @@ class GPUBindGroup(GPUObjectBase):
     Create a bind group using `GPUDevice.create_bind_group()`.
     """
 
-    def __init__(self, label, internal, device, bindings):
-        super().__init__(label, internal, device)
-        self._bindings = bindings
+    pass
 
 
 class GPUPipelineLayout(GPUObjectBase):
@@ -1664,9 +1666,7 @@ class GPUPipelineLayout(GPUObjectBase):
     Create a pipeline layout using `GPUDevice.create_pipeline_layout()`.
     """
 
-    def __init__(self, label, internal, device, layouts):
-        super().__init__(label, internal, device)
-        self._layouts = tuple(layouts)  # GPUBindGroupLayout objects
+    pass
 
 
 class GPUShaderModule(GPUObjectBase):
@@ -1693,9 +1693,6 @@ class GPUShaderModule(GPUObjectBase):
 
 class GPUPipelineBase:
     """A mixin class for render and compute pipelines."""
-
-    def __init__(self, label, internal, device):
-        super().__init__(label, internal, device)
 
     # IDL: [NewObject] GPUBindGroupLayout getBindGroupLayout(unsigned long index);
     def get_bind_group_layout(self, index: int):

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -680,7 +680,7 @@ class GPUObjectBase:
         if self._label:
             return f'<{self.__class__.__name__} "{self._label}">'
         else:
-            return f"<{self.__class__.__name__} id(self)>"
+            return f"<{self.__class__.__name__} {id(self)}>"
 
     def _release(self):
         """Subclasses can implement this to clean up."""

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1338,7 +1338,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
 
         # H: WGPUBindGroupLayout f(WGPUDevice device, WGPUBindGroupLayoutDescriptor const * descriptor)
         id = libf.wgpuDeviceCreateBindGroupLayout(self._internal, struct)
-        return GPUBindGroupLayout(label, id, self, entries)
+        return GPUBindGroupLayout(label, id, self)
 
     def create_bind_group(
         self,
@@ -1408,7 +1408,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
 
         # H: WGPUBindGroup f(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor)
         id = libf.wgpuDeviceCreateBindGroup(self._internal, struct)
-        return GPUBindGroup(label, id, self, entries)
+        return GPUBindGroup(label, id, self)
 
     def create_pipeline_layout(
         self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
@@ -1459,7 +1459,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
 
         # H: WGPUPipelineLayout f(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor)
         id = libf.wgpuDeviceCreatePipelineLayout(self._internal, struct)
-        return GPUPipelineLayout(label, id, self, bind_group_layouts)
+        return GPUPipelineLayout(label, id, self)
 
     def create_shader_module(
         self,
@@ -1956,7 +1956,9 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         render_bundle_encoder_id = libf.wgpuDeviceCreateRenderBundleEncoder(
             self._internal, render_bundle_encoder_descriptor
         )
-        return GPURenderBundleEncoder(label, render_bundle_encoder_id, self)
+        result = GPURenderBundleEncoder(label, render_bundle_encoder_id, self)
+        result._objects_to_keep_alive = set()
+        return result
 
     def create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
         return self._create_query_set(label, type, count, None)
@@ -2398,26 +2400,27 @@ class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
 
 class GPUPipelineBase(classes.GPUPipelineBase):
     def get_bind_group_layout(self, index: int):
-        """Get the bind group layout at the given index."""
-        if isinstance(self, GPUComputePipeline):
-            # H: WGPUBindGroupLayout f(WGPUComputePipeline computePipeline, uint32_t groupIndex)
-            layout_id = libf.wgpuComputePipelineGetBindGroupLayout(
-                self._internal, index
-            )
-        else:
-            # H: WGPUBindGroupLayout f(WGPURenderPipeline renderPipeline, uint32_t groupIndex)
-            layout_id = libf.wgpuRenderPipelineGetBindGroupLayout(self._internal, index)
-        return GPUBindGroupLayout("", layout_id, self._device, [])
+        # H: WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex)
+        # H: WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex)
+        function = type(self)._get_bind_group_layout_function
+        layout_id = function(self._internal, index)
+        return GPUBindGroupLayout("", layout_id, self._device)
 
 
 class GPUComputePipeline(classes.GPUComputePipeline, GPUPipelineBase, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuComputePipelineRelease
 
+    # GPUPipelineBase
+    _get_bind_group_layout_function = libf.wgpuComputePipelineGetBindGroupLayout
+
 
 class GPURenderPipeline(classes.GPURenderPipeline, GPUPipelineBase, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuRenderPipelineRelease
+
+    # GPUPipelineBase
+    _get_bind_group_layout_function = libf.wgpuRenderPipelineGetBindGroupLayout
 
 
 class GPUCommandBuffer(classes.GPUCommandBuffer, GPUObjectBase):
@@ -2461,13 +2464,12 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
 
         offsets = list(dynamic_offsets_data)
         c_offsets = ffi.new("uint32_t []", offsets)
-        bind_group_id = bind_group._internal
-
+        self._maybe_keep_alive(bind_group)
         # H: void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets)
         # H: void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets)
         # H: void wgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets)
         function = type(self)._set_bind_group_function
-        function(self._internal, index, bind_group_id, len(offsets), c_offsets)
+        function(self._internal, index, bind_group._internal, len(offsets), c_offsets)
 
 
 class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
@@ -2501,6 +2503,7 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
 
 class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
     def set_pipeline(self, pipeline: GPURenderPipeline):
+        self._maybe_keep_alive(pipeline)
         pipeline_id = pipeline._internal
         # H: void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline)
         # H: void wgpuRenderBundleEncoderSetPipeline(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderPipeline pipeline)
@@ -2514,6 +2517,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         offset: int = 0,
         size: Optional[int] = None,
     ):
+        self._maybe_keep_alive(buffer)
         if not size:
             size = lib.WGPU_WHOLE_SIZE
         c_index_format = enummap[f"IndexFormat.{index_format}"]
@@ -2527,6 +2531,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
     def set_vertex_buffer(
         self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
     ):
+        self._maybe_keep_alive(buffer)
         if not size:
             size = lib.WGPU_WHOLE_SIZE
         # H: void wgpuRenderPassEncoderSetVertexBuffer(WGPURenderPassEncoder renderPassEncoder, uint32_t slot, WGPUBuffer buffer, uint64_t offset, uint64_t size)
@@ -2549,6 +2554,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         )
 
     def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+        self._maybe_keep_alive(indirect_buffer)
         buffer_id = indirect_buffer._internal
         # H: void wgpuRenderPassEncoderDrawIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
         # H: void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
@@ -2576,6 +2582,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         )
 
     def draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+        self._maybe_keep_alive(indirect_buffer)
         buffer_id = indirect_buffer._internal
         # H: void wgpuRenderPassEncoderDrawIndexedIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
         # H: void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
@@ -2651,12 +2658,8 @@ class GPUCommandEncoder(
                 ),
             )
 
-        objects_to_keep_alive = {}
-
         c_color_attachments_list = [
-            self._create_render_pass_color_attachment(
-                color_attachment, objects_to_keep_alive
-            )
+            self._create_render_pass_color_attachment(color_attachment)
             for color_attachment in color_attachments
         ]
         c_color_attachments_array = ffi.new(
@@ -2673,7 +2676,6 @@ class GPUCommandEncoder(
         c_occlusion_query_set = ffi.NULL
         if occlusion_query_set is not None:
             c_occlusion_query_set = occlusion_query_set._internal
-            objects_to_keep_alive[c_occlusion_query_set] = occlusion_query_set
 
         # H: nextInChain: WGPUChainedStruct *, label: char *, colorAttachmentCount: int, colorAttachments: WGPURenderPassColorAttachment *, depthStencilAttachment: WGPURenderPassDepthStencilAttachment *, occlusionQuerySet: WGPUQuerySet, timestampWrites: WGPURenderPassTimestampWrites *
         struct = new_struct_p(
@@ -2690,18 +2692,14 @@ class GPUCommandEncoder(
         # H: WGPURenderPassEncoder f(WGPUCommandEncoder commandEncoder, WGPURenderPassDescriptor const * descriptor)
         raw_encoder = libf.wgpuCommandEncoderBeginRenderPass(self._internal, struct)
         encoder = GPURenderPassEncoder(label, raw_encoder, self._device)
-        encoder._objects_to_keep_alive = objects_to_keep_alive
         return encoder
 
-    def _create_render_pass_color_attachment(
-        self, color_attachment, objects_to_keep_alive
-    ):
+    def _create_render_pass_color_attachment(self, color_attachment):
         check_struct("RenderPassColorAttachment", color_attachment)
         texture_view = color_attachment["view"]
         if not isinstance(texture_view, GPUTextureView):
             raise TypeError("Color attachment view must be a GPUTextureView.")
         texture_view_id = texture_view._internal
-        objects_to_keep_alive[texture_view_id] = texture_view
         c_resolve_target = (
             ffi.NULL
             if color_attachment.get("resolve_target", None) is None
@@ -3095,8 +3093,6 @@ class GPUComputePassEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuComputePassEncoderRelease
 
-    _ended = False
-
     def set_pipeline(self, pipeline: GPUComputePipeline):
         pipeline_id = pipeline._internal
         # H: void f(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline)
@@ -3135,10 +3131,12 @@ class GPUComputePassEncoder(
     def end(self):
         # H: void f(WGPUComputePassEncoder computePassEncoder)
         libf.wgpuComputePassEncoderEnd(self._internal)
-        self._ended = True
         # Need to release, see https://github.com/gfx-rs/wgpu-native/issues/412
         # As of wgpu-native v22.1.0.5, this bug is still present.
         self._release()
+
+    def _maybe_keep_alive(self, object):
+        pass
 
 
 class GPURenderPassEncoder(
@@ -3168,8 +3166,6 @@ class GPURenderPassEncoder(
 
     # GPUObjectBaseMixin
     _release_function = libf.wgpuRenderPassEncoderRelease
-
-    _ended = False
 
     def set_viewport(
         self,
@@ -3219,7 +3215,6 @@ class GPURenderPassEncoder(
     def end(self):
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEnd(self._internal)
-        self._ended = True
         # Need to release, see https://github.com/gfx-rs/wgpu-native/issues/412
         # As of wgpu-native v22.1.0.5, this bug is still present.
         self._release()
@@ -3291,6 +3286,9 @@ class GPURenderPassEncoder(
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEndPipelineStatisticsQuery(self._internal)
 
+    def _maybe_keep_alive(self, object):
+        pass
+
 
 class GPURenderBundleEncoder(
     classes.GPURenderBundleEncoder,
@@ -3331,7 +3329,13 @@ class GPURenderBundleEncoder(
         id = libf.wgpuRenderBundleEncoderFinish(self._internal, struct)
         # The other encoders require that we call self._release() when
         # we're done with it.  But that doesn't seem to be an issue here.
+        # There doesn't seem to be an issue with needing to keep the objects alive after
+        # the call to finish().
+        self._objects_to_keep_alive.clear()
         return GPURenderBundle(label, id, self._device)
+
+    def _maybe_keep_alive(self, object):
+        self._objects_to_keep_alive.add(object)
 
 
 class GPUQueue(classes.GPUQueue, GPUObjectBase):

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -3329,8 +3329,7 @@ class GPURenderBundleEncoder(
         id = libf.wgpuRenderBundleEncoderFinish(self._internal, struct)
         # The other encoders require that we call self._release() when
         # we're done with it.  But that doesn't seem to be an issue here.
-        # There doesn't seem to be an issue with needing to keep the objects alive after
-        # the call to finish().
+        # We no longer need to keep these objects alive after the call to finish().
         self._objects_to_keep_alive.clear()
         return GPURenderBundle(label, id, self._device)
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -18,7 +18,7 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 120 methods, 46 properties
+* Validated 37 classes, 121 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
 * Validated 37 classes, 120 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -18,9 +18,9 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 124 methods, 46 properties
+* Validated 37 classes, 120 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 117 methods, 0 properties
+* Validated 37 classes, 120 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.texture-compression-bc-sliced-3d missing in wgpu.h
 * Enum field FeatureName.clip-distances missing in wgpu.h


### PR DESCRIPTION
As of wgpu 1.25, we no longer need to keep alive as many objects internally as we used to.  I have deleted several pieces of code that kept a copy of its arguments to that they wouldn't be released.  

The only exception is RenderBundleEncoder.  I have filed a [bug](https://github.com/gfx-rs/wgpu/issues/6433) about it.  

Added a test that agressively deletes objects even though they are needed by the GPU, just to make sure that things work correctly.