### PR TITLE
Add rendercanvas version to diagnostics

### DIFF
--- a/wgpu/_diagnostics.py
+++ b/wgpu/_diagnostics.py
@@ -473,7 +473,7 @@ class VersionDiagnostics(DiagnosticsBase):
     def get_dict(self):
         core_libs = ["wgpu", "cffi"]
         qt_libs = ["PySide6", "PyQt6", "PySide2", "PyQt5"]
-        gui_libs = [*qt_libs, "glfw", "jupyter_rfb", "wx"]
+        gui_libs = ["rendercanvas", *qt_libs, "glfw", "jupyter_rfb", "wx"]
         extra_libs = ["numpy", "pygfx", "pylinalg", "fastplotlib"]
 
         info = {}


### PR DESCRIPTION
Also nice to see the detailed versioning appear here.
```
██ versions:

        wgpu:  0.19.2.post3+gd101e33.dirty
rendercanvas:  1.0.0.post8+ge9ba8f8
```