### PR TITLE
Add return type hints

### DIFF
--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -433,9 +433,8 @@ class IdlPatcherMixin:
         args = idl_line.split("(", 1)[1].split(")", 1)[0].split(",")
         args = [Attribute(arg) for arg in args if arg.strip()]
         return_type = idl_line.split()[0]
-        if return_type.startswith("["):
-            # TODO: figure out if [NewObject] can be skipped: https://webidl.spec.whatwg.org/#NewObject
-            # [SameObject] only applicable to readonly attribute - so we shouldn't get here anyway.
+        if return_type.startswith("[NewObject]"):
+            # [NewObject] can be skipped: https://webidl.spec.whatwg.org/#NewObject
             return_type = idl_line.split()[1]
         if return_type.startswith("constructor"):
             # this means __init__ which essentially returns None (used with Error Messages)

--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -442,7 +442,6 @@ class IdlPatcherMixin:
         if return_type:
             return_type = self.idl.resolve_type(return_type)
 
-
         # If one arg that is a dict, flatten dict to kwargs
         if len(args) == 1 and args[0].typename.endswith(
             ("Options", "Descriptor", "Configuration")
@@ -475,7 +474,10 @@ class IdlPatcherMixin:
 
         # Construct final def
         line = preamble + ", ".join(py_args) + "): pass\n"
-        line = format_code(line, True).split("):")[0] + f"){f' -> {return_type}' if return_type else ''}:"
+        line = (
+            format_code(line, True).split("):")[0]
+            + f"){f' -> {return_type}' if return_type else ''}:"
+        )
         return "    " + line
 
     def _arg_from_attribute(self, methodname, attribute, force_optional=False):

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -218,6 +218,7 @@ class IdlParser:
             "GPUPipelineConstantValue": "float",
             "GPUExternalTexture": "object",
             "undefined": "None",
+            "ArrayBuffer": "memoryview",
         }
         name = pythonmap.get(name, name)
 
@@ -248,7 +249,7 @@ class IdlParser:
         elif name in ["PredefinedColorSpace"]:
             return "str"
         else:
-            assert name.startswith("GPU")
+            assert name.startswith("GPU"), f"Unknown type: {name}"
             name = name[3:]
             name = name[:-4] if name.endswith("Dict") else name
             if name in self.flags:

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -236,6 +236,10 @@ class IdlParser:
             names = [self.resolve_type(t).strip("'") for t in name.split(" or ")]
             names = sorted(set(names))
             return f"Union[{', '.join(names)}]"
+        if name.startswith("Promise<") and name.endswith(">"):
+            name = name.split("<")[-1].rstrip(">")
+            # recursive call if there are any of the above situations?
+            return self.resolve_type(name)
 
         # Triage
         if name in __builtins__:

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -2523,8 +2523,9 @@ class GPUOutOfMemoryError(GPUError, MemoryError):
     """An error raised when the GPU is out of memory."""
 
     # FIXME: was __init__(self, message: str):
+    # FIXME: was __init__(self, message: str) -> str:
     # IDL: constructor(DOMString message);
-    def __init__(self, message: str) -> str:
+    def __init__(self, message: str):
         super().__init__(message or "GPU is out of memory.")
 
 
@@ -2532,8 +2533,9 @@ class GPUValidationError(GPUError):
     """An error raised when the pipeline could not be validated."""
 
     # FIXME: was __init__(self, message: str):
+    # FIXME: was __init__(self, message: str) -> str:
     # IDL: constructor(DOMString message);
-    def __init__(self, message: str) -> str:
+    def __init__(self, message: str):
         super().__init__(message)
 
 
@@ -2541,8 +2543,9 @@ class GPUPipelineError(Exception):
     """An error raised when a pipeline could not be created."""
 
     # FIXME: was __init__(self, message: str, options: structs.PipelineErrorInit):
+    # FIXME: was __init__(self, message: str, options: structs.PipelineErrorInit) -> str:
     # IDL: constructor(optional DOMString message = "", GPUPipelineErrorInit options);
-    def __init__(self, message: str, options: structs.PipelineErrorInit) -> str:
+    def __init__(self, message: str, options: structs.PipelineErrorInit):
         super().__init__(message or "")
         self._options = options
 
@@ -2561,8 +2564,9 @@ class GPUInternalError(GPUError):
     """
 
     # FIXME: was __init__(self, message: str):
+    # FIXME: was __init__(self, message: str) -> str:
     # IDL: constructor(DOMString message);
-    def __init__(self, message: str) -> str:
+    def __init__(self, message: str):
         super().__init__(message)
 
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -276,11 +276,13 @@ class GPUCanvasContext:
         formats = capabilities["formats"]
         return formats[0] if formats else "bgra8-unorm"
 
+    # FIXME: was get_configuration(self):
     # IDL: GPUCanvasConfiguration? getConfiguration();
-    def get_configuration(self):
+    def get_configuration(self) -> structs.CanvasConfiguration:
         """Get the current configuration (or None if the context is not yet configured)."""
         return self._config
 
+    # FIXME: was configure(self, *, device: GPUDevice, format: enums.TextureFormat, usage: flags.TextureUsage = 0x10, view_formats: List[enums.TextureFormat] = [], color_space: str = "srgb", tone_mapping: structs.CanvasToneMapping = {}, alpha_mode: enums.CanvasAlphaMode = "opaque"):
     # IDL: undefined configure(GPUCanvasConfiguration configuration); -> required GPUDevice device, required GPUTextureFormat format, GPUTextureUsageFlags usage = 0x10, sequence<GPUTextureFormat> viewFormats = [], PredefinedColorSpace colorSpace = "srgb", GPUCanvasToneMapping toneMapping = {}, GPUCanvasAlphaMode alphaMode = "opaque"
     def configure(
         self,
@@ -292,7 +294,7 @@ class GPUCanvasContext:
         color_space: str = "srgb",
         tone_mapping: structs.CanvasToneMapping = {},
         alpha_mode: enums.CanvasAlphaMode = "opaque",
-    ):
+    ) -> None:
         """Configures the presentation context for the associated canvas.
         Destroys any textures produced with a previous configuration.
         This clears the drawing buffer to transparent black.
@@ -387,8 +389,9 @@ class GPUCanvasContext:
     ):
         raise NotImplementedError()
 
+    # FIXME: was unconfigure(self):
     # IDL: undefined unconfigure();
-    def unconfigure(self):
+    def unconfigure(self) -> None:
         """Removes the presentation context configuration.
         Destroys any textures produced while configured.
         """
@@ -400,8 +403,9 @@ class GPUCanvasContext:
     def _unconfigure_screen(self):
         raise NotImplementedError()
 
+    # FIXME: was get_current_texture(self):
     # IDL: GPUTexture getCurrentTexture();
-    def get_current_texture(self):
+    def get_current_texture(self) -> GPUTexture:
         """Get the `GPUTexture` that will be composited to the canvas next."""
         if not self._config:
             raise RuntimeError(
@@ -609,6 +613,7 @@ class GPUAdapter:
         """Information associated with this adapter."""
         return self._adapter_info
 
+    # FIXME: was request_device_sync(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {}); -> USVString label = "", sequence<GPUFeatureName> requiredFeatures = [], record<DOMString, (GPUSize64 or undefined)> requiredLimits = {}, GPUQueueDescriptor defaultQueue = {}
     def request_device_sync(
         self,
@@ -617,13 +622,14 @@ class GPUAdapter:
         required_features: List[enums.FeatureName] = [],
         required_limits: Dict[str, Union[None, int]] = {},
         default_queue: structs.QueueDescriptor = {},
-    ):
+    ) -> GPUDevice:
         """Sync version of `request_device_async()`.
 
         Provided by wgpu-py, but not compatible with WebGPU.
         """
         raise NotImplementedError()
 
+    # FIXME: was request_device_async(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {}); -> USVString label = "", sequence<GPUFeatureName> requiredFeatures = [], record<DOMString, (GPUSize64 or undefined)> requiredLimits = {}, GPUQueueDescriptor defaultQueue = {}
     async def request_device_async(
         self,
@@ -632,7 +638,7 @@ class GPUAdapter:
         required_features: List[enums.FeatureName] = [],
         required_limits: Dict[str, Union[None, int]] = {},
         default_queue: structs.QueueDescriptor = {},
-    ):
+    ) -> GPUDevice:
         """Request a `GPUDevice` from the adapter.
 
         Arguments:
@@ -799,8 +805,9 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was destroy(self):
     # IDL: undefined destroy();
-    def destroy(self):
+    def destroy(self) -> None:
         """Destroy this device.
 
         This cleans up all its resources and puts it in an unusable state.
@@ -819,7 +826,7 @@ class GPUDevice(GPUObjectBase):
         size: int,
         usage: flags.BufferUsage,
         mapped_at_creation: bool = False,
-    ):
+    ) -> GPUBuffer:
         """Create a `GPUBuffer` object.
 
         Arguments:
@@ -869,6 +876,7 @@ class GPUDevice(GPUObjectBase):
         buf.unmap()
         return buf
 
+    # FIXME: was create_texture(self, *, label: str = "", size: Union[List[int], structs.Extent3D], mip_level_count: int = 1, sample_count: int = 1, dimension: enums.TextureDimension = "2d", format: enums.TextureFormat, usage: flags.TextureUsage, view_formats: List[enums.TextureFormat] = []):
     # IDL: GPUTexture createTexture(GPUTextureDescriptor descriptor); -> USVString label = "", required GPUExtent3D size, GPUIntegerCoordinate mipLevelCount = 1, GPUSize32 sampleCount = 1, GPUTextureDimension dimension = "2d", required GPUTextureFormat format, required GPUTextureUsageFlags usage, sequence<GPUTextureFormat> viewFormats = []
     def create_texture(
         self,
@@ -881,7 +889,7 @@ class GPUDevice(GPUObjectBase):
         format: enums.TextureFormat,
         usage: flags.TextureUsage,
         view_formats: List[enums.TextureFormat] = [],
-    ):
+    ) -> GPUTexture:
         """Create a `GPUTexture` object.
 
         Arguments:
@@ -902,6 +910,7 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_sampler(self, *, label: str = "", address_mode_u: enums.AddressMode = "clamp-to-edge", address_mode_v: enums.AddressMode = "clamp-to-edge", address_mode_w: enums.AddressMode = "clamp-to-edge", mag_filter: enums.FilterMode = "nearest", min_filter: enums.FilterMode = "nearest", mipmap_filter: enums.MipmapFilterMode = "nearest", lod_min_clamp: float = 0, lod_max_clamp: float = 32, compare: enums.CompareFunction = optional, max_anisotropy: int = 1):
     # IDL: GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {}); -> USVString label = "", GPUAddressMode addressModeU = "clamp-to-edge", GPUAddressMode addressModeV = "clamp-to-edge", GPUAddressMode addressModeW = "clamp-to-edge", GPUFilterMode magFilter = "nearest", GPUFilterMode minFilter = "nearest", GPUMipmapFilterMode mipmapFilter = "nearest", float lodMinClamp = 0, float lodMaxClamp = 32, GPUCompareFunction compare, [Clamp] unsigned short maxAnisotropy = 1
     def create_sampler(
         self,
@@ -917,7 +926,7 @@ class GPUDevice(GPUObjectBase):
         lod_max_clamp: float = 32,
         compare: enums.CompareFunction = optional,
         max_anisotropy: int = 1,
-    ):
+    ) -> GPUSampler:
         """Create a `GPUSampler` object. Samplers specify how a texture is sampled.
 
         Arguments:
@@ -940,10 +949,11 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_bind_group_layout(self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]):
     # IDL: GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor); -> USVString label = "", required sequence<GPUBindGroupLayoutEntry> entries
     def create_bind_group_layout(
         self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]
-    ):
+    ) -> GPUBindGroupLayout:
         """Create a `GPUBindGroupLayout` object. One or more
         such objects are passed to `create_pipeline_layout()` to
         specify the (abstract) pipeline layout for resources. See the
@@ -977,6 +987,7 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_bind_group(self, *, label: str = "", layout: GPUBindGroupLayout, entries: List[structs.BindGroupEntry]):
     # IDL: GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor); -> USVString label = "", required GPUBindGroupLayout layout, required sequence<GPUBindGroupEntry> entries
     def create_bind_group(
         self,
@@ -984,7 +995,7 @@ class GPUDevice(GPUObjectBase):
         label: str = "",
         layout: GPUBindGroupLayout,
         entries: List[structs.BindGroupEntry],
-    ):
+    ) -> GPUBindGroup:
         """Create a `GPUBindGroup` object, which can be used in
         `pass.set_bind_group()` to attach a group of resources.
 
@@ -1021,10 +1032,11 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_pipeline_layout(self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]):
     # IDL: GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor); -> USVString label = "", required sequence<GPUBindGroupLayout?> bindGroupLayouts
     def create_pipeline_layout(
         self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
-    ):
+    ) -> GPUPipelineLayout:
         """Create a `GPUPipelineLayout` object, which can be
         used in `create_render_pipeline()` or `create_compute_pipeline()`.
 
@@ -1034,6 +1046,7 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_shader_module(self, *, label: str = "", code: str, compilation_hints: List[structs.ShaderModuleCompilationHint] = []):
     # IDL: GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor); -> USVString label = "", required USVString code, sequence<GPUShaderModuleCompilationHint> compilationHints = []
     def create_shader_module(
         self,
@@ -1041,7 +1054,7 @@ class GPUDevice(GPUObjectBase):
         label: str = "",
         code: str,
         compilation_hints: List[structs.ShaderModuleCompilationHint] = [],
-    ):
+    ) -> GPUShaderModule:
         """Create a `GPUShaderModule` object from shader source.
 
         The primary shader language is WGSL, though SpirV is also supported,
@@ -1057,6 +1070,7 @@ class GPUDevice(GPUObjectBase):
         # Noe: compilation_hints has been removed: https://github.com/webgpu-native/webgpu-headers/pull/337
         raise NotImplementedError()
 
+    # FIXME: was create_compute_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     # IDL: GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUProgrammableStage compute
     def create_compute_pipeline(
         self,
@@ -1064,7 +1078,7 @@ class GPUDevice(GPUObjectBase):
         label: str = "",
         layout: Union[GPUPipelineLayout, enums.AutoLayoutMode],
         compute: structs.ProgrammableStage,
-    ):
+    ) -> GPUComputePipeline:
         """Create a `GPUComputePipeline` object.
 
         Arguments:
@@ -1074,6 +1088,7 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_compute_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     # IDL: Promise<GPUComputePipeline> createComputePipelineAsync(GPUComputePipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUProgrammableStage compute
     async def create_compute_pipeline_async(
         self,
@@ -1081,12 +1096,13 @@ class GPUDevice(GPUObjectBase):
         label: str = "",
         layout: Union[GPUPipelineLayout, enums.AutoLayoutMode],
         compute: structs.ProgrammableStage,
-    ):
+    ) -> GPUComputePipeline:
         """Async version of `create_compute_pipeline()`.
 
         Both versions are compatible with WebGPU."""
         raise NotImplementedError()
 
+    # FIXME: was create_render_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     # IDL: GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUVertexState vertex, GPUPrimitiveState primitive = {}, GPUDepthStencilState depthStencil, GPUMultisampleState multisample = {}, GPUFragmentState fragment
     def create_render_pipeline(
         self,
@@ -1098,7 +1114,7 @@ class GPUDevice(GPUObjectBase):
         depth_stencil: structs.DepthStencilState = optional,
         multisample: structs.MultisampleState = {},
         fragment: structs.FragmentState = optional,
-    ):
+    ) -> GPURenderPipeline:
         """Create a `GPURenderPipeline` object.
 
         Arguments:
@@ -1231,6 +1247,7 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_render_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     # IDL: Promise<GPURenderPipeline> createRenderPipelineAsync(GPURenderPipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUVertexState vertex, GPUPrimitiveState primitive = {}, GPUDepthStencilState depthStencil, GPUMultisampleState multisample = {}, GPUFragmentState fragment
     async def create_render_pipeline_async(
         self,
@@ -1242,14 +1259,15 @@ class GPUDevice(GPUObjectBase):
         depth_stencil: structs.DepthStencilState = optional,
         multisample: structs.MultisampleState = {},
         fragment: structs.FragmentState = optional,
-    ):
+    ) -> GPURenderPipeline:
         """Async version of `create_render_pipeline()`.
 
         Both versions are compatible with WebGPU."""
         raise NotImplementedError()
 
+    # FIXME: was create_command_encoder(self, *, label: str = ""):
     # IDL: GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {}); -> USVString label = ""
-    def create_command_encoder(self, *, label: str = ""):
+    def create_command_encoder(self, *, label: str = "") -> GPUCommandEncoder:
         """Create a `GPUCommandEncoder` object. A command
         encoder is used to record commands, which can then be submitted
         at once to the GPU.
