### PR TITLE
Add pre-commit hooks for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.7.0
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ This code is distributed under the 2-clause BSD license.
   binaries.
   * You can use `python tools/download_wgpu_native.py` when needed.
   * Or point the `WGPU_LIB_PATH` environment variable to a custom build of `wgpu-native`.
-* Install the `pre-commit` hooks with `pre-commit install`.
-* Linting and formatting will be automatically applied on `git commit` but you can manually verify compliance with `pre-commit run --all-files`.
+* Use `ruff format` to apply autoformatting.
+* Use `ruff check` to check for linting errors.
+* Optionally, if you install `pre-commit` hooks with `pre-commit install`, lint fixes and formatting will be automatically applied on `git commit`.
 
 
 ### Updating to a later version of WebGPU or wgpu-native

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ This code is distributed under the 2-clause BSD license.
   binaries.
   * You can use `python tools/download_wgpu_native.py` when needed.
   * Or point the `WGPU_LIB_PATH` environment variable to a custom build of `wgpu-native`.
-* Use `ruff format` to apply autoformatting.
-* Use `ruff check` to check for linting errors.
+* Install the `pre-commit` hooks with `pre-commit install`.
+* Linting and formatting will be automatically applied on `git commit` but you can manually verify compliance with `pre-commit run --all-files`.
 
 
 ### Updating to a later version of WebGPU or wgpu-native


### PR DESCRIPTION
I did this with their recommended setup where you specify a revision. 

You can alternatively set it up to use the users `ruff` binary with something like:

```
repos:
  - repo: local
    hooks:
      - id: ruff
        name: ruff
        entry: ruff check .
        language: system
```


This is opt-in and requires running `pre-commit install`. Otherwise the current manual workflow still applies. 