### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,19 @@ Possible sections in each release:
 * Security: in case of vulnerabilities.
 
 
-### [v0.19.0] - 04-10-2024
+### [v0.19.1] - 19-11-2024
+
+Some internal refactoring, fix the doc theme, and compatibility with rendercanvas.
+
+Changed:
+
+* Do not confound STDERR and STDOUT by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/638
+* More consolidation by @fyellin in https://github.com/pygfx/wgpu-py/pull/641
+* Use rtd theme for docs by @almarklein in https://github.com/pygfx/wgpu-py/pull/639
+* Refactor present-method mechanic by @almarklein in https://github.com/pygfx/wgpu-py/pull/642
+
+
+### [v0.19.0] - 04-11-2024
 
 Added:
 

--- a/wgpu/_version.py
+++ b/wgpu/_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 # This is the reference version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 
 # Allow using nearly the same code in different projects
 project_name = "wgpu"


### PR DESCRIPTION
Motivation for doing a release now is because one of the changes implements compatibility with the new rendercanvas. But also because the doc theme is fixed.