### PR TITLE
Release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,39 @@ Fixed:
 * Allow ``rendercanvas.get_context()`` before a backend is selected by @almarklein in https://github.com/pygfx/wgpu-py/pull/652
 
 
+### [v0.20.0] - 14-03-2025
+
+Added:
+
+* Add Imgui based Stats component by @panxinmiao in https://github.com/pygfx/wgpu-py/pull/670 and https://github.com/pygfx/wgpu-py/pull/674
+* Can pass constants to compute helper by @kushalkolar in https://github.com/pygfx/wgpu-py/pull/676
+* Add simple matmul example by @kushalkolar in https://github.com/pygfx/wgpu-py/pull/677
+
+Fixed:
+
+* Fix imgui scroll event by @panxinmiao in https://github.com/pygfx/wgpu-py/pull/678
+
+Changed:
+
+* Improve error handling by @almarklein in https://github.com/pygfx/wgpu-py/pull/667
+* Bring sleep back to WgpuAwaitable. Slowly back off on the amount of time sleeping. by @fyellin in https://github.com/pygfx/wgpu-py/pull/655
+* Improve performance for 'bitmap' render method by @almarklein in https://github.com/pygfx/wgpu-py/pull/680
+
+Other:
+
+* Stop setting AA_EnableHighDpiScaling since Qt Says it is not needed by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/657
+* Remove unneeded pytest-anyio package by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/658
+* Actually run the tests instead of fully skipping them by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/659
+* Improve state of the art for screenshot testing by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/555
+* Use default lavapipe for screenshot by @Vipitis in https://github.com/pygfx/wgpu-py/pull/660
+* Fix one typo in _helpers.py by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/661
+* Fix typo in README.md by @patrini32 in https://github.com/pygfx/wgpu-py/pull/662
+* Improve docs regarding drives on Linux by @almarklein in https://github.com/pygfx/wgpu-py/pull/668
+* Add patches for conda compatibility by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/666
+* Allow disabling downloading lib when creating wheel by @almarklein in https://github.com/pygfx/wgpu-py/pull/669
+* examples/imgui_cmap_picker.py - update for imgui bundle 1.6.2 by @pthom in https://github.com/pygfx/wgpu-py/pull/671
+
+
 ### [v0.19.2] - 25-11-2024
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,7 @@ Possible sections in each release:
 * Security: in case of vulnerabilities.
 
 
-### [v0.19.3] - 10-12-2024
-
-Fixed:
-
-* Ensure that wgpu is compatible both with imgui 1.6.0 and older by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/649
-* Clean up async code and add proper trio / rendercanvas support by @fyellin in https://github.com/pygfx/wgpu-py/pull/631
-* Remove timeout in awaitable by @almarklein in https://github.com/pygfx/wgpu-py/pull/651
-* Allow ``rendercanvas.get_context()`` before a backend is selected by @almarklein in https://github.com/pygfx/wgpu-py/pull/652
-
-
-### [v0.20.0] - 14-03-2025
+### [v0.20.1] - 14-03-2025
 
 Added:
 
@@ -58,6 +48,16 @@ Other:
 * Add patches for conda compatibility by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/666
 * Allow disabling downloading lib when creating wheel by @almarklein in https://github.com/pygfx/wgpu-py/pull/669
 * examples/imgui_cmap_picker.py - update for imgui bundle 1.6.2 by @pthom in https://github.com/pygfx/wgpu-py/pull/671
+
+
+### [v0.19.3] - 10-12-2024
+
+Fixed:
+
+* Ensure that wgpu is compatible both with imgui 1.6.0 and older by @hmaarrfk in https://github.com/pygfx/wgpu-py/pull/649
+* Clean up async code and add proper trio / rendercanvas support by @fyellin in https://github.com/pygfx/wgpu-py/pull/631
+* Remove timeout in awaitable by @almarklein in https://github.com/pygfx/wgpu-py/pull/651
+* Allow ``rendercanvas.get_context()`` before a backend is selected by @almarklein in https://github.com/pygfx/wgpu-py/pull/652
 
 
 ### [v0.19.2] - 25-11-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Possible sections in each release:
 
 ### [v0.20.1] - 14-03-2025
 
+Other:
+* Add release notes.
+
+
+### [v0.20.0] - 14-03-2025
+
 Added:
 
 * Add Imgui based Stats component by @panxinmiao in https://github.com/pygfx/wgpu-py/pull/670 and https://github.com/pygfx/wgpu-py/pull/674

--- a/wgpu/_version.py
+++ b/wgpu/_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 # This is the reference version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 # Allow using nearly the same code in different projects
 project_name = "wgpu"

--- a/wgpu/backends/wgpu_native/__init__.py
+++ b/wgpu/backends/wgpu_native/__init__.py
@@ -13,7 +13,7 @@ from .. import _register_backend
 # The wgpu-native version that we target/expect
 __version__ = "22.1.0.5"
 __commit_sha__ = "fad19f5990d8eb9a6e942eb957344957193fe66d"
-version_info = tuple(map(int, __version__.split(".")))
+version_info = tuple(map(int, __version__.split(".")))  # noqa: RUF048
 _check_expected_version(version_info)  # produces a warning on mismatch
 
 # Instantiate and register this backend


### PR DESCRIPTION
I forgot that in wgpu-py we write the release notes in a file in the repo instead of in the GH release page. Maybe we should pick one approach to do consistently in all repos of the pygfx project.

Also bumped the version, sot that it includes the new release notes.