### PR TITLE
Fix codegen single-line logic for return types

### DIFF
--- a/codegen/tests/test_codegen_utils.py
+++ b/codegen/tests/test_codegen_utils.py
@@ -144,6 +144,34 @@ def test_format_code_comments():
     assert code3 == code2
 
 
+def test_format_code_return_type():
+    code1 = """
+    def foo() -> None:
+        pass
+    def foo(
+        a1,
+        a2,
+        a3,
+    ) -> None:
+        pass
+    """
+
+    code2 = """
+    def foo() -> None:
+        pass
+    def foo(a1, a2, a3) -> None:
+        pass
+    """
+
+    code1 = dedent(code1).strip()
+    code2 = dedent(code2).strip()
+
+    code3 = format_code(code1, True)
+    code3 = code3.replace("\n\n", "\n").replace("\n\n", "\n").strip()
+
+    assert code3 == code2
+
+
 def test_patcher():
     code = """
     class Foo1:


### PR DESCRIPTION
Closes #632

The logic to unfold signatures onto a single line was a bit crude and broke down when return type annotations are used. Basically, the end of the signature was detected by `line.endswith("):"):`. This fixes that by implementing the logic in a better way, following braces until the last one, and then searching from the final colon.