@@ -1259,6 +1277,7 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_render_bundle_encoder(self, *, label: str = "", color_formats: List[enums.TextureFormat], depth_stencil_format: enums.TextureFormat = optional, sample_count: int = 1, depth_read_only: bool = False, stencil_read_only: bool = False):
     # IDL: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor); -> USVString label = "", required sequence<GPUTextureFormat?> colorFormats, GPUTextureFormat depthStencilFormat, GPUSize32 sampleCount = 1, boolean depthReadOnly = false, boolean stencilReadOnly = false
     def create_render_bundle_encoder(
         self,
@@ -1269,7 +1288,7 @@ class GPUDevice(GPUObjectBase):
         sample_count: int = 1,
         depth_read_only: bool = False,
         stencil_read_only: bool = False,
-    ):
+    ) -> GPURenderBundleEncoder:
         """Create a `GPURenderBundleEncoder` object.
 
         Render bundles represent a pre-recorded bundle of commands. In cases where the same
@@ -1286,32 +1305,39 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
     # IDL: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); -> USVString label = "", required GPUQueryType type, required GPUSize32 count
-    def create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
+    def create_query_set(
+        self, *, label: str = "", type: enums.QueryType, count: int
+    ) -> GPUQuerySet:
         """Create a `GPUQuerySet` object."""
         raise NotImplementedError()
 
+    # FIXME: was push_error_scope(self, filter: enums.ErrorFilter):
     # IDL: undefined pushErrorScope(GPUErrorFilter filter);
     @apidiff.hide
-    def push_error_scope(self, filter: enums.ErrorFilter):
+    def push_error_scope(self, filter: enums.ErrorFilter) -> None:
         """Pushes a new GPU error scope onto the stack."""
         raise NotImplementedError()
 
+    # FIXME: was pop_error_scope_sync(self):
     # IDL: Promise<GPUError?> popErrorScope();
     @apidiff.hide
-    def pop_error_scope_sync(self):
+    def pop_error_scope_sync(self) -> GPUError:
         """Sync version of `pop_error_scope_async().
 
         Provided by wgpu-py, but not compatible with WebGPU.
         """
         raise NotImplementedError()
 
+    # FIXME: was pop_error_scope_async(self):
     # IDL: Promise<GPUError?> popErrorScope();
     @apidiff.hide
-    async def pop_error_scope_async(self):
+    async def pop_error_scope_async(self) -> GPUError:
         """Pops a GPU error scope from the stack."""
         raise NotImplementedError()
 
+    # FIXME: was import_external_texture(self, *, label: str = "", source: Union[memoryview, object], color_space: str = "srgb"):
     # IDL: GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor); -> USVString label = "", required (HTMLVideoElement or VideoFrame) source, PredefinedColorSpace colorSpace = "srgb"
     @apidiff.hide("Specific to browsers")
     def import_external_texture(
@@ -1320,7 +1346,7 @@ class GPUDevice(GPUObjectBase):
         label: str = "",
         source: Union[memoryview, object],
         color_space: str = "srgb",
-    ):
+    ) -> object:
         """For browsers only."""
         raise NotImplementedError()
 
@@ -1382,20 +1408,22 @@ class GPUBuffer(GPUObjectBase):
     # but reading and writing data goes via method calls instead of via
     # an array-like object that exposes the shared memory.
 
+    # FIXME: was map_sync(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     # IDL: Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def map_sync(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         """Sync version of `map_async()`.
 
         Provided by wgpu-py, but not compatible with WebGPU.
         """
         raise NotImplementedError()
 
+    # FIXME: was map_async(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     # IDL: Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     async def map_async(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         """Maps the given range of the GPUBuffer.
 
         When this call returns, the buffer content is ready to be
@@ -1412,8 +1440,9 @@ class GPUBuffer(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was unmap(self):
     # IDL: undefined unmap();
-    def unmap(self):
+    def unmap(self) -> None:
         """Unmaps the buffer.
 
         Unmaps the mapped range of the GPUBuffer and makes its contents
@@ -1476,13 +1505,17 @@ class GPUBuffer(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was get_mapped_range(self, offset: int = 0, size: Optional[int] = None):
     # IDL: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     @apidiff.hide
-    def get_mapped_range(self, offset: int = 0, size: Optional[int] = None):
+    def get_mapped_range(
+        self, offset: int = 0, size: Optional[int] = None
+    ) -> memoryview:
         raise NotImplementedError("The Python API differs from WebGPU here")
 
+    # FIXME: was destroy(self):
     # IDL: undefined destroy();
-    def destroy(self):
+    def destroy(self) -> None:
         """Destroy the buffer.
 
         Explicitly destroys the buffer, freeing its memory and putting
@@ -1580,6 +1613,7 @@ class GPUTexture(GPUObjectBase):
         """The allowed usages for this texture."""
         return self._tex_info["usage"]
 
+    # FIXME: was create_view(self, *, label: str = "", format: enums.TextureFormat = optional, dimension: enums.TextureViewDimension = optional, usage: flags.TextureUsage = 0, aspect: enums.TextureAspect = "all", base_mip_level: int = 0, mip_level_count: int = optional, base_array_layer: int = 0, array_layer_count: int = optional):
     # IDL: GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {}); -> USVString label = "", GPUTextureFormat format, GPUTextureViewDimension dimension, GPUTextureUsageFlags usage = 0, GPUTextureAspect aspect = "all", GPUIntegerCoordinate baseMipLevel = 0, GPUIntegerCoordinate mipLevelCount, GPUIntegerCoordinate baseArrayLayer = 0, GPUIntegerCoordinate arrayLayerCount
     def create_view(
         self,
@@ -1593,7 +1627,7 @@ class GPUTexture(GPUObjectBase):
         mip_level_count: int = optional,
         base_array_layer: int = 0,
         array_layer_count: int = optional,
-    ):
+    ) -> GPUTextureView:
         """Create a `GPUTextureView` object.
 
         If no arguments are given, a default view is given, with the
@@ -1615,8 +1649,9 @@ class GPUTexture(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was destroy(self):
     # IDL: undefined destroy();
-    def destroy(self):
+    def destroy(self) -> None:
         """Destroy the texture.
 
         Explicitly destroys the texture, freeing its memory and putting
@@ -1698,16 +1733,18 @@ class GPUShaderModule(GPUObjectBase):
     Create a shader module using `GPUDevice.create_shader_module()`.
     """
 
+    # FIXME: was get_compilation_info_sync(self):
     # IDL: Promise<GPUCompilationInfo> getCompilationInfo();
-    def get_compilation_info_sync(self):
+    def get_compilation_info_sync(self) -> GPUCompilationInfo:
         """Sync version of `get_compilation_info_async()`.
 
         Provided by wgpu-py, but not compatible with WebGPU.
         """
         raise NotImplementedError()
 
+    # FIXME: was get_compilation_info_async(self):
     # IDL: Promise<GPUCompilationInfo> getCompilationInfo();
-    async def get_compilation_info_async(self):
+    async def get_compilation_info_async(self) -> GPUCompilationInfo:
         """Get shader compilation info. Always returns empty list at the moment."""
         # How can this return shader errors if one cannot create a
         # shader module when the shader source has errors?
@@ -1717,8 +1754,9 @@ class GPUShaderModule(GPUObjectBase):
 class GPUPipelineBase:
     """A mixin class for render and compute pipelines."""
 
+    # FIXME: was get_bind_group_layout(self, index: int):
     # IDL: [NewObject] GPUBindGroupLayout getBindGroupLayout(unsigned long index);
-    def get_bind_group_layout(self, index: int):
+    def get_bind_group_layout(self, index: int) -> GPUBindGroupLayout:
         """Get the bind group layout at the given index."""
         raise NotImplementedError()
 
@@ -1791,18 +1829,21 @@ class GPUBindingCommandsMixin:
 class GPUDebugCommandsMixin:
     """Mixin for classes that support debug groups and markers."""
 
+    # FIXME: was push_debug_group(self, group_label: str):
     # IDL: undefined pushDebugGroup(USVString groupLabel);
-    def push_debug_group(self, group_label: str):
+    def push_debug_group(self, group_label: str) -> None:
         """Push a named debug group into the command stream."""
         raise NotImplementedError()
 
+    # FIXME: was pop_debug_group(self):
     # IDL: undefined popDebugGroup();
-    def pop_debug_group(self):
+    def pop_debug_group(self) -> None:
         """Pop the active debug group."""
         raise NotImplementedError()
 
+    # FIXME: was insert_debug_marker(self, marker_label: str):
     # IDL: undefined insertDebugMarker(USVString markerLabel);
-    def insert_debug_marker(self, marker_label: str):
+    def insert_debug_marker(self, marker_label: str) -> None:
         """Insert the given message into the debug message queue."""
         raise NotImplementedError()
 
@@ -1810,8 +1851,9 @@ class GPUDebugCommandsMixin:
 class GPURenderCommandsMixin:
     """Mixin for classes that provide rendering commands."""
 
+    # FIXME: was set_pipeline(self, pipeline: GPURenderPipeline):
     # IDL: undefined setPipeline(GPURenderPipeline pipeline);
-    def set_pipeline(self, pipeline: GPURenderPipeline):
+    def set_pipeline(self, pipeline: GPURenderPipeline) -> None:
         """Set the pipeline for this render pass.
 
         Arguments:
@@ -1819,6 +1861,7 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
+    # FIXME: was set_index_buffer(self, buffer: GPUBuffer, index_format: enums.IndexFormat, offset: int = 0, size: Optional[int] = None):
     # IDL: undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def set_index_buffer(
         self,
@@ -1826,7 +1869,7 @@ class GPURenderCommandsMixin:
         index_format: enums.IndexFormat,
         offset: int = 0,
         size: Optional[int] = None,
-    ):
+    ) -> None:
         """Set the index buffer for this render pass.
 
         Arguments:
@@ -1840,10 +1883,11 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
+    # FIXME: was set_vertex_buffer(self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     # IDL: undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer? buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def set_vertex_buffer(
         self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         """Associate a vertex buffer with a bind slot.
 
         Arguments:
@@ -1857,6 +1901,7 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
+    # FIXME: was draw(self, vertex_count: int, instance_count: int = 1, first_vertex: int = 0, first_instance: int = 0):
     # IDL: undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1, optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
     def draw(
         self,
@@ -1864,7 +1909,7 @@ class GPURenderCommandsMixin:
         instance_count: int = 1,
         first_vertex: int = 0,
         first_instance: int = 0,
-    ):
+    ) -> None:
         """Run the render pipeline without an index buffer.
 
         Arguments:
@@ -1875,8 +1920,9 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
+    # FIXME: was draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     # IDL: undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+    def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int) -> None:
         """Like `draw()`, but the function arguments are in a buffer.
 
         Arguments:
@@ -1887,6 +1933,7 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
+    # FIXME: was draw_indexed(self, index_count: int, instance_count: int = 1, first_index: int = 0, base_vertex: int = 0, first_instance: int = 0):
     # IDL: undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1, optional GPUSize32 firstIndex = 0, optional GPUSignedOffset32 baseVertex = 0, optional GPUSize32 firstInstance = 0);
     def draw_indexed(
         self,
@@ -1895,7 +1942,7 @@ class GPURenderCommandsMixin:
         first_index: int = 0,
         base_vertex: int = 0,
         first_instance: int = 0,
-    ):
+    ) -> None:
         """Run the render pipeline using an index buffer.
 
         Arguments:
@@ -1909,8 +1956,11 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
+    # FIXME: was draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     # IDL: undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    def draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+    def draw_indexed_indirect(
+        self, indirect_buffer: GPUBuffer, indirect_offset: int
+    ) -> None:
         """
         Like `draw_indexed()`, but the function arguments are in a buffer.
 
@@ -1929,13 +1979,14 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
     Create a command encoder using `GPUDevice.create_command_encoder()`.
     """
 
+    # FIXME: was begin_compute_pass(self, *, label: str = "", timestamp_writes: structs.ComputePassTimestampWrites = optional):
     # IDL: GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {}); -> USVString label = "", GPUComputePassTimestampWrites timestampWrites
     def begin_compute_pass(
         self,
         *,
         label: str = "",
         timestamp_writes: structs.ComputePassTimestampWrites = optional,
-    ):
+    ) -> GPUComputePassEncoder:
         """Record the beginning of a compute pass. Returns a
         `GPUComputePassEncoder` object.
 
@@ -1945,6 +1996,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was begin_render_pass(self, *, label: str = "", color_attachments: List[structs.RenderPassColorAttachment], depth_stencil_attachment: structs.RenderPassDepthStencilAttachment = optional, occlusion_query_set: GPUQuerySet = optional, timestamp_writes: structs.RenderPassTimestampWrites = optional, max_draw_count: int = 50000000):
     # IDL: GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor); -> USVString label = "", required sequence<GPURenderPassColorAttachment?> colorAttachments, GPURenderPassDepthStencilAttachment depthStencilAttachment, GPUQuerySet occlusionQuerySet, GPURenderPassTimestampWrites timestampWrites, GPUSize64 maxDrawCount = 50000000
     def begin_render_pass(
         self,
@@ -1955,7 +2007,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         occlusion_query_set: GPUQuerySet = optional,
         timestamp_writes: structs.RenderPassTimestampWrites = optional,
         max_draw_count: int = 50000000,
-    ):
+    ) -> GPURenderPassEncoder:
         """Record the beginning of a render pass. Returns a
         `GPURenderPassEncoder` object.
 
@@ -1968,10 +2020,11 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was clear_buffer(self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     # IDL: undefined clearBuffer( GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def clear_buffer(
         self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         """Set (part of) the given buffer to zeros.
 
         Arguments:
@@ -1983,6 +2036,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was copy_buffer_to_buffer(self, source: GPUBuffer, source_offset: int, destination: GPUBuffer, destination_offset: int, size: int):
     # IDL: undefined copyBufferToBuffer( GPUBuffer source, GPUSize64 sourceOffset, GPUBuffer destination, GPUSize64 destinationOffset, GPUSize64 size);
     def copy_buffer_to_buffer(
         self,
@@ -1991,7 +2045,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         destination: GPUBuffer,
         destination_offset: int,
         size: int,
-    ):
+    ) -> None:
         """Copy the contents of a buffer to another buffer.
 
         Arguments:
@@ -2005,13 +2059,14 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was copy_buffer_to_texture(self, source: structs.TexelCopyBufferInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyBufferToTexture( GPUTexelCopyBufferInfo source, GPUTexelCopyTextureInfo destination, GPUExtent3D copySize);
     def copy_buffer_to_texture(
         self,
         source: structs.TexelCopyBufferInfo,
         destination: structs.TexelCopyTextureInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         """Copy the contents of a buffer to a texture (view).
 
         Arguments:
@@ -2023,13 +2078,14 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was copy_texture_to_buffer(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyBufferInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyTextureToBuffer( GPUTexelCopyTextureInfo source, GPUTexelCopyBufferInfo destination, GPUExtent3D copySize);
     def copy_texture_to_buffer(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyBufferInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         """Copy the contents of a texture (view) to a buffer.
 
         Arguments:
@@ -2041,13 +2097,14 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was copy_texture_to_texture(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyTextureToTexture( GPUTexelCopyTextureInfo source, GPUTexelCopyTextureInfo destination, GPUExtent3D copySize);
     def copy_texture_to_texture(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyTextureInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         """Copy the contents of a texture (view) to another texture (view).
 
         Arguments:
@@ -2057,8 +2114,9 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was finish(self, *, label: str = ""):
     # IDL: GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {}); -> USVString label = ""
-    def finish(self, *, label: str = ""):
+    def finish(self, *, label: str = "") -> GPUCommandBuffer:
         """Finish recording. Returns a `GPUCommandBuffer` to
         submit to a `GPUQueue`.
 
@@ -2067,6 +2125,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was resolve_query_set(self, query_set: GPUQuerySet, first_query: int, query_count: int, destination: GPUBuffer, destination_offset: int):
     # IDL: undefined resolveQuerySet( GPUQuerySet querySet, GPUSize32 firstQuery, GPUSize32 queryCount, GPUBuffer destination, GPUSize64 destinationOffset);
     def resolve_query_set(
         self,
@@ -2075,7 +2134,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         query_count: int,
         destination: GPUBuffer,
         destination_offset: int,
-    ):
+    ) -> None:
         """
         Resolves query results from a ``GPUQuerySet`` out into a range of a ``GPUBuffer``.
 
@@ -2099,8 +2158,9 @@ class GPUComputePassEncoder(
     Create a compute pass encoder using `GPUCommandEncoder.begin_compute_pass()`.
     """
 
+    # FIXME: was set_pipeline(self, pipeline: GPUComputePipeline):
     # IDL: undefined setPipeline(GPUComputePipeline pipeline);
-    def set_pipeline(self, pipeline: GPUComputePipeline):
+    def set_pipeline(self, pipeline: GPUComputePipeline) -> None:
         """Set the pipeline for this compute pass.
 
         Arguments:
@@ -2108,13 +2168,14 @@ class GPUComputePassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was dispatch_workgroups(self, workgroup_count_x: int, workgroup_count_y: int = 1, workgroup_count_z: int = 1):
     # IDL: undefined dispatchWorkgroups(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
     def dispatch_workgroups(
         self,
         workgroup_count_x: int,
         workgroup_count_y: int = 1,
         workgroup_count_z: int = 1,
-    ):
+    ) -> None:
         """Run the compute shader.
 
         Arguments:
@@ -2124,10 +2185,11 @@ class GPUComputePassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was dispatch_workgroups_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     # IDL: undefined dispatchWorkgroupsIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
     def dispatch_workgroups_indirect(
         self, indirect_buffer: GPUBuffer, indirect_offset: int
-    ):
+    ) -> None:
         """Like `dispatch_workgroups()`, but the function arguments are in a buffer.
 
         Arguments:
@@ -2136,8 +2198,9 @@ class GPUComputePassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was end(self):
     # IDL: undefined end();
-    def end(self):
+    def end(self) -> None:
         """Record the end of the compute pass."""
         raise NotImplementedError()
 
@@ -2154,6 +2217,7 @@ class GPURenderPassEncoder(
     Create a render pass encoder using `GPUCommandEncoder.begin_render_pass`.
     """
 
+    # FIXME: was set_viewport(self, x: float, y: float, width: float, height: float, min_depth: float, max_depth: float):
     # IDL: undefined setViewport(float x, float y, float width, float height, float minDepth, float maxDepth);
     def set_viewport(
         self,
@@ -2163,7 +2227,7 @@ class GPURenderPassEncoder(
         height: float,
         min_depth: float,
         max_depth: float,
-    ):
+    ) -> None:
         """Set the viewport for this render pass. The whole scene is rendered
         to this sub-rectangle.
 
@@ -2178,8 +2242,9 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was set_scissor_rect(self, x: int, y: int, width: int, height: int):
     # IDL: undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,  GPUIntegerCoordinate width, GPUIntegerCoordinate height);
-    def set_scissor_rect(self, x: int, y: int, width: int, height: int):
+    def set_scissor_rect(self, x: int, y: int, width: int, height: int) -> None:
         """Set the scissor rectangle for this render pass. The scene
         is rendered as usual, but is only applied to this sub-rectangle.
 
@@ -2191,8 +2256,9 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was set_blend_constant(self, color: Union[List[float], structs.Color]):
     # IDL: undefined setBlendConstant(GPUColor color);
-    def set_blend_constant(self, color: Union[List[float], structs.Color]):
+    def set_blend_constant(self, color: Union[List[float], structs.Color]) -> None:
         """Set the blend color for the render pass.
 
         Arguments:
@@ -2200,8 +2266,9 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was set_stencil_reference(self, reference: int):
     # IDL: undefined setStencilReference(GPUStencilValue reference);
-    def set_stencil_reference(self, reference: int):
+    def set_stencil_reference(self, reference: int) -> None:
         """Set the reference stencil value for this render pass.
 
         Arguments:
@@ -2209,8 +2276,9 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was execute_bundles(self, bundles: List[GPURenderBundle]):
     # IDL: undefined executeBundles(sequence<GPURenderBundle> bundles);
-    def execute_bundles(self, bundles: List[GPURenderBundle]):
+    def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
         """Executes commands previously recorded into the render bundles
           as part of this render pass.
 
@@ -2219,13 +2287,15 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
+    # FIXME: was end(self):
     # IDL: undefined end();
-    def end(self):
+    def end(self) -> None:
         """Record the end of the render pass."""
         raise NotImplementedError()
 
+    # FIXME: was begin_occlusion_query(self, query_index: int):
     # IDL: undefined beginOcclusionQuery(GPUSize32 queryIndex);
-    def begin_occlusion_query(self, query_index: int):
+    def begin_occlusion_query(self, query_index: int) -> None:
         """Begins an occlusion query.
 
         Arguments:
@@ -2236,8 +2306,9 @@ class GPURenderPassEncoder(
 
         raise NotImplementedError()
 
+    # FIXME: was end_occlusion_query(self):
     # IDL: undefined endOcclusionQuery();
-    def end_occlusion_query(self):
+    def end_occlusion_query(self) -> None:
         """Ends an occlusion query."""
         raise NotImplementedError()
 
@@ -2257,8 +2328,9 @@ class GPURenderBundleEncoder(
 ):
     """Encodes a series of render commands into a reusable render bundle."""
 
+    # FIXME: was finish(self, *, label: str = ""):
     # IDL: GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {}); -> USVString label = ""
-    def finish(self, *, label: str = ""):
+    def finish(self, *, label: str = "") -> GPURenderBundle:
         """Finish recording and return a `GPURenderBundle`.
 
         Arguments:
@@ -2273,8 +2345,9 @@ class GPUQueue(GPUObjectBase):
     You can obtain a queue object via the :attr:`GPUDevice.queue` property.
     """
 
+    # FIXME: was submit(self, command_buffers: List[GPUCommandBuffer]):
     # IDL: undefined submit(sequence<GPUCommandBuffer> commandBuffers);
-    def submit(self, command_buffers: List[GPUCommandBuffer]):
+    def submit(self, command_buffers: List[GPUCommandBuffer]) -> None:
         """Submit a `GPUCommandBuffer` to the queue.
 
         Arguments:
@@ -2282,6 +2355,7 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was write_buffer(self, buffer: GPUBuffer, buffer_offset: int, data: memoryview, data_offset: int = 0, size: Optional[int] = None):
     # IDL: undefined writeBuffer( GPUBuffer buffer, GPUSize64 bufferOffset, AllowSharedBufferSource data, optional GPUSize64 dataOffset = 0, optional GPUSize64 size);
     def write_buffer(
         self,
@@ -2290,7 +2364,7 @@ class GPUQueue(GPUObjectBase):
         data: memoryview,
         data_offset: int = 0,
         size: Optional[int] = None,
-    ):
+    ) -> None:
         """Takes the data contents and schedules a write operation to the buffer.
 
         Changes to the data after this function is called don't affect
@@ -2332,6 +2406,7 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was write_texture(self, destination: structs.TexelCopyTextureInfo, data: memoryview, data_layout: structs.TexelCopyBufferLayout, size: Union[List[int], structs.Extent3D]):
     # IDL: undefined writeTexture( GPUTexelCopyTextureInfo destination, AllowSharedBufferSource data, GPUTexelCopyBufferLayout dataLayout, GPUExtent3D size);
     def write_texture(
         self,
@@ -2339,7 +2414,7 @@ class GPUQueue(GPUObjectBase):
         data: memoryview,
         data_layout: structs.TexelCopyBufferLayout,
         size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         """Takes the data contents and schedules a write operation of
         these contents to the destination texture in the queue. A
         snapshot of the data is taken; any changes to the data after
@@ -2379,6 +2454,7 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
+    # FIXME: was copy_external_image_to_texture(self, source: structs.CopyExternalImageSourceInfo, destination: structs.CopyExternalImageDestInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyExternalImageToTexture( GPUCopyExternalImageSourceInfo source, GPUCopyExternalImageDestInfo destination, GPUExtent3D copySize);
     @apidiff.hide("Specific to browsers")
     def copy_external_image_to_texture(
@@ -2386,19 +2462,21 @@ class GPUQueue(GPUObjectBase):
         source: structs.CopyExternalImageSourceInfo,
         destination: structs.CopyExternalImageDestInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         raise NotImplementedError()
 
+    # FIXME: was on_submitted_work_done_sync(self):
     # IDL: Promise<undefined> onSubmittedWorkDone();
-    def on_submitted_work_done_sync(self):
+    def on_submitted_work_done_sync(self) -> None:
         """Sync version of `on_submitted_work_done_async()`.
 
         Provided by wgpu-py, but not compatible with WebGPU.
         """
         raise NotImplementedError()
 
+    # FIXME: was on_submitted_work_done_async(self):
     # IDL: Promise<undefined> onSubmittedWorkDone();
-    async def on_submitted_work_done_async(self):
+    async def on_submitted_work_done_async(self) -> None:
         """TODO"""
         raise NotImplementedError()
 
@@ -2444,24 +2522,27 @@ class GPUError(Exception):
 class GPUOutOfMemoryError(GPUError, MemoryError):
     """An error raised when the GPU is out of memory."""
 
+    # FIXME: was __init__(self, message: str):
     # IDL: constructor(DOMString message);
-    def __init__(self, message: str):
+    def __init__(self, message: str) -> str:
         super().__init__(message or "GPU is out of memory.")
 
 
 class GPUValidationError(GPUError):
     """An error raised when the pipeline could not be validated."""
 
+    # FIXME: was __init__(self, message: str):
     # IDL: constructor(DOMString message);
-    def __init__(self, message: str):
+    def __init__(self, message: str) -> str:
         super().__init__(message)
 
 
 class GPUPipelineError(Exception):
     """An error raised when a pipeline could not be created."""
 
+    # FIXME: was __init__(self, message: str, options: structs.PipelineErrorInit):
     # IDL: constructor(optional DOMString message = "", GPUPipelineErrorInit options);
-    def __init__(self, message: str, options: structs.PipelineErrorInit):
+    def __init__(self, message: str, options: structs.PipelineErrorInit) -> str:
         super().__init__(message or "")
         self._options = options
 
@@ -2479,8 +2560,9 @@ class GPUInternalError(GPUError):
     reason even when all validation requirements have been satisfied.
     """
 
+    # FIXME: was __init__(self, message: str):
     # IDL: constructor(DOMString message);
-    def __init__(self, message: str):
+    def __init__(self, message: str) -> str:
         super().__init__(message)
 
 
@@ -2560,8 +2642,9 @@ class GPUQuerySet(GPUObjectBase):
         """The number of the queries managed by this queryset."""
         return self._count
 
+    # FIXME: was destroy(self):
     # IDL: undefined destroy();
-    def destroy(self):
+    def destroy(self) -> None:
         """Destroy the QuerySet.
 
         This cleans up all its resources and puts it in an unusable state.

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -96,7 +96,7 @@ class GPU:
         power_preference: enums.PowerPreference = None,
         force_fallback_adapter: bool = False,
         canvas=None,
-    ):
+    ) -> GPUAdapter:
         """Sync version of `request_adapter_async()`.
 
         Provided by wgpu-py, but not compatible with WebGPU.
@@ -119,7 +119,7 @@ class GPU:
         power_preference: enums.PowerPreference = None,
         force_fallback_adapter: bool = False,
         canvas=None,
-    ):
+    ) -> GPUAdapter:
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -276,13 +276,11 @@ class GPUCanvasContext:
         formats = capabilities["formats"]
         return formats[0] if formats else "bgra8-unorm"
 
-    # FIXME: was get_configuration(self):
     # IDL: GPUCanvasConfiguration? getConfiguration();
     def get_configuration(self) -> structs.CanvasConfiguration:
         """Get the current configuration (or None if the context is not yet configured)."""
         return self._config
 
-    # FIXME: was configure(self, *, device: GPUDevice, format: enums.TextureFormat, usage: flags.TextureUsage = 0x10, view_formats: List[enums.TextureFormat] = [], color_space: str = "srgb", tone_mapping: structs.CanvasToneMapping = {}, alpha_mode: enums.CanvasAlphaMode = "opaque"):
     # IDL: undefined configure(GPUCanvasConfiguration configuration); -> required GPUDevice device, required GPUTextureFormat format, GPUTextureUsageFlags usage = 0x10, sequence<GPUTextureFormat> viewFormats = [], PredefinedColorSpace colorSpace = "srgb", GPUCanvasToneMapping toneMapping = {}, GPUCanvasAlphaMode alphaMode = "opaque"
     def configure(
         self,
@@ -389,7 +387,6 @@ class GPUCanvasContext:
     ):
         raise NotImplementedError()
 
-    # FIXME: was unconfigure(self):
     # IDL: undefined unconfigure();
     def unconfigure(self) -> None:
         """Removes the presentation context configuration.
@@ -403,7 +400,6 @@ class GPUCanvasContext:
     def _unconfigure_screen(self):
         raise NotImplementedError()
 
-    # FIXME: was get_current_texture(self):
     # IDL: GPUTexture getCurrentTexture();
     def get_current_texture(self) -> GPUTexture:
         """Get the `GPUTexture` that will be composited to the canvas next."""
@@ -613,7 +609,6 @@ class GPUAdapter:
         """Information associated with this adapter."""
         return self._adapter_info
 
-    # FIXME: was request_device_sync(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {}); -> USVString label = "", sequence<GPUFeatureName> requiredFeatures = [], record<DOMString, (GPUSize64 or undefined)> requiredLimits = {}, GPUQueueDescriptor defaultQueue = {}
     def request_device_sync(
         self,
@@ -629,7 +624,6 @@ class GPUAdapter:
         """
         raise NotImplementedError()
 
-    # FIXME: was request_device_async(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {}); -> USVString label = "", sequence<GPUFeatureName> requiredFeatures = [], record<DOMString, (GPUSize64 or undefined)> requiredLimits = {}, GPUQueueDescriptor defaultQueue = {}
     async def request_device_async(
         self,
@@ -805,7 +799,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was destroy(self):
     # IDL: undefined destroy();
     def destroy(self) -> None:
         """Destroy this device.
@@ -876,7 +869,6 @@ class GPUDevice(GPUObjectBase):
         buf.unmap()
         return buf
 
-    # FIXME: was create_texture(self, *, label: str = "", size: Union[List[int], structs.Extent3D], mip_level_count: int = 1, sample_count: int = 1, dimension: enums.TextureDimension = "2d", format: enums.TextureFormat, usage: flags.TextureUsage, view_formats: List[enums.TextureFormat] = []):
     # IDL: GPUTexture createTexture(GPUTextureDescriptor descriptor); -> USVString label = "", required GPUExtent3D size, GPUIntegerCoordinate mipLevelCount = 1, GPUSize32 sampleCount = 1, GPUTextureDimension dimension = "2d", required GPUTextureFormat format, required GPUTextureUsageFlags usage, sequence<GPUTextureFormat> viewFormats = []
     def create_texture(
         self,
@@ -910,7 +902,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_sampler(self, *, label: str = "", address_mode_u: enums.AddressMode = "clamp-to-edge", address_mode_v: enums.AddressMode = "clamp-to-edge", address_mode_w: enums.AddressMode = "clamp-to-edge", mag_filter: enums.FilterMode = "nearest", min_filter: enums.FilterMode = "nearest", mipmap_filter: enums.MipmapFilterMode = "nearest", lod_min_clamp: float = 0, lod_max_clamp: float = 32, compare: enums.CompareFunction = optional, max_anisotropy: int = 1):
     # IDL: GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {}); -> USVString label = "", GPUAddressMode addressModeU = "clamp-to-edge", GPUAddressMode addressModeV = "clamp-to-edge", GPUAddressMode addressModeW = "clamp-to-edge", GPUFilterMode magFilter = "nearest", GPUFilterMode minFilter = "nearest", GPUMipmapFilterMode mipmapFilter = "nearest", float lodMinClamp = 0, float lodMaxClamp = 32, GPUCompareFunction compare, [Clamp] unsigned short maxAnisotropy = 1
     def create_sampler(
         self,
@@ -949,7 +940,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_bind_group_layout(self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]):
     # IDL: GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor); -> USVString label = "", required sequence<GPUBindGroupLayoutEntry> entries
     def create_bind_group_layout(
         self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]
@@ -987,7 +977,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_bind_group(self, *, label: str = "", layout: GPUBindGroupLayout, entries: List[structs.BindGroupEntry]):
     # IDL: GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor); -> USVString label = "", required GPUBindGroupLayout layout, required sequence<GPUBindGroupEntry> entries
     def create_bind_group(
         self,
@@ -1032,7 +1021,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_pipeline_layout(self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]):
     # IDL: GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor); -> USVString label = "", required sequence<GPUBindGroupLayout?> bindGroupLayouts
     def create_pipeline_layout(
         self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
@@ -1046,7 +1034,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_shader_module(self, *, label: str = "", code: str, compilation_hints: List[structs.ShaderModuleCompilationHint] = []):
     # IDL: GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor); -> USVString label = "", required USVString code, sequence<GPUShaderModuleCompilationHint> compilationHints = []
     def create_shader_module(
         self,
@@ -1070,7 +1057,6 @@ class GPUDevice(GPUObjectBase):
         # Noe: compilation_hints has been removed: https://github.com/webgpu-native/webgpu-headers/pull/337
         raise NotImplementedError()
 
-    # FIXME: was create_compute_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     # IDL: GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUProgrammableStage compute
     def create_compute_pipeline(
         self,
@@ -1088,7 +1074,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_compute_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     # IDL: Promise<GPUComputePipeline> createComputePipelineAsync(GPUComputePipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUProgrammableStage compute
     async def create_compute_pipeline_async(
         self,
@@ -1102,7 +1087,6 @@ class GPUDevice(GPUObjectBase):
         Both versions are compatible with WebGPU."""
         raise NotImplementedError()
 
-    # FIXME: was create_render_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     # IDL: GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUVertexState vertex, GPUPrimitiveState primitive = {}, GPUDepthStencilState depthStencil, GPUMultisampleState multisample = {}, GPUFragmentState fragment
     def create_render_pipeline(
         self,
@@ -1247,7 +1231,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_render_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     # IDL: Promise<GPURenderPipeline> createRenderPipelineAsync(GPURenderPipelineDescriptor descriptor); -> USVString label = "", required (GPUPipelineLayout or GPUAutoLayoutMode) layout, required GPUVertexState vertex, GPUPrimitiveState primitive = {}, GPUDepthStencilState depthStencil, GPUMultisampleState multisample = {}, GPUFragmentState fragment
     async def create_render_pipeline_async(
         self,
@@ -1265,7 +1248,6 @@ class GPUDevice(GPUObjectBase):
         Both versions are compatible with WebGPU."""
         raise NotImplementedError()
 
-    # FIXME: was create_command_encoder(self, *, label: str = ""):
     # IDL: GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {}); -> USVString label = ""
     def create_command_encoder(self, *, label: str = "") -> GPUCommandEncoder:
         """Create a `GPUCommandEncoder` object. A command
@@ -1277,7 +1259,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_render_bundle_encoder(self, *, label: str = "", color_formats: List[enums.TextureFormat], depth_stencil_format: enums.TextureFormat = optional, sample_count: int = 1, depth_read_only: bool = False, stencil_read_only: bool = False):
     # IDL: GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor); -> USVString label = "", required sequence<GPUTextureFormat?> colorFormats, GPUTextureFormat depthStencilFormat, GPUSize32 sampleCount = 1, boolean depthReadOnly = false, boolean stencilReadOnly = false
     def create_render_bundle_encoder(
         self,
@@ -1305,7 +1286,6 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
     # IDL: GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor); -> USVString label = "", required GPUQueryType type, required GPUSize32 count
     def create_query_set(
         self, *, label: str = "", type: enums.QueryType, count: int
@@ -1313,14 +1293,12 @@ class GPUDevice(GPUObjectBase):
         """Create a `GPUQuerySet` object."""
         raise NotImplementedError()
 
-    # FIXME: was push_error_scope(self, filter: enums.ErrorFilter):
     # IDL: undefined pushErrorScope(GPUErrorFilter filter);
     @apidiff.hide
     def push_error_scope(self, filter: enums.ErrorFilter) -> None:
         """Pushes a new GPU error scope onto the stack."""
         raise NotImplementedError()
 
-    # FIXME: was pop_error_scope_sync(self):
     # IDL: Promise<GPUError?> popErrorScope();
     @apidiff.hide
     def pop_error_scope_sync(self) -> GPUError:
@@ -1330,14 +1308,12 @@ class GPUDevice(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was pop_error_scope_async(self):
     # IDL: Promise<GPUError?> popErrorScope();
     @apidiff.hide
     async def pop_error_scope_async(self) -> GPUError:
         """Pops a GPU error scope from the stack."""
         raise NotImplementedError()
 
-    # FIXME: was import_external_texture(self, *, label: str = "", source: Union[memoryview, object], color_space: str = "srgb"):
     # IDL: GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor); -> USVString label = "", required (HTMLVideoElement or VideoFrame) source, PredefinedColorSpace colorSpace = "srgb"
     @apidiff.hide("Specific to browsers")
     def import_external_texture(
@@ -1408,7 +1384,6 @@ class GPUBuffer(GPUObjectBase):
     # but reading and writing data goes via method calls instead of via
     # an array-like object that exposes the shared memory.
 
-    # FIXME: was map_sync(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     # IDL: Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def map_sync(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
@@ -1419,7 +1394,6 @@ class GPUBuffer(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was map_async(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     # IDL: Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     async def map_async(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
@@ -1440,7 +1414,6 @@ class GPUBuffer(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was unmap(self):
     # IDL: undefined unmap();
     def unmap(self) -> None:
         """Unmaps the buffer.
@@ -1505,7 +1478,6 @@ class GPUBuffer(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was get_mapped_range(self, offset: int = 0, size: Optional[int] = None):
     # IDL: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     @apidiff.hide
     def get_mapped_range(
@@ -1513,7 +1485,6 @@ class GPUBuffer(GPUObjectBase):
     ) -> memoryview:
         raise NotImplementedError("The Python API differs from WebGPU here")
 
-    # FIXME: was destroy(self):
     # IDL: undefined destroy();
     def destroy(self) -> None:
         """Destroy the buffer.
@@ -1613,7 +1584,6 @@ class GPUTexture(GPUObjectBase):
         """The allowed usages for this texture."""
         return self._tex_info["usage"]
 
-    # FIXME: was create_view(self, *, label: str = "", format: enums.TextureFormat = optional, dimension: enums.TextureViewDimension = optional, usage: flags.TextureUsage = 0, aspect: enums.TextureAspect = "all", base_mip_level: int = 0, mip_level_count: int = optional, base_array_layer: int = 0, array_layer_count: int = optional):
     # IDL: GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {}); -> USVString label = "", GPUTextureFormat format, GPUTextureViewDimension dimension, GPUTextureUsageFlags usage = 0, GPUTextureAspect aspect = "all", GPUIntegerCoordinate baseMipLevel = 0, GPUIntegerCoordinate mipLevelCount, GPUIntegerCoordinate baseArrayLayer = 0, GPUIntegerCoordinate arrayLayerCount
     def create_view(
         self,
@@ -1649,7 +1619,6 @@ class GPUTexture(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was destroy(self):
     # IDL: undefined destroy();
     def destroy(self) -> None:
         """Destroy the texture.
@@ -1733,7 +1702,6 @@ class GPUShaderModule(GPUObjectBase):
     Create a shader module using `GPUDevice.create_shader_module()`.
     """
 
-    # FIXME: was get_compilation_info_sync(self):
     # IDL: Promise<GPUCompilationInfo> getCompilationInfo();
     def get_compilation_info_sync(self) -> GPUCompilationInfo:
         """Sync version of `get_compilation_info_async()`.
@@ -1742,7 +1710,6 @@ class GPUShaderModule(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was get_compilation_info_async(self):
     # IDL: Promise<GPUCompilationInfo> getCompilationInfo();
     async def get_compilation_info_async(self) -> GPUCompilationInfo:
         """Get shader compilation info. Always returns empty list at the moment."""
@@ -1754,7 +1721,6 @@ class GPUShaderModule(GPUObjectBase):
 class GPUPipelineBase:
     """A mixin class for render and compute pipelines."""
 
-    # FIXME: was get_bind_group_layout(self, index: int):
     # IDL: [NewObject] GPUBindGroupLayout getBindGroupLayout(unsigned long index);
     def get_bind_group_layout(self, index: int) -> GPUBindGroupLayout:
         """Get the bind group layout at the given index."""
@@ -1829,19 +1795,16 @@ class GPUBindingCommandsMixin:
 class GPUDebugCommandsMixin:
     """Mixin for classes that support debug groups and markers."""
 
-    # FIXME: was push_debug_group(self, group_label: str):
     # IDL: undefined pushDebugGroup(USVString groupLabel);
     def push_debug_group(self, group_label: str) -> None:
         """Push a named debug group into the command stream."""
         raise NotImplementedError()
 
-    # FIXME: was pop_debug_group(self):
     # IDL: undefined popDebugGroup();
     def pop_debug_group(self) -> None:
         """Pop the active debug group."""
         raise NotImplementedError()
 
-    # FIXME: was insert_debug_marker(self, marker_label: str):
     # IDL: undefined insertDebugMarker(USVString markerLabel);
     def insert_debug_marker(self, marker_label: str) -> None:
         """Insert the given message into the debug message queue."""
@@ -1851,7 +1814,6 @@ class GPUDebugCommandsMixin:
 class GPURenderCommandsMixin:
     """Mixin for classes that provide rendering commands."""
 
-    # FIXME: was set_pipeline(self, pipeline: GPURenderPipeline):
     # IDL: undefined setPipeline(GPURenderPipeline pipeline);
     def set_pipeline(self, pipeline: GPURenderPipeline) -> None:
         """Set the pipeline for this render pass.
@@ -1861,7 +1823,6 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
-    # FIXME: was set_index_buffer(self, buffer: GPUBuffer, index_format: enums.IndexFormat, offset: int = 0, size: Optional[int] = None):
     # IDL: undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def set_index_buffer(
         self,
@@ -1883,7 +1844,6 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
-    # FIXME: was set_vertex_buffer(self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     # IDL: undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer? buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def set_vertex_buffer(
         self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
@@ -1901,7 +1861,6 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
-    # FIXME: was draw(self, vertex_count: int, instance_count: int = 1, first_vertex: int = 0, first_instance: int = 0):
     # IDL: undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1, optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
     def draw(
         self,
@@ -1920,7 +1879,6 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
-    # FIXME: was draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     # IDL: undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
     def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int) -> None:
         """Like `draw()`, but the function arguments are in a buffer.
@@ -1933,7 +1891,6 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
-    # FIXME: was draw_indexed(self, index_count: int, instance_count: int = 1, first_index: int = 0, base_vertex: int = 0, first_instance: int = 0):
     # IDL: undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1, optional GPUSize32 firstIndex = 0, optional GPUSignedOffset32 baseVertex = 0, optional GPUSize32 firstInstance = 0);
     def draw_indexed(
         self,
@@ -1956,7 +1913,6 @@ class GPURenderCommandsMixin:
         """
         raise NotImplementedError()
 
-    # FIXME: was draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     # IDL: undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
     def draw_indexed_indirect(
         self, indirect_buffer: GPUBuffer, indirect_offset: int
@@ -1979,7 +1935,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
     Create a command encoder using `GPUDevice.create_command_encoder()`.
     """
 
-    # FIXME: was begin_compute_pass(self, *, label: str = "", timestamp_writes: structs.ComputePassTimestampWrites = optional):
     # IDL: GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {}); -> USVString label = "", GPUComputePassTimestampWrites timestampWrites
     def begin_compute_pass(
         self,
@@ -1996,7 +1951,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was begin_render_pass(self, *, label: str = "", color_attachments: List[structs.RenderPassColorAttachment], depth_stencil_attachment: structs.RenderPassDepthStencilAttachment = optional, occlusion_query_set: GPUQuerySet = optional, timestamp_writes: structs.RenderPassTimestampWrites = optional, max_draw_count: int = 50000000):
     # IDL: GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor); -> USVString label = "", required sequence<GPURenderPassColorAttachment?> colorAttachments, GPURenderPassDepthStencilAttachment depthStencilAttachment, GPUQuerySet occlusionQuerySet, GPURenderPassTimestampWrites timestampWrites, GPUSize64 maxDrawCount = 50000000
     def begin_render_pass(
         self,
@@ -2020,7 +1974,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was clear_buffer(self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     # IDL: undefined clearBuffer( GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def clear_buffer(
         self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
@@ -2036,7 +1989,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was copy_buffer_to_buffer(self, source: GPUBuffer, source_offset: int, destination: GPUBuffer, destination_offset: int, size: int):
     # IDL: undefined copyBufferToBuffer( GPUBuffer source, GPUSize64 sourceOffset, GPUBuffer destination, GPUSize64 destinationOffset, GPUSize64 size);
     def copy_buffer_to_buffer(
         self,
@@ -2059,7 +2011,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was copy_buffer_to_texture(self, source: structs.TexelCopyBufferInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyBufferToTexture( GPUTexelCopyBufferInfo source, GPUTexelCopyTextureInfo destination, GPUExtent3D copySize);
     def copy_buffer_to_texture(
         self,
@@ -2078,7 +2029,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was copy_texture_to_buffer(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyBufferInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyTextureToBuffer( GPUTexelCopyTextureInfo source, GPUTexelCopyBufferInfo destination, GPUExtent3D copySize);
     def copy_texture_to_buffer(
         self,
@@ -2097,7 +2047,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was copy_texture_to_texture(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyTextureToTexture( GPUTexelCopyTextureInfo source, GPUTexelCopyTextureInfo destination, GPUExtent3D copySize);
     def copy_texture_to_texture(
         self,
@@ -2114,7 +2063,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was finish(self, *, label: str = ""):
     # IDL: GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {}); -> USVString label = ""
     def finish(self, *, label: str = "") -> GPUCommandBuffer:
         """Finish recording. Returns a `GPUCommandBuffer` to
@@ -2125,7 +2073,6 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was resolve_query_set(self, query_set: GPUQuerySet, first_query: int, query_count: int, destination: GPUBuffer, destination_offset: int):
     # IDL: undefined resolveQuerySet( GPUQuerySet querySet, GPUSize32 firstQuery, GPUSize32 queryCount, GPUBuffer destination, GPUSize64 destinationOffset);
     def resolve_query_set(
         self,
@@ -2158,7 +2105,6 @@ class GPUComputePassEncoder(
     Create a compute pass encoder using `GPUCommandEncoder.begin_compute_pass()`.
     """
 
-    # FIXME: was set_pipeline(self, pipeline: GPUComputePipeline):
     # IDL: undefined setPipeline(GPUComputePipeline pipeline);
     def set_pipeline(self, pipeline: GPUComputePipeline) -> None:
         """Set the pipeline for this compute pass.
@@ -2168,7 +2114,6 @@ class GPUComputePassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was dispatch_workgroups(self, workgroup_count_x: int, workgroup_count_y: int = 1, workgroup_count_z: int = 1):
     # IDL: undefined dispatchWorkgroups(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
     def dispatch_workgroups(
         self,
@@ -2185,7 +2130,6 @@ class GPUComputePassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was dispatch_workgroups_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     # IDL: undefined dispatchWorkgroupsIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
     def dispatch_workgroups_indirect(
         self, indirect_buffer: GPUBuffer, indirect_offset: int
@@ -2198,7 +2142,6 @@ class GPUComputePassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was end(self):
     # IDL: undefined end();
     def end(self) -> None:
         """Record the end of the compute pass."""
@@ -2217,7 +2160,6 @@ class GPURenderPassEncoder(
     Create a render pass encoder using `GPUCommandEncoder.begin_render_pass`.
     """
 
-    # FIXME: was set_viewport(self, x: float, y: float, width: float, height: float, min_depth: float, max_depth: float):
     # IDL: undefined setViewport(float x, float y, float width, float height, float minDepth, float maxDepth);
     def set_viewport(
         self,
@@ -2242,7 +2184,6 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was set_scissor_rect(self, x: int, y: int, width: int, height: int):
     # IDL: undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,  GPUIntegerCoordinate width, GPUIntegerCoordinate height);
     def set_scissor_rect(self, x: int, y: int, width: int, height: int) -> None:
         """Set the scissor rectangle for this render pass. The scene
@@ -2256,7 +2197,6 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was set_blend_constant(self, color: Union[List[float], structs.Color]):
     # IDL: undefined setBlendConstant(GPUColor color);
     def set_blend_constant(self, color: Union[List[float], structs.Color]) -> None:
         """Set the blend color for the render pass.
@@ -2266,7 +2206,6 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was set_stencil_reference(self, reference: int):
     # IDL: undefined setStencilReference(GPUStencilValue reference);
     def set_stencil_reference(self, reference: int) -> None:
         """Set the reference stencil value for this render pass.
@@ -2276,7 +2215,6 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was execute_bundles(self, bundles: List[GPURenderBundle]):
     # IDL: undefined executeBundles(sequence<GPURenderBundle> bundles);
     def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
         """Executes commands previously recorded into the render bundles
@@ -2287,13 +2225,11 @@ class GPURenderPassEncoder(
         """
         raise NotImplementedError()
 
-    # FIXME: was end(self):
     # IDL: undefined end();
     def end(self) -> None:
         """Record the end of the render pass."""
         raise NotImplementedError()
 
-    # FIXME: was begin_occlusion_query(self, query_index: int):
     # IDL: undefined beginOcclusionQuery(GPUSize32 queryIndex);
     def begin_occlusion_query(self, query_index: int) -> None:
         """Begins an occlusion query.
@@ -2306,7 +2242,6 @@ class GPURenderPassEncoder(
 
         raise NotImplementedError()
 
-    # FIXME: was end_occlusion_query(self):
     # IDL: undefined endOcclusionQuery();
     def end_occlusion_query(self) -> None:
         """Ends an occlusion query."""
@@ -2328,7 +2263,6 @@ class GPURenderBundleEncoder(
 ):
     """Encodes a series of render commands into a reusable render bundle."""
 
-    # FIXME: was finish(self, *, label: str = ""):
     # IDL: GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {}); -> USVString label = ""
     def finish(self, *, label: str = "") -> GPURenderBundle:
         """Finish recording and return a `GPURenderBundle`.
@@ -2345,7 +2279,6 @@ class GPUQueue(GPUObjectBase):
     You can obtain a queue object via the :attr:`GPUDevice.queue` property.
     """
 
-    # FIXME: was submit(self, command_buffers: List[GPUCommandBuffer]):
     # IDL: undefined submit(sequence<GPUCommandBuffer> commandBuffers);
     def submit(self, command_buffers: List[GPUCommandBuffer]) -> None:
         """Submit a `GPUCommandBuffer` to the queue.
@@ -2355,7 +2288,6 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was write_buffer(self, buffer: GPUBuffer, buffer_offset: int, data: memoryview, data_offset: int = 0, size: Optional[int] = None):
     # IDL: undefined writeBuffer( GPUBuffer buffer, GPUSize64 bufferOffset, AllowSharedBufferSource data, optional GPUSize64 dataOffset = 0, optional GPUSize64 size);
     def write_buffer(
         self,
@@ -2406,7 +2338,6 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was write_texture(self, destination: structs.TexelCopyTextureInfo, data: memoryview, data_layout: structs.TexelCopyBufferLayout, size: Union[List[int], structs.Extent3D]):
     # IDL: undefined writeTexture( GPUTexelCopyTextureInfo destination, AllowSharedBufferSource data, GPUTexelCopyBufferLayout dataLayout, GPUExtent3D size);
     def write_texture(
         self,
@@ -2454,7 +2385,6 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was copy_external_image_to_texture(self, source: structs.CopyExternalImageSourceInfo, destination: structs.CopyExternalImageDestInfo, copy_size: Union[List[int], structs.Extent3D]):
     # IDL: undefined copyExternalImageToTexture( GPUCopyExternalImageSourceInfo source, GPUCopyExternalImageDestInfo destination, GPUExtent3D copySize);
     @apidiff.hide("Specific to browsers")
     def copy_external_image_to_texture(
@@ -2465,7 +2395,6 @@ class GPUQueue(GPUObjectBase):
     ) -> None:
         raise NotImplementedError()
 
-    # FIXME: was on_submitted_work_done_sync(self):
     # IDL: Promise<undefined> onSubmittedWorkDone();
     def on_submitted_work_done_sync(self) -> None:
         """Sync version of `on_submitted_work_done_async()`.
@@ -2474,7 +2403,6 @@ class GPUQueue(GPUObjectBase):
         """
         raise NotImplementedError()
 
-    # FIXME: was on_submitted_work_done_async(self):
     # IDL: Promise<undefined> onSubmittedWorkDone();
     async def on_submitted_work_done_async(self) -> None:
         """TODO"""
@@ -2522,8 +2450,6 @@ class GPUError(Exception):
 class GPUOutOfMemoryError(GPUError, MemoryError):
     """An error raised when the GPU is out of memory."""
 
-    # FIXME: was __init__(self, message: str):
-    # FIXME: was __init__(self, message: str) -> str:
     # IDL: constructor(DOMString message);
     def __init__(self, message: str):
         super().__init__(message or "GPU is out of memory.")
@@ -2532,8 +2458,6 @@ class GPUOutOfMemoryError(GPUError, MemoryError):
 class GPUValidationError(GPUError):
     """An error raised when the pipeline could not be validated."""
 
-    # FIXME: was __init__(self, message: str):
-    # FIXME: was __init__(self, message: str) -> str:
     # IDL: constructor(DOMString message);
     def __init__(self, message: str):
         super().__init__(message)
@@ -2542,8 +2466,6 @@ class GPUValidationError(GPUError):
 class GPUPipelineError(Exception):
     """An error raised when a pipeline could not be created."""
 
-    # FIXME: was __init__(self, message: str, options: structs.PipelineErrorInit):
-    # FIXME: was __init__(self, message: str, options: structs.PipelineErrorInit) -> str:
     # IDL: constructor(optional DOMString message = "", GPUPipelineErrorInit options);
     def __init__(self, message: str, options: structs.PipelineErrorInit):
         super().__init__(message or "")
@@ -2563,8 +2485,6 @@ class GPUInternalError(GPUError):
     reason even when all validation requirements have been satisfied.
     """
 
-    # FIXME: was __init__(self, message: str):
-    # FIXME: was __init__(self, message: str) -> str:
     # IDL: constructor(DOMString message);
     def __init__(self, message: str):
         super().__init__(message)
@@ -2646,7 +2566,6 @@ class GPUQuerySet(GPUObjectBase):
         """The number of the queries managed by this queryset."""
         return self._count
 
-    # FIXME: was destroy(self):
     # IDL: undefined destroy();
     def destroy(self) -> None:
         """Destroy the QuerySet.

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1003,6 +1003,7 @@ class GPUAdapterInfo(classes.GPUAdapterInfo):
 
 
 class GPUAdapter(classes.GPUAdapter):
+    # FIXME: was request_device_sync(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     def request_device_sync(
         self,
         *,
@@ -1010,7 +1011,7 @@ class GPUAdapter(classes.GPUAdapter):
         required_features: List[enums.FeatureName] = [],
         required_limits: Dict[str, Union[None, int]] = {},
         default_queue: structs.QueueDescriptor = {},
-    ):
+    ) -> GPUDevice:
         check_can_use_sync_variants()
         if default_queue:
             check_struct("QueueDescriptor", default_queue)
@@ -1019,6 +1020,7 @@ class GPUAdapter(classes.GPUAdapter):
         )
         return awaitable.sync_wait()
 
+    # FIXME: was request_device_async(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     async def request_device_async(
         self,
         *,
@@ -1026,7 +1028,7 @@ class GPUAdapter(classes.GPUAdapter):
         required_features: List[enums.FeatureName] = [],
         required_limits: Dict[str, Union[None, int]] = {},
         default_queue: structs.QueueDescriptor = {},
-    ):
+    ) -> GPUDevice:
         if default_queue:
             check_struct("QueueDescriptor", default_queue)
         awaitable = self._request_device(
@@ -1307,6 +1309,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
             # H: WGPUBool f(WGPUDevice device, WGPUBool wait, WGPUSubmissionIndex const * wrappedSubmissionIndex)
             libf.wgpuDevicePoll(self._internal, True, ffi.NULL)
 
+    # FIXME: was create_buffer(self, *, label: str = "", size: int, usage: flags.BufferUsage, mapped_at_creation: bool = False):
     def create_buffer(
         self,
         *,
@@ -1314,7 +1317,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         size: int,
         usage: flags.BufferUsage,
         mapped_at_creation: bool = False,
-    ):
+    ) -> GPUBuffer:
         return self._create_buffer(label, int(size), usage, bool(mapped_at_creation))
 
     def _create_buffer(self, label, size, usage, mapped_at_creation):
@@ -1342,6 +1345,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         # Return wrapped buffer
         return GPUBuffer(label, id, self, size, usage, map_state)
 
+    # FIXME: was create_texture(self, *, label: str = "", size: Union[List[int], structs.Extent3D], mip_level_count: int = 1, sample_count: int = 1, dimension: enums.TextureDimension = "2d", format: enums.TextureFormat, usage: flags.TextureUsage, view_formats: List[enums.TextureFormat] = []):
     def create_texture(
         self,
         *,
@@ -1353,7 +1357,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         format: enums.TextureFormat,
         usage: flags.TextureUsage,
         view_formats: List[enums.TextureFormat] = [],
-    ):
+    ) -> GPUTexture:
         if isinstance(usage, str):
             usage = str_flag_to_int(flags.TextureUsage, usage)
         usage = int(usage)
@@ -1416,6 +1420,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         }
         return GPUTexture(label, id, self, tex_info)
 
+    # FIXME: was create_sampler(self, *, label: str = "", address_mode_u: enums.AddressMode = "clamp-to-edge", address_mode_v: enums.AddressMode = "clamp-to-edge", address_mode_w: enums.AddressMode = "clamp-to-edge", mag_filter: enums.FilterMode = "nearest", min_filter: enums.FilterMode = "nearest", mipmap_filter: enums.MipmapFilterMode = "nearest", lod_min_clamp: float = 0, lod_max_clamp: float = 32, compare: enums.CompareFunction = optional, max_anisotropy: int = 1):
     def create_sampler(
         self,
         *,
@@ -1430,7 +1435,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         lod_max_clamp: float = 32,
         compare: enums.CompareFunction = optional,
         max_anisotropy: int = 1,
-    ):
+    ) -> GPUSampler:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView, addressModeU: WGPUAddressMode, addressModeV: WGPUAddressMode, addressModeW: WGPUAddressMode, magFilter: WGPUFilterMode, minFilter: WGPUFilterMode, mipmapFilter: WGPUMipmapFilterMode, lodMinClamp: float, lodMaxClamp: float, compare: WGPUCompareFunction, maxAnisotropy: int
         struct = new_struct_p(
             "WGPUSamplerDescriptor *",
@@ -1452,9 +1457,10 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateSampler(self._internal, struct)
         return GPUSampler(label, id, self)
 
+    # FIXME: was create_bind_group_layout(self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]):
     def create_bind_group_layout(
         self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]
-    ):
+    ) -> GPUBindGroupLayout:
         c_entries_list = []
         for entry in entries:
             check_struct("BindGroupLayoutEntry", entry)
@@ -1558,13 +1564,14 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateBindGroupLayout(self._internal, struct)
         return GPUBindGroupLayout(label, id, self)
 
+    # FIXME: was create_bind_group(self, *, label: str = "", layout: GPUBindGroupLayout, entries: List[structs.BindGroupEntry]):
     def create_bind_group(
         self,
         *,
         label: str = "",
         layout: GPUBindGroupLayout,
         entries: List[structs.BindGroupEntry],
-    ):
+    ) -> GPUBindGroup:
         c_entries_list = []
         for entry in entries:
             check_struct("BindGroupEntry", entry)
@@ -1624,9 +1631,10 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateBindGroup(self._internal, struct)
         return GPUBindGroup(label, id, self)
 
+    # FIXME: was create_pipeline_layout(self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]):
     def create_pipeline_layout(
         self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
-    ):
+    ) -> GPUPipelineLayout:
         return self._create_pipeline_layout(label, bind_group_layouts, [])
 
     def _create_pipeline_layout(
@@ -1675,13 +1683,14 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreatePipelineLayout(self._internal, struct)
         return GPUPipelineLayout(label, id, self)
 
+    # FIXME: was create_shader_module(self, *, label: str = "", code: str, compilation_hints: List[structs.ShaderModuleCompilationHint] = []):
     def create_shader_module(
         self,
         *,
         label: str = "",
         code: str,
         compilation_hints: List[structs.ShaderModuleCompilationHint] = [],
-    ):
+    ) -> GPUShaderModule:
         if False:
             # Trick the check_struct check in the codegen.
             # Compilation_hint are not used, but part of the WebGPU API (for now)
@@ -1772,25 +1781,27 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
             raise RuntimeError("Shader module creation failed")
         return GPUShaderModule(label, id, self)
 
+    # FIXME: was create_compute_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     def create_compute_pipeline(
         self,
         *,
         label: str = "",
         layout: Union[GPUPipelineLayout, enums.AutoLayoutMode],
         compute: structs.ProgrammableStage,
-    ):
+    ) -> GPUComputePipeline:
         descriptor = self._create_compute_pipeline_descriptor(label, layout, compute)
         # H: WGPUComputePipeline f(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor)
         id = libf.wgpuDeviceCreateComputePipeline(self._internal, descriptor)
         return GPUComputePipeline(label, id, self)
 
+    # FIXME: was create_compute_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     async def create_compute_pipeline_async(
         self,
         *,
         label: str = "",
         layout: Union[GPUPipelineLayout, enums.AutoLayoutMode],
         compute: structs.ProgrammableStage,
-    ):
+    ) -> GPUComputePipeline:
         descriptor = self._create_compute_pipeline_descriptor(label, layout, compute)
 
         if not self._CREATE_PIPELINE_ASYNC_IS_IMPLEMENTED:
@@ -1871,6 +1882,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         )
         return struct
 
+    # FIXME: was create_render_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     def create_render_pipeline(
         self,
         *,
@@ -1881,7 +1893,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         depth_stencil: structs.DepthStencilState = optional,
         multisample: structs.MultisampleState = {},
         fragment: structs.FragmentState = optional,
-    ):
+    ) -> GPURenderPipeline:
         descriptor = self._create_render_pipeline_descriptor(
             label, layout, vertex, primitive, depth_stencil, multisample, fragment
         )
@@ -1889,6 +1901,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateRenderPipeline(self._internal, descriptor)
         return GPURenderPipeline(label, id, self)
 
+    # FIXME: was create_render_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     async def create_render_pipeline_async(
         self,
         *,
@@ -1899,7 +1912,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         depth_stencil: structs.DepthStencilState = optional,
         multisample: structs.MultisampleState = {},
         fragment: structs.FragmentState = optional,
-    ):
+    ) -> GPURenderPipeline:
         # TODO: wgpuDeviceCreateRenderPipelineAsync is not yet implemented in wgpu-native
         descriptor = self._create_render_pipeline_descriptor(
             label, layout, vertex, primitive, depth_stencil, multisample, fragment
@@ -2151,7 +2164,8 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         )
         return c_depth_stencil_state
 
-    def create_command_encoder(self, *, label: str = ""):
+    # FIXME: was create_command_encoder(self, *, label: str = ""):
+    def create_command_encoder(self, *, label: str = "") -> GPUCommandEncoder:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView
         struct = new_struct_p(
             "WGPUCommandEncoderDescriptor *",
@@ -2163,6 +2177,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateCommandEncoder(self._internal, struct)
         return GPUCommandEncoder(label, id, self)
 
+    # FIXME: was create_render_bundle_encoder(self, *, label: str = "", color_formats: List[enums.TextureFormat], depth_stencil_format: enums.TextureFormat = optional, sample_count: int = 1, depth_read_only: bool = False, stencil_read_only: bool = False):
     def create_render_bundle_encoder(
         self,
         *,
@@ -2172,7 +2187,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         sample_count: int = 1,
         depth_read_only: bool = False,
         stencil_read_only: bool = False,
-    ):
+    ) -> GPURenderBundleEncoder:
         c_color_formats, color_formats_count = ffi.NULL, 0
         if color_formats:
             color_formats_list = [enummap["TextureFormat." + x] for x in color_formats]
@@ -2199,7 +2214,10 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         result._objects_to_keep_alive = set()
         return result
 
-    def create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
+    # FIXME: was create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
+    def create_query_set(
+        self, *, label: str = "", type: enums.QueryType, count: int
+    ) -> GPUQuerySet:
         return self._create_query_set(label, type, count, None)
 
     def _create_statistics_query_set(self, label, count, statistics):
@@ -2251,7 +2269,8 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
     async def _get_lost_async(self):
         raise NotImplementedError()
 
-    def destroy(self):
+    # FIXME: was destroy(self):
+    def destroy(self) -> None:
         # Note: not yet implemented in wgpu-core, the wgpu-native func is a noop
         internal = self._internal
         if internal is not None:
@@ -2309,16 +2328,18 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
             raise ValueError("Mapped range must not extend beyond total buffer size.")
         return offset, size
 
+    # FIXME: was map_sync(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     def map_sync(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         check_can_use_sync_variants()
         awaitable = self._map(mode, offset, size)
         return awaitable.sync_wait()
 
+    # FIXME: was map_async(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     async def map_async(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         awaitable = self._map(mode, offset, size)  # for now
         return await awaitable
 
@@ -2390,7 +2411,8 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
 
         return awaitable
 
-    def unmap(self):
+    # FIXME: was unmap(self):
+    def unmap(self) -> None:
         if self._map_state != enums.BufferMapState.mapped:
             raise RuntimeError("Can only unmap a buffer if its currently mapped.")
         # H: void f(WGPUBuffer buffer)
@@ -2496,7 +2518,8 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
 
         return src_m
 
-    def destroy(self):
+    # FIXME: was destroy(self):
+    def destroy(self) -> None:
         # NOTE: destroy means that the wgpu-core object gets into a destroyed
         # state. The wgpu-core object still exists. So destroying is quite
         # different from releasing.
@@ -2514,6 +2537,7 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuTextureRelease
 
+    # FIXME: was create_view(self, *, label: str = "", format: enums.TextureFormat = optional, dimension: enums.TextureViewDimension = optional, usage: flags.TextureUsage = 0, aspect: enums.TextureAspect = "all", base_mip_level: int = 0, mip_level_count: int = optional, base_array_layer: int = 0, array_layer_count: int = optional):
     def create_view(
         self,
         *,
@@ -2526,7 +2550,7 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
         mip_level_count: int = optional,
         base_array_layer: int = 0,
         array_layer_count: int = optional,
-    ):
+    ) -> GPUTextureView:
         # Resolve defaults
         if not format:
             format = self._tex_info["format"]
@@ -2567,7 +2591,8 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
         id = libf.wgpuTextureCreateView(self._internal, struct)
         return GPUTextureView(label, id, self._device, self, self.size)
 
-    def destroy(self):
+    # FIXME: was destroy(self):
+    def destroy(self) -> None:
         internal = self._internal
         if internal is not None:
             # H: void f(WGPUTexture texture)
@@ -2603,11 +2628,13 @@ class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuShaderModuleRelease
 
-    def get_compilation_info_sync(self):
+    # FIXME: was get_compilation_info_sync(self):
+    def get_compilation_info_sync(self) -> GPUCompilationInfo:
         check_can_use_sync_variants()
         return self._get_compilation_info()
 
-    async def get_compilation_info_async(self):
+    # FIXME: was get_compilation_info_async(self):
+    async def get_compilation_info_async(self) -> GPUCompilationInfo:
         return self._get_compilation_info()
 
     def _get_compilation_info(self):
@@ -2643,7 +2670,8 @@ class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
 
 
 class GPUPipelineBase(classes.GPUPipelineBase):
-    def get_bind_group_layout(self, index: int):
+    # FIXME: was get_bind_group_layout(self, index: int):
+    def get_bind_group_layout(self, index: int) -> GPUBindGroupLayout:
         # H: WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex)
         # H: WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex)
         function = type(self)._get_bind_group_layout_function
@@ -2776,7 +2804,8 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
 
 class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
     # whole class is likely going to be solved better: https://github.com/pygfx/wgpu-py/pull/546
-    def push_debug_group(self, group_label: str):
+    # FIXME: was push_debug_group(self, group_label: str):
+    def push_debug_group(self, group_label: str) -> None:
         c_group_label = to_c_string_view(group_label)
         # H: void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, WGPUStringView groupLabel)
         # H: void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, WGPUStringView groupLabel)
@@ -2785,7 +2814,8 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
         function = type(self)._push_debug_group_function
         function(self._internal, c_group_label)
 
-    def pop_debug_group(self):
+    # FIXME: was pop_debug_group(self):
+    def pop_debug_group(self) -> None:
         # H: void wgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder)
         # H: void wgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder)
         # H: void wgpuRenderPassEncoderPopDebugGroup(WGPURenderPassEncoder renderPassEncoder)
@@ -2793,7 +2823,8 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
         function = type(self)._pop_debug_group_function
         function(self._internal)
 
-    def insert_debug_marker(self, marker_label: str):
+    # FIXME: was insert_debug_marker(self, marker_label: str):
+    def insert_debug_marker(self, marker_label: str) -> None:
         c_marker_label = to_c_string_view(marker_label)
         # H: void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, WGPUStringView markerLabel)
         # H: void wgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder computePassEncoder, WGPUStringView markerLabel)
@@ -2815,7 +2846,8 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
 
 
 class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
-    def set_pipeline(self, pipeline: GPURenderPipeline):
+    # FIXME: was set_pipeline(self, pipeline: GPURenderPipeline):
+    def set_pipeline(self, pipeline: GPURenderPipeline) -> None:
         self._maybe_keep_alive(pipeline)
         pipeline_id = pipeline._internal
         # H: void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline)
@@ -2823,13 +2855,14 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         function = type(self)._set_pipeline_function
         function(self._internal, pipeline_id)
 
+    # FIXME: was set_index_buffer(self, buffer: GPUBuffer, index_format: enums.IndexFormat, offset: int = 0, size: Optional[int] = None):
     def set_index_buffer(
         self,
         buffer: GPUBuffer,
         index_format: enums.IndexFormat,
         offset: int = 0,
         size: Optional[int] = None,
-    ):
+    ) -> None:
         self._maybe_keep_alive(buffer)
         if not size:
             size = lib.WGPU_WHOLE_SIZE
@@ -2841,9 +2874,10 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
             self._internal, buffer._internal, c_index_format, int(offset), int(size)
         )
 
+    # FIXME: was set_vertex_buffer(self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     def set_vertex_buffer(
         self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         self._maybe_keep_alive(buffer)
         if not size:
             size = lib.WGPU_WHOLE_SIZE
@@ -2852,13 +2886,14 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         function = type(self)._set_vertex_buffer_function
         function(self._internal, int(slot), buffer._internal, int(offset), int(size))
 
+    # FIXME: was draw(self, vertex_count: int, instance_count: int = 1, first_vertex: int = 0, first_instance: int = 0):
     def draw(
         self,
         vertex_count: int,
         instance_count: int = 1,
         first_vertex: int = 0,
         first_instance: int = 0,
-    ):
+    ) -> None:
         # H: void wgpuRenderPassEncoderDraw(WGPURenderPassEncoder renderPassEncoder, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance)
         # H: void wgpuRenderBundleEncoderDraw(WGPURenderBundleEncoder renderBundleEncoder, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance)
         function = type(self)._draw_function
@@ -2866,7 +2901,8 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
             self._internal, vertex_count, instance_count, first_vertex, first_instance
         )
 
-    def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+    # FIXME: was draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+    def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int) -> None:
         self._maybe_keep_alive(indirect_buffer)
         buffer_id = indirect_buffer._internal
         # H: void wgpuRenderPassEncoderDrawIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
@@ -2874,6 +2910,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         function = type(self)._draw_indirect_function
         function(self._internal, buffer_id, int(indirect_offset))
 
+    # FIXME: was draw_indexed(self, index_count: int, instance_count: int = 1, first_index: int = 0, base_vertex: int = 0, first_instance: int = 0):
     def draw_indexed(
         self,
         index_count: int,
@@ -2881,7 +2918,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         first_index: int = 0,
         base_vertex: int = 0,
         first_instance: int = 0,
-    ):
+    ) -> None:
         # H: void wgpuRenderPassEncoderDrawIndexed(WGPURenderPassEncoder renderPassEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance)
         # H: void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance)
         function = type(self)._draw_indexed_function
@@ -2894,7 +2931,10 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
             first_instance,
         )
 
-    def draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+    # FIXME: was draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
+    def draw_indexed_indirect(
+        self, indirect_buffer: GPUBuffer, indirect_offset: int
+    ) -> None:
         self._maybe_keep_alive(indirect_buffer)
         buffer_id = indirect_buffer._internal
         # H: void wgpuRenderPassEncoderDrawIndexedIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
@@ -2915,12 +2955,13 @@ class GPUCommandEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuCommandEncoderRelease
 
+    # FIXME: was begin_compute_pass(self, *, label: str = "", timestamp_writes: structs.ComputePassTimestampWrites = optional):
     def begin_compute_pass(
         self,
         *,
         label: str = "",
         timestamp_writes: structs.ComputePassTimestampWrites = optional,
-    ):
+    ) -> GPUComputePassEncoder:
         c_timestamp_writes_struct = ffi.NULL
         if timestamp_writes is not None:
             check_struct("ComputePassTimestampWrites", timestamp_writes)
@@ -2947,6 +2988,7 @@ class GPUCommandEncoder(
         encoder = GPUComputePassEncoder(label, raw_encoder, self._device)
         return encoder
 
+    # FIXME: was begin_render_pass(self, *, label: str = "", color_attachments: List[structs.RenderPassColorAttachment], depth_stencil_attachment: structs.RenderPassDepthStencilAttachment = optional, occlusion_query_set: GPUQuerySet = optional, timestamp_writes: structs.RenderPassTimestampWrites = optional, max_draw_count: int = 50000000):
     def begin_render_pass(
         self,
         *,
@@ -2956,7 +2998,7 @@ class GPUCommandEncoder(
         occlusion_query_set: GPUQuerySet = optional,
         timestamp_writes: structs.RenderPassTimestampWrites = optional,
         max_draw_count: int = 50000000,
-    ):
+    ) -> GPURenderPassEncoder:
         c_timestamp_writes_struct = ffi.NULL
         if timestamp_writes is not None:
             check_struct("RenderPassTimestampWrites", timestamp_writes)
@@ -3104,9 +3146,10 @@ class GPUCommandEncoder(
         )
         return c_depth_stencil_attachment
 
+    # FIXME: was clear_buffer(self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     def clear_buffer(
         self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
-    ):
+    ) -> None:
         offset = int(offset)
         if offset % 4 != 0:  # pragma: no cover
             raise ValueError("offset must be a multiple of 4")
@@ -3128,6 +3171,7 @@ class GPUCommandEncoder(
             self._internal, buffer._internal, offset, size
         )
 
+    # FIXME: was copy_buffer_to_buffer(self, source: GPUBuffer, source_offset: int, destination: GPUBuffer, destination_offset: int, size: int):
     def copy_buffer_to_buffer(
         self,
         source: GPUBuffer,
@@ -3135,7 +3179,7 @@ class GPUCommandEncoder(
         destination: GPUBuffer,
         destination_offset: int,
         size: int,
-    ):
+    ) -> None:
         if source_offset % 4 != 0:  # pragma: no cover
             raise ValueError("source_offset must be a multiple of 4")
         if destination_offset % 4 != 0:  # pragma: no cover
@@ -3157,12 +3201,13 @@ class GPUCommandEncoder(
             int(size),
         )
 
+    # FIXME: was copy_buffer_to_texture(self, source: structs.TexelCopyBufferInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     def copy_buffer_to_texture(
         self,
         source: structs.TexelCopyBufferInfo,
         destination: structs.TexelCopyTextureInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         check_struct("TexelCopyBufferInfo", source)
         check_struct("TexelCopyTextureInfo", destination)
 
@@ -3223,12 +3268,13 @@ class GPUCommandEncoder(
             c_copy_size,
         )
 
+    # FIXME: was copy_texture_to_buffer(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyBufferInfo, copy_size: Union[List[int], structs.Extent3D]):
     def copy_texture_to_buffer(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyBufferInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         check_struct("TexelCopyTextureInfo", source)
         check_struct("TexelCopyBufferInfo", destination)
 
@@ -3289,12 +3335,13 @@ class GPUCommandEncoder(
             c_copy_size,
         )
 
+    # FIXME: was copy_texture_to_texture(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     def copy_texture_to_texture(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyTextureInfo,
         copy_size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         check_struct("TexelCopyTextureInfo", source)
         check_struct("TexelCopyTextureInfo", destination)
 
@@ -3354,7 +3401,8 @@ class GPUCommandEncoder(
             c_copy_size,
         )
 
-    def finish(self, *, label: str = ""):
+    # FIXME: was finish(self, *, label: str = ""):
+    def finish(self, *, label: str = "") -> GPUCommandBuffer:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView
         struct = new_struct_p(
             "WGPUCommandBufferDescriptor *",
@@ -3366,6 +3414,7 @@ class GPUCommandEncoder(
 
         return GPUCommandBuffer(label, id, self._device)
 
+    # FIXME: was resolve_query_set(self, query_set: GPUQuerySet, first_query: int, query_count: int, destination: GPUBuffer, destination_offset: int):
     def resolve_query_set(
         self,
         query_set: GPUQuerySet,
@@ -3373,7 +3422,7 @@ class GPUCommandEncoder(
         query_count: int,
         destination: GPUBuffer,
         destination_offset: int,
-    ):
+    ) -> None:
         # H: void f(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t firstQuery, uint32_t queryCount, WGPUBuffer destination, uint64_t destinationOffset)
         libf.wgpuCommandEncoderResolveQuerySet(
             self._internal,
@@ -3407,32 +3456,36 @@ class GPUComputePassEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuComputePassEncoderRelease
 
-    def set_pipeline(self, pipeline: GPUComputePipeline):
+    # FIXME: was set_pipeline(self, pipeline: GPUComputePipeline):
+    def set_pipeline(self, pipeline: GPUComputePipeline) -> None:
         pipeline_id = pipeline._internal
         # H: void f(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline)
         libf.wgpuComputePassEncoderSetPipeline(self._internal, pipeline_id)
 
+    # FIXME: was dispatch_workgroups(self, workgroup_count_x: int, workgroup_count_y: int = 1, workgroup_count_z: int = 1):
     def dispatch_workgroups(
         self,
         workgroup_count_x: int,
         workgroup_count_y: int = 1,
         workgroup_count_z: int = 1,
-    ):
+    ) -> None:
         # H: void f(WGPUComputePassEncoder computePassEncoder, uint32_t workgroupCountX, uint32_t workgroupCountY, uint32_t workgroupCountZ)
         libf.wgpuComputePassEncoderDispatchWorkgroups(
             self._internal, workgroup_count_x, workgroup_count_y, workgroup_count_z
         )
 
+    # FIXME: was dispatch_workgroups_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     def dispatch_workgroups_indirect(
         self, indirect_buffer: GPUBuffer, indirect_offset: int
-    ):
+    ) -> None:
         buffer_id = indirect_buffer._internal
         # H: void f(WGPUComputePassEncoder computePassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
         libf.wgpuComputePassEncoderDispatchWorkgroupsIndirect(
             self._internal, buffer_id, int(indirect_offset)
         )
 
-    def end(self):
+    # FIXME: was end(self):
+    def end(self) -> None:
         # H: void f(WGPUComputePassEncoder computePassEncoder)
         libf.wgpuComputePassEncoderEnd(self._internal)
         # Need to release, see https://github.com/gfx-rs/wgpu-native/issues/412
@@ -3475,6 +3528,7 @@ class GPURenderPassEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuRenderPassEncoderRelease
 
+    # FIXME: was set_viewport(self, x: float, y: float, width: float, height: float, min_depth: float, max_depth: float):
     def set_viewport(
         self,
         x: float,
@@ -3483,7 +3537,7 @@ class GPURenderPassEncoder(
         height: float,
         min_depth: float,
         max_depth: float,
-    ):
+    ) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, float x, float y, float width, float height, float minDepth, float maxDepth)
         libf.wgpuRenderPassEncoderSetViewport(
             self._internal,
@@ -3495,13 +3549,15 @@ class GPURenderPassEncoder(
             float(max_depth),
         )
 
-    def set_scissor_rect(self, x: int, y: int, width: int, height: int):
+    # FIXME: was set_scissor_rect(self, x: int, y: int, width: int, height: int):
+    def set_scissor_rect(self, x: int, y: int, width: int, height: int) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height)
         libf.wgpuRenderPassEncoderSetScissorRect(
             self._internal, int(x), int(y), int(width), int(height)
         )
 
-    def set_blend_constant(self, color: Union[List[float], structs.Color]):
+    # FIXME: was set_blend_constant(self, color: Union[List[float], structs.Color]):
+    def set_blend_constant(self, color: Union[List[float], structs.Color]) -> None:
         if isinstance(color, dict):
             check_struct("Color", color)
             color = _tuple_from_color(color)
@@ -3516,18 +3572,21 @@ class GPURenderPassEncoder(
         # H: void f(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color)
         libf.wgpuRenderPassEncoderSetBlendConstant(self._internal, c_color)
 
-    def set_stencil_reference(self, reference: int):
+    # FIXME: was set_stencil_reference(self, reference: int):
+    def set_stencil_reference(self, reference: int) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t reference)
         libf.wgpuRenderPassEncoderSetStencilReference(self._internal, int(reference))
 
-    def end(self):
+    # FIXME: was end(self):
+    def end(self) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEnd(self._internal)
         # Need to release, see https://github.com/gfx-rs/wgpu-native/issues/412
         # As of wgpu-native v22.1.0.5, this bug is still present.
         self._release()
 
-    def execute_bundles(self, bundles: List[GPURenderBundle]):
+    # FIXME: was execute_bundles(self, bundles: List[GPURenderBundle]):
+    def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
         bundle_ids = [bundle._internal for bundle in bundles]
         c_bundle_info = new_array("WGPURenderBundle[]", bundle_ids)
         # H: void f(WGPURenderPassEncoder renderPassEncoder, size_t bundleCount, WGPURenderBundle const * bundles)
@@ -3535,11 +3594,13 @@ class GPURenderPassEncoder(
             self._internal, len(bundles), c_bundle_info
         )
 
-    def begin_occlusion_query(self, query_index: int):
+    # FIXME: was begin_occlusion_query(self, query_index: int):
+    def begin_occlusion_query(self, query_index: int) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t queryIndex)
         libf.wgpuRenderPassEncoderBeginOcclusionQuery(self._internal, int(query_index))
 
-    def end_occlusion_query(self):
+    # FIXME: was end_occlusion_query(self):
+    def end_occlusion_query(self) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEndOcclusionQuery(self._internal)
 
@@ -3617,7 +3678,8 @@ class GPURenderBundleEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuRenderBundleEncoderRelease
 
-    def finish(self, *, label: str = ""):
+    # FIXME: was finish(self, *, label: str = ""):
+    def finish(self, *, label: str = "") -> GPURenderBundle:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView
         struct = new_struct_p(
             "WGPURenderBundleDescriptor *",
@@ -3640,12 +3702,14 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuQueueRelease
 
-    def submit(self, command_buffers: List[GPUCommandBuffer]):
+    # FIXME: was submit(self, command_buffers: List[GPUCommandBuffer]):
+    def submit(self, command_buffers: List[GPUCommandBuffer]) -> None:
         command_buffer_ids = [cb._internal for cb in command_buffers]
         c_command_buffers = new_array("WGPUCommandBuffer[]", command_buffer_ids)
         # H: void f(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands)
         libf.wgpuQueueSubmit(self._internal, len(command_buffer_ids), c_command_buffers)
 
+    # FIXME: was write_buffer(self, buffer: GPUBuffer, buffer_offset: int, data: memoryview, data_offset: int = 0, size: Optional[int] = None):
     def write_buffer(
         self,
         buffer: GPUBuffer,
@@ -3653,7 +3717,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         data: memoryview,
         data_offset: int = 0,
         size: Optional[int] = None,
-    ):
+    ) -> None:
         # We support anything that memoryview supports, i.e. anything
         # that implements the buffer protocol, including, bytes,
         # bytearray, ctypes arrays, numpy arrays, etc.
@@ -3721,13 +3785,14 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
 
         return data
 
+    # FIXME: was write_texture(self, destination: structs.TexelCopyTextureInfo, data: memoryview, data_layout: structs.TexelCopyBufferLayout, size: Union[List[int], structs.Extent3D]):
     def write_texture(
         self,
         destination: structs.TexelCopyTextureInfo,
         data: memoryview,
         data_layout: structs.TexelCopyBufferLayout,
         size: Union[List[int], structs.Extent3D],
-    ):
+    ) -> None:
         # Note that the bytes_per_row restriction does not apply for
         # this function; wgpu-native deals with it.
 
@@ -3885,12 +3950,14 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
 
         return data
 
-    def on_submitted_work_done_sync(self):
+    # FIXME: was on_submitted_work_done_sync(self):
+    def on_submitted_work_done_sync(self) -> None:
         check_can_use_sync_variants()
         awaitable = self._on_submitted_work_done()
         awaitable.sync_wait()
 
-    async def on_submitted_work_done_async(self):
+    # FIXME: was on_submitted_work_done_async(self):
+    async def on_submitted_work_done_async(self) -> None:
         awaitable = self._on_submitted_work_done()
         await awaitable
 
@@ -3942,7 +4009,8 @@ class GPUQuerySet(classes.GPUQuerySet, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuQuerySetRelease
 
-    def destroy(self):
+    # FIXME: was destroy(self):
+    def destroy(self) -> None:
         # Note: not yet implemented in wgpu-core, the wgpu-native func is a noop
         internal = self._internal
         if internal is not None:

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -424,7 +424,6 @@ libf = SafeLibCalls(lib, error_handler)
 
 
 class GPU(classes.GPU):
-    # FIXME: was request_adapter_sync(self, *, feaure_level: str = "core", power_preference: enums.PowerPreference = None, force_fallback_adapter: bool = False, canvas=None):
     def request_adapter_sync(
         self,
         *,
@@ -446,7 +445,6 @@ class GPU(classes.GPU):
 
         return awaitable.sync_wait()
 
-    # FIXME: was request_adapter_async(self, *, feaure_level: str = "core", power_preference: enums.PowerPreference = None, force_fallback_adapter: bool = False, canvas=None):
     async def request_adapter_async(
         self,
         *,
@@ -1005,7 +1003,6 @@ class GPUAdapterInfo(classes.GPUAdapterInfo):
 
 
 class GPUAdapter(classes.GPUAdapter):
-    # FIXME: was request_device_sync(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     def request_device_sync(
         self,
         *,
@@ -1022,7 +1019,6 @@ class GPUAdapter(classes.GPUAdapter):
         )
         return awaitable.sync_wait()
 
-    # FIXME: was request_device_async(self, *, label: str = "", required_features: List[enums.FeatureName] = [], required_limits: Dict[str, Union[None, int]] = {}, default_queue: structs.QueueDescriptor = {}):
     async def request_device_async(
         self,
         *,
@@ -1311,7 +1307,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
             # H: WGPUBool f(WGPUDevice device, WGPUBool wait, WGPUSubmissionIndex const * wrappedSubmissionIndex)
             libf.wgpuDevicePoll(self._internal, True, ffi.NULL)
 
-    # FIXME: was create_buffer(self, *, label: str = "", size: int, usage: flags.BufferUsage, mapped_at_creation: bool = False):
     def create_buffer(
         self,
         *,
@@ -1347,7 +1342,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         # Return wrapped buffer
         return GPUBuffer(label, id, self, size, usage, map_state)
 
-    # FIXME: was create_texture(self, *, label: str = "", size: Union[List[int], structs.Extent3D], mip_level_count: int = 1, sample_count: int = 1, dimension: enums.TextureDimension = "2d", format: enums.TextureFormat, usage: flags.TextureUsage, view_formats: List[enums.TextureFormat] = []):
     def create_texture(
         self,
         *,
@@ -1422,7 +1416,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         }
         return GPUTexture(label, id, self, tex_info)
 
-    # FIXME: was create_sampler(self, *, label: str = "", address_mode_u: enums.AddressMode = "clamp-to-edge", address_mode_v: enums.AddressMode = "clamp-to-edge", address_mode_w: enums.AddressMode = "clamp-to-edge", mag_filter: enums.FilterMode = "nearest", min_filter: enums.FilterMode = "nearest", mipmap_filter: enums.MipmapFilterMode = "nearest", lod_min_clamp: float = 0, lod_max_clamp: float = 32, compare: enums.CompareFunction = optional, max_anisotropy: int = 1):
     def create_sampler(
         self,
         *,
@@ -1459,7 +1452,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateSampler(self._internal, struct)
         return GPUSampler(label, id, self)
 
-    # FIXME: was create_bind_group_layout(self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]):
     def create_bind_group_layout(
         self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]
     ) -> GPUBindGroupLayout:
@@ -1566,7 +1558,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateBindGroupLayout(self._internal, struct)
         return GPUBindGroupLayout(label, id, self)
 
-    # FIXME: was create_bind_group(self, *, label: str = "", layout: GPUBindGroupLayout, entries: List[structs.BindGroupEntry]):
     def create_bind_group(
         self,
         *,
@@ -1633,7 +1624,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateBindGroup(self._internal, struct)
         return GPUBindGroup(label, id, self)
 
-    # FIXME: was create_pipeline_layout(self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]):
     def create_pipeline_layout(
         self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
     ) -> GPUPipelineLayout:
@@ -1685,7 +1675,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreatePipelineLayout(self._internal, struct)
         return GPUPipelineLayout(label, id, self)
 
-    # FIXME: was create_shader_module(self, *, label: str = "", code: str, compilation_hints: List[structs.ShaderModuleCompilationHint] = []):
     def create_shader_module(
         self,
         *,
@@ -1783,7 +1772,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
             raise RuntimeError("Shader module creation failed")
         return GPUShaderModule(label, id, self)
 
-    # FIXME: was create_compute_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     def create_compute_pipeline(
         self,
         *,
@@ -1796,7 +1784,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateComputePipeline(self._internal, descriptor)
         return GPUComputePipeline(label, id, self)
 
-    # FIXME: was create_compute_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], compute: structs.ProgrammableStage):
     async def create_compute_pipeline_async(
         self,
         *,
@@ -1884,7 +1871,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         )
         return struct
 
-    # FIXME: was create_render_pipeline(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     def create_render_pipeline(
         self,
         *,
@@ -1903,7 +1889,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateRenderPipeline(self._internal, descriptor)
         return GPURenderPipeline(label, id, self)
 
-    # FIXME: was create_render_pipeline_async(self, *, label: str = "", layout: Union[GPUPipelineLayout, enums.AutoLayoutMode], vertex: structs.VertexState, primitive: structs.PrimitiveState = {}, depth_stencil: structs.DepthStencilState = optional, multisample: structs.MultisampleState = {}, fragment: structs.FragmentState = optional):
     async def create_render_pipeline_async(
         self,
         *,
@@ -2166,7 +2151,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         )
         return c_depth_stencil_state
 
-    # FIXME: was create_command_encoder(self, *, label: str = ""):
     def create_command_encoder(self, *, label: str = "") -> GPUCommandEncoder:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView
         struct = new_struct_p(
@@ -2179,7 +2163,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         id = libf.wgpuDeviceCreateCommandEncoder(self._internal, struct)
         return GPUCommandEncoder(label, id, self)
 
-    # FIXME: was create_render_bundle_encoder(self, *, label: str = "", color_formats: List[enums.TextureFormat], depth_stencil_format: enums.TextureFormat = optional, sample_count: int = 1, depth_read_only: bool = False, stencil_read_only: bool = False):
     def create_render_bundle_encoder(
         self,
         *,
@@ -2216,7 +2199,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         result._objects_to_keep_alive = set()
         return result
 
-    # FIXME: was create_query_set(self, *, label: str = "", type: enums.QueryType, count: int):
     def create_query_set(
         self, *, label: str = "", type: enums.QueryType, count: int
     ) -> GPUQuerySet:
@@ -2271,7 +2253,6 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
     async def _get_lost_async(self):
         raise NotImplementedError()
 
-    # FIXME: was destroy(self):
     def destroy(self) -> None:
         # Note: not yet implemented in wgpu-core, the wgpu-native func is a noop
         internal = self._internal
@@ -2330,7 +2311,6 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
             raise ValueError("Mapped range must not extend beyond total buffer size.")
         return offset, size
 
-    # FIXME: was map_sync(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     def map_sync(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
     ) -> None:
@@ -2338,7 +2318,6 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
         awaitable = self._map(mode, offset, size)
         return awaitable.sync_wait()
 
-    # FIXME: was map_async(self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None):
     async def map_async(
         self, mode: flags.MapMode, offset: int = 0, size: Optional[int] = None
     ) -> None:
@@ -2413,7 +2392,6 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
 
         return awaitable
 
-    # FIXME: was unmap(self):
     def unmap(self) -> None:
         if self._map_state != enums.BufferMapState.mapped:
             raise RuntimeError("Can only unmap a buffer if its currently mapped.")
@@ -2520,7 +2498,6 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
 
         return src_m
 
-    # FIXME: was destroy(self):
     def destroy(self) -> None:
         # NOTE: destroy means that the wgpu-core object gets into a destroyed
         # state. The wgpu-core object still exists. So destroying is quite
@@ -2539,7 +2516,6 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuTextureRelease
 
-    # FIXME: was create_view(self, *, label: str = "", format: enums.TextureFormat = optional, dimension: enums.TextureViewDimension = optional, usage: flags.TextureUsage = 0, aspect: enums.TextureAspect = "all", base_mip_level: int = 0, mip_level_count: int = optional, base_array_layer: int = 0, array_layer_count: int = optional):
     def create_view(
         self,
         *,
@@ -2593,7 +2569,6 @@ class GPUTexture(classes.GPUTexture, GPUObjectBase):
         id = libf.wgpuTextureCreateView(self._internal, struct)
         return GPUTextureView(label, id, self._device, self, self.size)
 
-    # FIXME: was destroy(self):
     def destroy(self) -> None:
         internal = self._internal
         if internal is not None:
@@ -2630,12 +2605,10 @@ class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuShaderModuleRelease
 
-    # FIXME: was get_compilation_info_sync(self):
     def get_compilation_info_sync(self) -> GPUCompilationInfo:
         check_can_use_sync_variants()
         return self._get_compilation_info()
 
-    # FIXME: was get_compilation_info_async(self):
     async def get_compilation_info_async(self) -> GPUCompilationInfo:
         return self._get_compilation_info()
 
@@ -2672,7 +2645,6 @@ class GPUShaderModule(classes.GPUShaderModule, GPUObjectBase):
 
 
 class GPUPipelineBase(classes.GPUPipelineBase):
-    # FIXME: was get_bind_group_layout(self, index: int):
     def get_bind_group_layout(self, index: int) -> GPUBindGroupLayout:
         # H: WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex)
         # H: WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex)
@@ -2806,7 +2778,6 @@ class GPUBindingCommandsMixin(classes.GPUBindingCommandsMixin):
 
 class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
     # whole class is likely going to be solved better: https://github.com/pygfx/wgpu-py/pull/546
-    # FIXME: was push_debug_group(self, group_label: str):
     def push_debug_group(self, group_label: str) -> None:
         c_group_label = to_c_string_view(group_label)
         # H: void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, WGPUStringView groupLabel)
@@ -2816,7 +2787,6 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
         function = type(self)._push_debug_group_function
         function(self._internal, c_group_label)
 
-    # FIXME: was pop_debug_group(self):
     def pop_debug_group(self) -> None:
         # H: void wgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder)
         # H: void wgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder)
@@ -2825,7 +2795,6 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
         function = type(self)._pop_debug_group_function
         function(self._internal)
 
-    # FIXME: was insert_debug_marker(self, marker_label: str):
     def insert_debug_marker(self, marker_label: str) -> None:
         c_marker_label = to_c_string_view(marker_label)
         # H: void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, WGPUStringView markerLabel)
@@ -2848,7 +2817,6 @@ class GPUDebugCommandsMixin(classes.GPUDebugCommandsMixin):
 
 
 class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
-    # FIXME: was set_pipeline(self, pipeline: GPURenderPipeline):
     def set_pipeline(self, pipeline: GPURenderPipeline) -> None:
         self._maybe_keep_alive(pipeline)
         pipeline_id = pipeline._internal
@@ -2857,7 +2825,6 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         function = type(self)._set_pipeline_function
         function(self._internal, pipeline_id)
 
-    # FIXME: was set_index_buffer(self, buffer: GPUBuffer, index_format: enums.IndexFormat, offset: int = 0, size: Optional[int] = None):
     def set_index_buffer(
         self,
         buffer: GPUBuffer,
@@ -2876,7 +2843,6 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
             self._internal, buffer._internal, c_index_format, int(offset), int(size)
         )
 
-    # FIXME: was set_vertex_buffer(self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     def set_vertex_buffer(
         self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
     ) -> None:
@@ -2888,7 +2854,6 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         function = type(self)._set_vertex_buffer_function
         function(self._internal, int(slot), buffer._internal, int(offset), int(size))
 
-    # FIXME: was draw(self, vertex_count: int, instance_count: int = 1, first_vertex: int = 0, first_instance: int = 0):
     def draw(
         self,
         vertex_count: int,
@@ -2903,7 +2868,6 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
             self._internal, vertex_count, instance_count, first_vertex, first_instance
         )
 
-    # FIXME: was draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     def draw_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int) -> None:
         self._maybe_keep_alive(indirect_buffer)
         buffer_id = indirect_buffer._internal
@@ -2912,7 +2876,6 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         function = type(self)._draw_indirect_function
         function(self._internal, buffer_id, int(indirect_offset))
 
-    # FIXME: was draw_indexed(self, index_count: int, instance_count: int = 1, first_index: int = 0, base_vertex: int = 0, first_instance: int = 0):
     def draw_indexed(
         self,
         index_count: int,
@@ -2933,7 +2896,6 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
             first_instance,
         )
 
-    # FIXME: was draw_indexed_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     def draw_indexed_indirect(
         self, indirect_buffer: GPUBuffer, indirect_offset: int
     ) -> None:
@@ -2957,7 +2919,6 @@ class GPUCommandEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuCommandEncoderRelease
 
-    # FIXME: was begin_compute_pass(self, *, label: str = "", timestamp_writes: structs.ComputePassTimestampWrites = optional):
     def begin_compute_pass(
         self,
         *,
@@ -2990,7 +2951,6 @@ class GPUCommandEncoder(
         encoder = GPUComputePassEncoder(label, raw_encoder, self._device)
         return encoder
 
-    # FIXME: was begin_render_pass(self, *, label: str = "", color_attachments: List[structs.RenderPassColorAttachment], depth_stencil_attachment: structs.RenderPassDepthStencilAttachment = optional, occlusion_query_set: GPUQuerySet = optional, timestamp_writes: structs.RenderPassTimestampWrites = optional, max_draw_count: int = 50000000):
     def begin_render_pass(
         self,
         *,
@@ -3148,7 +3108,6 @@ class GPUCommandEncoder(
         )
         return c_depth_stencil_attachment
 
-    # FIXME: was clear_buffer(self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None):
     def clear_buffer(
         self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
     ) -> None:
@@ -3173,7 +3132,6 @@ class GPUCommandEncoder(
             self._internal, buffer._internal, offset, size
         )
 
-    # FIXME: was copy_buffer_to_buffer(self, source: GPUBuffer, source_offset: int, destination: GPUBuffer, destination_offset: int, size: int):
     def copy_buffer_to_buffer(
         self,
         source: GPUBuffer,
@@ -3203,7 +3161,6 @@ class GPUCommandEncoder(
             int(size),
         )
 
-    # FIXME: was copy_buffer_to_texture(self, source: structs.TexelCopyBufferInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     def copy_buffer_to_texture(
         self,
         source: structs.TexelCopyBufferInfo,
@@ -3270,7 +3227,6 @@ class GPUCommandEncoder(
             c_copy_size,
         )
 
-    # FIXME: was copy_texture_to_buffer(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyBufferInfo, copy_size: Union[List[int], structs.Extent3D]):
     def copy_texture_to_buffer(
         self,
         source: structs.TexelCopyTextureInfo,
@@ -3337,7 +3293,6 @@ class GPUCommandEncoder(
             c_copy_size,
         )
 
-    # FIXME: was copy_texture_to_texture(self, source: structs.TexelCopyTextureInfo, destination: structs.TexelCopyTextureInfo, copy_size: Union[List[int], structs.Extent3D]):
     def copy_texture_to_texture(
         self,
         source: structs.TexelCopyTextureInfo,
@@ -3403,7 +3358,6 @@ class GPUCommandEncoder(
             c_copy_size,
         )
 
-    # FIXME: was finish(self, *, label: str = ""):
     def finish(self, *, label: str = "") -> GPUCommandBuffer:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView
         struct = new_struct_p(
@@ -3416,7 +3370,6 @@ class GPUCommandEncoder(
 
         return GPUCommandBuffer(label, id, self._device)
 
-    # FIXME: was resolve_query_set(self, query_set: GPUQuerySet, first_query: int, query_count: int, destination: GPUBuffer, destination_offset: int):
     def resolve_query_set(
         self,
         query_set: GPUQuerySet,
@@ -3458,13 +3411,11 @@ class GPUComputePassEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuComputePassEncoderRelease
 
-    # FIXME: was set_pipeline(self, pipeline: GPUComputePipeline):
     def set_pipeline(self, pipeline: GPUComputePipeline) -> None:
         pipeline_id = pipeline._internal
         # H: void f(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline)
         libf.wgpuComputePassEncoderSetPipeline(self._internal, pipeline_id)
 
-    # FIXME: was dispatch_workgroups(self, workgroup_count_x: int, workgroup_count_y: int = 1, workgroup_count_z: int = 1):
     def dispatch_workgroups(
         self,
         workgroup_count_x: int,
@@ -3476,7 +3427,6 @@ class GPUComputePassEncoder(
             self._internal, workgroup_count_x, workgroup_count_y, workgroup_count_z
         )
 
-    # FIXME: was dispatch_workgroups_indirect(self, indirect_buffer: GPUBuffer, indirect_offset: int):
     def dispatch_workgroups_indirect(
         self, indirect_buffer: GPUBuffer, indirect_offset: int
     ) -> None:
@@ -3486,7 +3436,6 @@ class GPUComputePassEncoder(
             self._internal, buffer_id, int(indirect_offset)
         )
 
-    # FIXME: was end(self):
     def end(self) -> None:
         # H: void f(WGPUComputePassEncoder computePassEncoder)
         libf.wgpuComputePassEncoderEnd(self._internal)
@@ -3530,7 +3479,6 @@ class GPURenderPassEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuRenderPassEncoderRelease
 
-    # FIXME: was set_viewport(self, x: float, y: float, width: float, height: float, min_depth: float, max_depth: float):
     def set_viewport(
         self,
         x: float,
@@ -3551,14 +3499,12 @@ class GPURenderPassEncoder(
             float(max_depth),
         )
 
-    # FIXME: was set_scissor_rect(self, x: int, y: int, width: int, height: int):
     def set_scissor_rect(self, x: int, y: int, width: int, height: int) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height)
         libf.wgpuRenderPassEncoderSetScissorRect(
             self._internal, int(x), int(y), int(width), int(height)
         )
 
-    # FIXME: was set_blend_constant(self, color: Union[List[float], structs.Color]):
     def set_blend_constant(self, color: Union[List[float], structs.Color]) -> None:
         if isinstance(color, dict):
             check_struct("Color", color)
@@ -3574,12 +3520,10 @@ class GPURenderPassEncoder(
         # H: void f(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color)
         libf.wgpuRenderPassEncoderSetBlendConstant(self._internal, c_color)
 
-    # FIXME: was set_stencil_reference(self, reference: int):
     def set_stencil_reference(self, reference: int) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t reference)
         libf.wgpuRenderPassEncoderSetStencilReference(self._internal, int(reference))
 
-    # FIXME: was end(self):
     def end(self) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEnd(self._internal)
@@ -3587,7 +3531,6 @@ class GPURenderPassEncoder(
         # As of wgpu-native v22.1.0.5, this bug is still present.
         self._release()
 
-    # FIXME: was execute_bundles(self, bundles: List[GPURenderBundle]):
     def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
         bundle_ids = [bundle._internal for bundle in bundles]
         c_bundle_info = new_array("WGPURenderBundle[]", bundle_ids)
@@ -3596,12 +3539,10 @@ class GPURenderPassEncoder(
             self._internal, len(bundles), c_bundle_info
         )
 
-    # FIXME: was begin_occlusion_query(self, query_index: int):
     def begin_occlusion_query(self, query_index: int) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder, uint32_t queryIndex)
         libf.wgpuRenderPassEncoderBeginOcclusionQuery(self._internal, int(query_index))
 
-    # FIXME: was end_occlusion_query(self):
     def end_occlusion_query(self) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEndOcclusionQuery(self._internal)
@@ -3680,7 +3621,6 @@ class GPURenderBundleEncoder(
     # GPUObjectBaseMixin
     _release_function = libf.wgpuRenderBundleEncoderRelease
 
-    # FIXME: was finish(self, *, label: str = ""):
     def finish(self, *, label: str = "") -> GPURenderBundle:
         # H: nextInChain: WGPUChainedStruct *, label: WGPUStringView
         struct = new_struct_p(
@@ -3704,14 +3644,12 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuQueueRelease
 
-    # FIXME: was submit(self, command_buffers: List[GPUCommandBuffer]):
     def submit(self, command_buffers: List[GPUCommandBuffer]) -> None:
         command_buffer_ids = [cb._internal for cb in command_buffers]
         c_command_buffers = new_array("WGPUCommandBuffer[]", command_buffer_ids)
         # H: void f(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands)
         libf.wgpuQueueSubmit(self._internal, len(command_buffer_ids), c_command_buffers)
 
-    # FIXME: was write_buffer(self, buffer: GPUBuffer, buffer_offset: int, data: memoryview, data_offset: int = 0, size: Optional[int] = None):
     def write_buffer(
         self,
         buffer: GPUBuffer,
@@ -3787,7 +3725,6 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
 
         return data
 
-    # FIXME: was write_texture(self, destination: structs.TexelCopyTextureInfo, data: memoryview, data_layout: structs.TexelCopyBufferLayout, size: Union[List[int], structs.Extent3D]):
     def write_texture(
         self,
         destination: structs.TexelCopyTextureInfo,
@@ -3952,13 +3889,11 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
 
         return data
 
-    # FIXME: was on_submitted_work_done_sync(self):
     def on_submitted_work_done_sync(self) -> None:
         check_can_use_sync_variants()
         awaitable = self._on_submitted_work_done()
         awaitable.sync_wait()
 
-    # FIXME: was on_submitted_work_done_async(self):
     async def on_submitted_work_done_async(self) -> None:
         awaitable = self._on_submitted_work_done()
         await awaitable
@@ -4011,7 +3946,6 @@ class GPUQuerySet(classes.GPUQuerySet, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuQuerySetRelease
 
-    # FIXME: was destroy(self):
     def destroy(self) -> None:
         # Note: not yet implemented in wgpu-core, the wgpu-native func is a noop
         internal = self._internal

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -424,6 +424,7 @@ libf = SafeLibCalls(lib, error_handler)
 
 
 class GPU(classes.GPU):
+    # FIXME: was request_adapter_sync(self, *, feaure_level: str = "core", power_preference: enums.PowerPreference = None, force_fallback_adapter: bool = False, canvas=None):
     def request_adapter_sync(
         self,
         *,
@@ -431,7 +432,7 @@ class GPU(classes.GPU):
         power_preference: enums.PowerPreference = None,
         force_fallback_adapter: bool = False,
         canvas=None,
-    ):
+    ) -> GPUAdapter:
         """Sync version of ``request_adapter_async()``.
         This is the implementation based on wgpu-native.
         """
@@ -445,6 +446,7 @@ class GPU(classes.GPU):
 
         return awaitable.sync_wait()
 
+    # FIXME: was request_adapter_async(self, *, feaure_level: str = "core", power_preference: enums.PowerPreference = None, force_fallback_adapter: bool = False, canvas=None):
     async def request_adapter_async(
         self,
         *,
@@ -452,7 +454,7 @@ class GPU(classes.GPU):
         power_preference: enums.PowerPreference = None,
         force_fallback_adapter: bool = False,
         canvas=None,
-    ):
+    ) -> GPUAdapter:
         """Create a `GPUAdapter`, the object that represents an abstract wgpu
         implementation, from which one can request a `GPUDevice`.
 


### PR DESCRIPTION
closes #696 

found where the type hints can be added in codegen, had to work through a bunch of edge cases. Will see if these cases can be added to already existing utils.
also not sure if `-> None` is really wanted everywhere.

still in progress... hopefully I can get this done early next week.

as for the 2nd question in the issue, I looked through some ideas with stub classes in mypy, .pyi files and even using `if "TYPE_CHECKING"` to import the autobackend. But doesn't feel like that solves the issue if having the "go to declaration" button go to the implementation - I might keep this an option issue.