### PR TITLE
Allow disabling downloading lib when creating wheel

### DIFF
--- a/tools/download_wgpu_native.py
+++ b/tools/download_wgpu_native.py
@@ -6,8 +6,6 @@ import tempfile
 import platform
 from zipfile import ZipFile
 
-import requests
-
 
 DEFAULT_UPSTREAM = "gfx-rs/wgpu-native"
 
@@ -49,6 +47,8 @@ def write_current_version(version, commit_sha):
 
 
 def download_file(url, filename):
+    import requests  # lazy-load so build systems (like Conda) don't necessarily need it
+
     resp = requests.get(url, stream=True)
     with open(filename, mode="wb") as fh:
         for chunk in resp.iter_content(chunk_size=1024 * 128):

--- a/tools/download_wgpu_native.py
+++ b/tools/download_wgpu_native.py
@@ -6,6 +6,10 @@ import tempfile
 import platform
 from zipfile import ZipFile
 
+# Import requests unless doing a noarch build
+if os.getenv("WGPU_PY_BUILD_NOARCH", "").lower() not in ("1", "true"):
+    import requests
+
 
 DEFAULT_UPSTREAM = "gfx-rs/wgpu-native"
 
@@ -47,8 +51,6 @@ def write_current_version(version, commit_sha):
 
 
 def download_file(url, filename):
-    import requests  # lazy-load so build systems (like Conda) don't necessarily need it
-
     resp = requests.get(url, stream=True)
     with open(filename, mode="wb") as fh:
         for chunk in resp.iter_content(chunk_size=1024 * 128):

--- a/tools/hatch_build.py
+++ b/tools/hatch_build.py
@@ -42,8 +42,11 @@ class CustomBuildHook(BuildHookInterface):
         # We only do our thing when this is a wheel build from the repo.
         # If this is an sdist build, or a wheel build from an sdist,
         # we go pure-Python mode, and expect the user to set WGPU_LIB_PATH.
+        # We also allow building an arch-agnostic wheel explicitly, using an env var.
 
-        if self.target_name == "wheel" and is_git_repo():
+        if os.getenv("WGPU_PY_BUILD_NOARCH") in ("1", "true"):
+            pass  # Explicitly disable including the lib
+        elif self.target_name == "wheel" and is_git_repo():
             # Prepare
             check_git_status()
             remove_all_libs()


### PR DESCRIPTION
Ref #666

@hmaarrfk Would this simple tweak allow the feedstock to drop another patch?

Not sure if there's an env var that we can check that a conda build is in progress. But in any case I imagine you can set an env var in the recipe.