### PR TITLE
fix newlines

### DIFF
--- a/wgpu/backends/wgpu_native/_ffi.py
+++ b/wgpu/backends/wgpu_native/_ffi.py
@@ -34,7 +34,13 @@ def _get_wgpu_header(*filenames):
     lines1 = []
     for filename in filenames:
         with open(filename, "rb") as f:
-            lines1.extend(f.read().decode().replace("\\\n", "").splitlines(True))
+            lines1.extend(
+                f.read()
+                .decode()
+                .replace("\r\n", "\n")
+                .replace("\\\n", "")
+                .splitlines(True)
+            )
     # Deal with pre-processor commands, because cffi cannot handle them.
     # Just removing them, plus a few extra lines, seems to do the trick.
     lines2 = []


### PR DESCRIPTION
I updated my fork and local branches after the #673 merge and redownloaded the lib using the script. Got hit with an `pycparser.plyparser.ParseError: <cdef source string>:11:1: Illegal character '\r'` on my windows machine.

here is a fix, but likely not the best (still error prone due to the duplicated code for reading the headers).
Also maybe we can get a Windows runner for CI?