### PR TITLE
Prevent extra errors when canvascontext creation fails

### DIFF
--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -519,6 +519,8 @@ class GPUCanvasContext(classes.GPUCanvasContext):
     # we can give meaningful errors/warnings on invalid use, rather than
     # the more cryptic Rust panics.
 
+    _surface_id = ffi.NULL
+
     def __init__(self, canvas):
         super().__init__(canvas)
 


### PR DESCRIPTION
When the creation of the canvas context fails, this results in extra errors, because the context does not have the `_surface_id` attribute. This fixes that.