### PR TITLE
Combining more code

### DIFF
--- a/tests/test_wgpu_native_basics.py
+++ b/tests/test_wgpu_native_basics.py
@@ -342,7 +342,7 @@ def test_wgpu_native_tracer():
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_enumerate_adapters():
     # Get all available adapters
-    adapters = wgpu.gpu.enumerate_adapters_sync()
+    adapters = list(wgpu.gpu.enumerate_adapters_sync())
     assert len(adapters) > 0
 
     # Check adapter summaries
@@ -350,6 +350,25 @@ def test_enumerate_adapters():
         assert isinstance(adapter.summary, str)
         assert "\n" not in adapter.summary
         assert len(adapter.summary.strip()) > 10
+
+    # Check that we can get a device from each adapter
+    for adapter in adapters:
+        d = adapter.request_device_sync()
+        assert isinstance(d, wgpu.backends.wgpu_native.GPUDevice)
+
+
+@mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+@mark.asyncio
+async def test_enumerate_adapters_async():
+    # Get all available adapters
+    adapters = []
+    async for adapter in wgpu.gpu.enumerate_adapters_async():
+        assert isinstance(adapter.summary, str)
+        assert "\n" not in adapter.summary
+        assert len(adapter.summary.strip()) > 10
+        adapters.append(adapter)
+
+    assert len(adapters) > 0
 
     # Check that we can get a device from each adapter
     for adapter in adapters:

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -3247,6 +3247,7 @@ class GPURenderPassEncoder(
             check_struct("Color", color)
             color = _tuple_from_color(color)
         red, green, blue, alpha = color
+        # H: r: float, g: float, b: float, a: float
         c_color = new_struct_p(
             "WGPUColor *",
             r=red,

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -37,5 +37,4 @@
 * Wrote 236 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
 * Validated 140 C function calls
 * Not using 65 C functions
-* Notice: made a struct multiline. Rerun codegen to validate the struct.
 * Validated 82 C structs

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 121 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 120 methods, 0 properties
+* Validated 37 classes, 118 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.texture-compression-bc-sliced-3d missing in wgpu.h
 * Enum field FeatureName.clip-distances missing in wgpu.h

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -20,7 +20,7 @@
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
 * Validated 37 classes, 121 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
-* Validated 37 classes, 118 methods, 0 properties
+* Validated 37 classes, 119 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.texture-compression-bc-sliced-3d missing in wgpu.h
 * Enum field FeatureName.clip-distances missing in wgpu.h
@@ -37,4 +37,5 @@
 * Wrote 236 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
 * Validated 140 C function calls
 * Not using 65 C functions
+* Notice: made a struct multiline. Rerun codegen to validate the struct.
 * Validated 82 C structs


### PR DESCRIPTION
Several native-wgpu extensions apply to RenderPassEncoder and ComputePassEncoder, but not to RenderBundleEncoder.   Push Constants will soon join this group.  

Even though there is no Class that is the ancestor of just these two, we put the code into GPUBindingCommandsMixin.