### PR TITLE
wx: delegate event handling to subwidget

### DIFF
--- a/wgpu/gui/wx.py
+++ b/wgpu/gui/wx.py
@@ -452,6 +452,16 @@ class WxWgpuCanvas(WgpuAutoGui, WgpuCanvasBase, wx.Frame):
         super().Refresh()
         self._subwidget.Refresh()
 
+    def Bind(self, event, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):  # noqa: N802
+        self._subwidget.Bind(
+            event=event, handler=handler, source=source, id=id, id2=id2
+        )
+
+    def Unbind(self, event, source=None, id=wx.ID_ANY, id2=wx.ID_ANY, handler=None):  # noqa: N802
+        self._subwidget.Unbind(
+            event=event, source=source, id=id, id2=id2, handler=handler
+        )
+
     # Methods that we add from wgpu
 
     def get_present_methods(self):


### PR DESCRIPTION
Found while working on pyapp-kit/ndv#114 that `WxWgpuCanvas` wasn't responding to events the way that I expected. With this change, we can react to events. 

I didn't see any location within the tests folder that looked like a good location for automated testing code, but I manually tested this change using a modification of [gui_wx.py](https://github.com/pygfx/wgpu-py/blob/main/examples/gui_wx.py), which prints many lines with the change and does not without the change. Tested on Windows 11, Python 3.11 and latest `main`:
```python
"""
Run the triangle/cube example in the wx GUI backend.
"""

# run_example = false

import wx
from wgpu.gui.wx import WgpuCanvas

from triangle import setup_drawing_sync
# from cube import setup_drawing_sync


app = wx.App()
canvas = WgpuCanvas(title=f"Triangle example on {WgpuCanvas.__name__}")

draw_func = setup_drawing_sync(canvas)
canvas.request_draw(draw_func)

def on_mouse_move(event: wx.MouseEvent):
    print("Captured mouse event!")

canvas.Bind(wx.EVT_MOTION, on_mouse_move)

app.MainLoop()
```

Happy to add an automated test if there's somewhere that makes sense. Also, I'm also pretty naive about wx, so unsure about the correctness of the behavior (e.g. should calls to `super().Bind()`/`super().Unbind()` occur before calling them on the subwidget? 