### PR TITLE
Merge enumerate_adapters_async and _sync into just enumerate_adapters.

### DIFF
--- a/docs/start.rst
+++ b/docs/start.rst
@@ -99,7 +99,7 @@ You can verify whether the `"DiscreteGPU"` adapters are found:
     import wgpu
     import pprint
 
-    for a in wgpu.gpu.enumerate_adapters_sync():
+    for a in wgpu.gpu.enumerate_adapters():
         pprint.pprint(a.info)
 
 If you are using a remote frame buffer via `jupyter-rfb <https://github.com/vispy/jupyter_rfb>`_ we also recommend installing the following for optimal performance:

--- a/examples/compute_noop.py
+++ b/examples/compute_noop.py
@@ -62,7 +62,7 @@ assert result == list(range(20))
 device = wgpu.utils.get_default_device()
 
 # Show all available adapters
-adapters = wgpu.gpu.enumerate_adapters_sync()
+adapters = wgpu.gpu.enumerate_adapters()
 for a in adapters:
     print(a.summary)
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -455,7 +455,7 @@ if __name__ == "__main__":
     from wgpu.gui.auto import WgpuCanvas, run
 
     print("Available adapters on this system:")
-    for a in wgpu.gpu.enumerate_adapters_sync():
+    for a in wgpu.gpu.enumerate_adapters():
         print(a.summary)
 
     canvas = WgpuCanvas(size=(640, 480), title="wgpu cube example")

--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -342,7 +342,7 @@ def test_wgpu_native_tracer():
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_enumerate_adapters():
     # Get all available adapters
-    adapters = wgpu.gpu.enumerate_adapters_sync()
+    adapters = wgpu.gpu.enumerate_adapters()
     assert len(adapters) > 0
 
     # Check adapter summaries

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -138,19 +138,7 @@ class GPU:
         )
 
     @apidiff.add("Method useful for multi-gpu environments")
-    def enumerate_adapters_sync(self):
-        """Sync version of `enumerate_adapters_async()`.
-
-        Provided by wgpu-py, but not compatible with WebGPU.
-        """
-
-        # If this method gets called, no backend has been loaded yet, let's do that now!
-        from .backends.auto import gpu
-
-        return gpu.enumerate_adapters_sync()
-
-    @apidiff.add("Method useful for multi-gpu environments")
-    async def enumerate_adapters_async(self):
+    def enumerate_adapters(self):
         """Get a list of adapter objects available on the current system.
 
         An adapter can then be selected (e.g. using it's summary), and a device
@@ -177,7 +165,7 @@ class GPU:
         # If this method gets called, no backend has been loaded yet, let's do that now!
         from .backends.auto import gpu
 
-        return await gpu.enumerate_adapters_async()
+        return gpu.enumerate_adapters()
 
     # IDL: GPUTextureFormat getPreferredCanvasFormat();
     @apidiff.change("Disabled because we put it on the canvas context")

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -424,20 +424,7 @@ class GPU(classes.GPU):
             "request_adapter", awaitable_result, callback, poll_func, finalizer
         )
 
-    def enumerate_adapters_sync(self):
-        """Sync version of ``enumerate_adapters_async()``.
-        This is the implementation based on wgpu-native.
-        """
-        check_can_use_sync_variants()
-        return self._enumerate_adapters()
-
-    async def enumerate_adapters_async(self):
-        """Get a list of adapter objects available on the current system.
-        This is the implementation based on wgpu-native.
-        """
-        return self._enumerate_adapters()
-
-    def _enumerate_adapters(self):
+    def enumerate_adapters(self):
         # The first call is to get the number of adapters, and the second call
         # is to get the actual adapters. Note that the second arg (now NULL) can
         # be a `WGPUInstanceEnumerateAdapterOptions` to filter by backend.

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -9,7 +9,7 @@
 * Wrote 34 enums to enums.py
 * Wrote 60 structs to structs.py
 ### Patching API for _classes.py
-* Diffs for GPU: add enumerate_adapters_async, add enumerate_adapters_sync, change get_preferred_canvas_format, change request_adapter_async, change request_adapter_sync
+* Diffs for GPU: add enumerate_adapters, change get_preferred_canvas_format, change request_adapter_async, change request_adapter_sync
 * Diffs for GPUCanvasContext: add get_preferred_format, add present
 * Diffs for GPUAdapter: add summary
 * Diffs for GPUDevice: add adapter, add create_buffer_with_data, hide import_external_texture, hide lost_async, hide lost_sync, hide onuncapturederror, hide pop_error_scope_async, hide pop_error_scope_sync, hide push_error_scope
@@ -18,9 +18,9 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 121 methods, 46 properties
+* Validated 37 classes, 120 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 120 methods, 0 properties
+* Validated 37 classes, 118 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.texture-compression-bc-sliced-3d missing in wgpu.h
 * Enum field FeatureName.clip-distances missing in wgpu.h


### PR DESCRIPTION
Speculative PR.  Feel free to not approve if you think this is a bad idea.

There is no reason for enumerate_adapters_async.  In Rust, there is only a single function that returns Vec<Adapter>, and it is not asynchronous in any way.