### PR TITLE
Add Imgui based Stats component

### DIFF
--- a/examples/imgui_renderer_sea.py
+++ b/examples/imgui_renderer_sea.py
@@ -9,10 +9,10 @@ import wgpu
 import time
 import numpy as np
 from imgui_bundle import imgui
-from wgpu.utils.imgui import ImguiRenderer
+from wgpu.utils.imgui import ImguiRenderer, Stats
 
 # Create a canvas to render to
-canvas = WgpuCanvas(title="imgui_sea", size=(800, 450), max_fps=60)
+canvas = WgpuCanvas(title="imgui_sea", size=(800, 450), max_fps=-1, vsync=False)
 
 # Create a wgpu device
 adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
@@ -377,10 +377,14 @@ def render():
 # set the GUI update function that gets called to return the draw data
 imgui_renderer.set_gui(lambda: gui(app_state))
 
+stats = Stats(device, canvas, align="right")
+
 
 def loop():
-    render()
+    with stats:
+        render()
     imgui_renderer.render()
+    stats.render()
     canvas.request_draw()
 
 

--- a/wgpu/utils/imgui/__init__.py
+++ b/wgpu/utils/imgui/__init__.py
@@ -1,2 +1,3 @@
 from .imgui_backend import ImguiWgpuBackend  # noqa: F401
 from .imgui_renderer import ImguiRenderer  # noqa: F401
+from .stats import Stats  # noqa: F401

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -86,7 +86,7 @@ class ImguiRenderer:
                 raise ValueError(
                     "The canvas is already configured with a different format."
                 )
-            render_target_format = self._canvas_context._config["format"]
+            render_target_format = config_format
 
         self._imgui_context = imgui.create_context()
         imgui.set_current_context(self._imgui_context)

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -70,16 +70,23 @@ class ImguiRenderer:
         # Prepare present context
         self._canvas_context = canvas.get_context("wgpu")
 
-        if render_target_format is None:
-            # todo: not sure if this is the correct format, maybe we should expose it in the public API
-            render_target_format = self._canvas_context.get_preferred_format(
-                device.adapter
-            )
-
         # if the canvas is not configured, we configure it self.
-        # todo: maybe we should just raise an error if the canvas is not configured?
         if self._canvas_context._config is None:
+            if render_target_format is None:
+                render_target_format = self._canvas_context.get_preferred_format(
+                    device.adapter
+                )
             self._canvas_context.configure(device=device, format=render_target_format)
+        else:
+            config_format = self._canvas_context._config.get("format")
+            if (
+                render_target_format is not None
+                and config_format != render_target_format
+            ):
+                raise ValueError(
+                    "The canvas is already configured with a different format."
+                )
+            render_target_format = self._canvas_context._config["format"]
 
         self._imgui_context = imgui.create_context()
         imgui.set_current_context(self._imgui_context)

