### PR TITLE
remove unneeded pytest-anyio package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ lint = ["ruff", "pre-commit"]
 tests = [
     "numpy",
     "pytest",
-    "pytest-anyio",
     "psutil",
     "imageio",
     "anyio",


### PR DESCRIPTION
> The pytest anyio plugin is built into anyio. You don't need this package.

https://github.com/graingert/pytest-anyio/blob/default/pytest_anyio.py