### PR TITLE
Update Imgui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["cffi>=1.15.0", "rubicon-objc>=0.4.1; sys_platform == 'darwin'"]
 # For users
 jupyter = ["jupyter_rfb>=0.4.2"]
 glfw = ["glfw>=1.9"]
-imgui = ["imgui-bundle>=1.2.1"]
+imgui = ["imgui-bundle>=1.6.0"]
 # For devs / ci
 build = ["build", "hatchling", "requests", "twine"]
 codegen = ["pytest", "numpy", "ruff"]

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -44,10 +44,10 @@ class ImguiRenderer:
     }
 
     KEY_MAP_MOD = {
-        "Shift": imgui.Key.im_gui_mod_shift,
-        "Control": imgui.Key.im_gui_mod_ctrl,
-        "Alt": imgui.Key.im_gui_mod_alt,
-        "Meta": imgui.Key.im_gui_mod_super,
+        "Shift": imgui.Key.mod_shift,
+        "Control": imgui.Key.mod_ctrl,
+        "Alt": imgui.Key.mod_alt,
+        "Meta": imgui.Key.mod_super,
     }
 
     def __init__(


### PR DESCRIPTION
The imgui_bundle has just released version [1.6.0](https://github.com/pthom/imgui_bundle/releases) (corresponding to Dear ImGui [v1.91.5](https://github.com/ocornut/imgui/releases/tag/v1.91.5)). 
Some API changes have been introduced, requiring updates to accommodate them.