--- a/wgpu/utils/imgui/stats.py
+++ b/wgpu/utils/imgui/stats.py
@@ -1,0 +1,139 @@
+import time
+
+from wgpu.utils.imgui import ImguiRenderer
+from imgui_bundle import imgui
+import numpy as np
+
+
+class Stats:
+    """A Stats helper which displays performance statistics such
+    as FPS and draw time on the screen.
+
+    """
+
+    def __init__(
+        self,
+        device,
+        canvas,
+    ):
+        self._foreground = imgui.ImVec4(0, 1, 0, 1)
+        self._background = imgui.ImVec4(0, 0.2, 0, 0.5)
+
+        self._renderer = ImguiRenderer(device, canvas)
+
+        self._renderer.set_gui(self._draw_imgui)
+
+        canvas.add_event_handler(self._on_mouse, "pointer_down", order=-100)
+
+        # flag used to skip the first frame
+        # which typically has all the CPU->GPU transfer and
+        # shader compilation overhead
+        self._init = False
+
+        # performance trackers
+        self._tmin = 1e10
+        self._tmax = 0
+        self._tbegin = None
+        self._tprev = self._tbegin
+        self._frames = 0
+        self._fmin = 1e10
+        self._fmax = 0
+        # Sentinel value of None indicates that the fps has never been computed
+        self._fps = None
+
+        self._fps_samples = np.zeros(100, dtype=np.float32)
+        self._ms_samples = np.zeros(100, dtype=np.float32)
+
+        self._mode = 0
+
+    def _draw_imgui(self):
+        imgui.new_frame()
+
+        imgui.set_next_window_size((150, 0), imgui.Cond_.always)
+        imgui.set_next_window_pos((0, 0), imgui.Cond_.always)
+
+        imgui.push_style_color(imgui.Col_.window_bg, self._background)
+
+        imgui.begin(
+            "stats",
+            True,
+            flags=imgui.WindowFlags_.no_move
+            | imgui.WindowFlags_.no_resize
+            | imgui.WindowFlags_.no_collapse
+            | imgui.WindowFlags_.no_scrollbar
+            | imgui.WindowFlags_.no_title_bar,
+        )
+
+        imgui.push_style_color(imgui.Col_.text, self._foreground)
+        if self._mode == 0:
+            if self._fps is not None:
+                ms = self._ms_samples[-1]
+                text = f"{ms} ms ({self._tmin}-{self._tmax})"
+                text += f"\n{self._fps} fps ({self._fmin}-{self._fmax})"
+                imgui.text(text)
+
+        elif self._mode == 1:
+            imgui.text(f"{self._fps} fps ({self._fmin}-{self._fmax})")
+            imgui.plot_histogram("##", self._fps_samples, graph_size=(120, 30))
+        elif self._mode == 2:
+            ms = self._ms_samples[-1]
+            imgui.text(f"{ms} ms ({self._tmin}-{self._tmax})")
+            imgui.plot_lines("##", self._ms_samples, graph_size=(120, 30))
+
+        imgui.pop_style_color()
+
+        imgui.end()
+
+        imgui.pop_style_color()
+
+        imgui.end_frame()
+        imgui.render()
+        return imgui.get_draw_data()
+
+    def _on_mouse(self, event):
+        self._mode = (self._mode + 1) % 3
+
+    def start(self):
+        if not self._init:
+            return
+
+        self._tbegin = time.perf_counter_ns()
+        if self._tprev is None:
+            self._tprev = self._tbegin
+
+    def stop(self):
+        if not self._init:
+            self._init = True
+            return
+
+        t = time.perf_counter_ns()
+        self._frames += 1
+
+        delta = round((t - self._tbegin) / 1_000_000)
+        self._tmin = min(self._tmin, delta)
+        self._tmax = max(self._tmax, delta)
+
+        if t >= self._tprev + 1_000_000_000:
+            # update FPS counter whenever a second has passed
+            fps = round(self._frames / ((t - self._tprev) / 1_000_000_000))
+            self._tprev = t
+            self._frames = 0
+            self._fmin = min(self._fmin, fps)
+            self._fmax = max(self._fmax, fps)
+            self._fps = fps
+
+            # update fps samples, remove last element
+            self._fps_samples = np.roll(self._fps_samples, -1)
+            self._fps_samples[-1] = fps
+
+        self._ms_samples = np.roll(self._ms_samples, -1)
+        self._ms_samples[-1] = delta
+
+    def render(self):
+        self._renderer.render()
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, *exc):
+        self.stop()


### PR DESCRIPTION
This pull request introduces an Imgui-based Stats component, inspired by `pygfx.Stats`. It offers three modes: fps/ms (text), fps (histogram), and ms (plot_lines), which can be toggled by clicking. 

Its performance surpasses that of `pygfx.Stats`; replacing `pygfx.Stats` with this component in the animation example can boost the frame rate by several dozen fps, aiding in obtaining more accurate performance results.

https://github.com/user-attachments/assets/96675875-1b92-41d5-8ddd-8bcd75b9e3d8

