### PR TITLE
Include pre-commit in optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This code is distributed under the 2-clause BSD license.
   * Or point the `WGPU_LIB_PATH` environment variable to a custom build of `wgpu-native`.
 * Use `ruff format` to apply autoformatting.
 * Use `ruff check` to check for linting errors.
-* Optionally, if you install `pre-commit` hooks with `pre-commit install`, lint fixes and formatting will be automatically applied on `git commit`.
+* Optionally, if you install [pre-commit](https://github.com/pre-commit/pre-commit/) hooks with `pre-commit install`, lint fixes and formatting will be automatically applied on `git commit`.
 
 
 ### Updating to a later version of WebGPU or wgpu-native

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ imgui = ["imgui-bundle>=1.2.1"]
 # For devs / ci
 build = ["build", "hatchling", "requests", "twine"]
 codegen = ["pytest", "numpy", "ruff"]
-lint = ["ruff"]
+lint = ["ruff", "pre-commit"]
 tests = ["numpy", "pytest", "psutil", "imageio"]
 examples = []
 docs = ["sphinx>7.2", "sphinx_rtd_theme"]


### PR DESCRIPTION
@fyellin [pointed out](https://github.com/pygfx/wgpu-py/pull/629#issuecomment-2433139825) that the current instructions in the README are not clear as to how a contributor may leverage `pre-commit` as a tool. 

I have included it in the `pip -e .[dev].` install as suggested and updated the reference in the README to point to the projects github landing page. 