### PR TITLE
Improve performance for 'bitmap' render method

### DIFF
--- a/tests_mem/test_gui.py
+++ b/tests_mem/test_gui.py
@@ -61,7 +61,7 @@ def test_release_canvas_context(n):
         "expected_counts_after_create": {
             "CanvasContext": (n, 0),
         },
-        "ignore": {"CommandBuffer"},
+        "ignore": {"CommandBuffer", "Buffer"},
     }
 
     canvases = weakref.WeakSet()

--- a/tests_mem/testutils.py
+++ b/tests_mem/testutils.py
@@ -256,7 +256,9 @@ def create_and_release(create_objects_func):
                 print("  more after release:", more3)
 
             # Check!
-            assert more3 == options["expected_counts_after_release"]
+            assert more3 == options["expected_counts_after_release"], (
+                f"Expected:\n{options['expected_counts_after_release']}\nGot:\n{more3}"
+            )
 
             # Print mem usage info
             if TEST_ITERS:

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -425,6 +425,9 @@ class GPUCanvasContext:
         if self._bitmap_texture is not None and self._bitmap_texture.size == size:
             return self._bitmap_texture
 
+        # Create the texture.
+        # Note that the label 'present' is used by read_texture() to determine whether its
+        # ok to store a copy-buffer so that it can be re-used too.
         device = self._config["device"]
         self._texture = device.create_texture(
             label="present",

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -3557,6 +3557,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         device = source["texture"]._device
 
         # Get and calculate striding info
+        # Note that full_stride (bytes per row) must be a multiple of 256
         ori_offset = data_layout.get("offset", 0)
         ori_stride = data_layout["bytes_per_row"]
         extra_stride = (256 - ori_stride % 256) % 256
@@ -3566,11 +3567,20 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
 
         # Create temporary buffer
         data_length = full_stride * size[1] * size[2]
-        tmp_usage = flags.BufferUsage.COPY_DST | flags.BufferUsage.MAP_READ
-        tmp_buffer = device._create_buffer("", data_length, tmp_usage, False)
+
+        is_present_texture = source["texture"].label == "present"
+        copy_buffer = None
+        if is_present_texture:
+            copy_buffer = getattr(source["texture"], "_copy_buffer", None)
+
+        if copy_buffer is None:
+            buf_usage = flags.BufferUsage.COPY_DST | flags.BufferUsage.MAP_READ
+            copy_buffer = device._create_buffer("", data_length, buf_usage, False)
+            if is_present_texture:
+                source["texture"]._copy_buffer = copy_buffer
 
         destination = {
-            "buffer": tmp_buffer,
+            "buffer": copy_buffer,
             "offset": 0,
             "bytes_per_row": full_stride,  # or WGPU_COPY_STRIDE_UNDEFINED ?
             "rows_per_image": data_layout.get("rows_per_image", size[1]),
@@ -3582,25 +3592,43 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         command_buffer = encoder.finish()
         self.submit([command_buffer])
 
+        awaitable = copy_buffer._map("READ_NOSYNC")
+
         # Download from mappable buffer
-        tmp_buffer._map("READ_NOSYNC").sync_wait()
-        data = tmp_buffer.read_mapped()
+        # Because we use `copy=False``, we *must* copy the data.
+        if copy_buffer.map_state == "pending":
+            awaitable.sync_wait()
+        mapped_data = copy_buffer.read_mapped(copy=False)
 
-        # Explicit drop.
-        tmp_buffer.destroy()
+        data_length2 = ori_stride * size[1] * size[2] + ori_offset
 
-        # Fix data strides if necessary
-        # Ugh, cannot do striding with memoryviews (yet: https://bugs.python.org/issue41226)
-        # and Numpy is not a dependency.
+        # Copy the data
         if extra_stride or ori_offset:
-            data_length2 = ori_stride * size[1] * size[2] + ori_offset
-            data2 = memoryview(bytearray(data_length2)).cast(data.format)
+            # Copy per row
+            data = memoryview(bytearray(data_length2)).cast(mapped_data.format)
+            i_start = ori_offset
             for i in range(size[1] * size[2]):
-                row = data[i * full_stride : i * full_stride + ori_stride]
-                i_start = ori_offset + i * ori_stride
-                i_end = ori_offset + i * ori_stride + ori_stride
-                data2[i_start:i_end] = row
-            data = data2
+                row = mapped_data[i * full_stride : i * full_stride + ori_stride]
+                data[i_start : i_start + ori_stride] = row
+                i_start += ori_stride
+        else:
+            # Copy as a whole
+            data = memoryview(bytearray(mapped_data)).cast(mapped_data.format)
+
+        # Alternative copy solution using Numpy.
+        # I expected this to be faster, but does not really seem to be. Seems not worth it
+        # since we technically don't depend on Numpy. Leaving here for reference.
+        # import numpy as np
+        # mapped_data = np.asarray(mapped_data)[:data_length]
+        # data = np.empty(data_length2, dtype=mapped_data.dtype)
+        # mapped_data.shape = -1, full_stride
+        # data.shape = -1, ori_stride
+        # data[:] = mapped_data[:, :ori_stride]
+        # data.shape = -1
+        # data = memoryview(data)
+
+        # Since we use read_mapped(copy=False), we must unmap it *after* we've copied the data.
+        copy_buffer.unmap()
 
         return data
 

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -3583,7 +3583,6 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
             elif time.time() - time_since_size_ok > 5.0:
                 copy_buffer = None  # Too large too long
         if copy_buffer is None:
-            print("new copy buffer")
             buffer_size = data_length
             buffer_size += (4096 - buffer_size % 4096) % 4096
             buf_usage = flags.BufferUsage.COPY_DST | flags.BufferUsage.MAP_READ

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -18,7 +18,7 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 121 methods, 46 properties
+* Validated 37 classes, 122 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
 * Validated 37 classes, 121 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -18,7 +18,7 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 122 methods, 46 properties
+* Validated 37 classes, 121 methods, 46 properties
 ### Patching API for backends/wgpu_native/_api.py
 * Validated 37 classes, 121 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py


### PR DESCRIPTION
I did some experiments and this is a relatively easy way to improve performance by about 20%, going from ~24 to ~30 fps on fullscreen window on a 4k monitor on my M1 MacBook.

Tricks applied:
* ~~re-use the target texture~~ -> let's not for memory concerns, also seems to not help much.
* Reuse (and share) the buffer needed to copy the texture data to the CPU.
* Avoid a data-copy when bytes-per-row is not a multiple of 256.
* ~~use numpy for copying~~ does not seem to help much, and would introduce a new optional dependency.

We can go much faster, but for that we need to have our async stuff sorted out better.
More details here: https://github.com/pygfx/rendercanvas/issues/40#issuecomment-2714064032 