### PR TITLE
Fix imgui scroll event

### DIFF
--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -214,7 +214,7 @@ class ImguiRenderer:
             event["stop_propagation"] = True
 
     def _on_wheel(self, event):
-        self._backend.io.add_mouse_wheel_event(event["dx"] / 100, event["dy"] / 100)
+        self._backend.io.add_mouse_wheel_event(event["dx"] / 100, -event["dy"] / 100)
 
         if self._backend.io.want_capture_mouse:
             event["stop_propagation"] = True


### PR DESCRIPTION
I found that the mouse wheel operation on imgui is reversed.
A simple fix.


I think because we take the reversed value here:
https://github.com/pygfx/wgpu-py/blob/8b61daa061755ae0c3161a1a2f9bf94eb17042f6/wgpu/gui/glfw.py#L464
