### PR TITLE
Use GPUAdapterInfo.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,7 +90,7 @@ def test_enums_and_flags_and_structs():
 
 def test_base_wgpu_api():
     # Fake a device and an adapter
-    adapter = wgpu.GPUAdapter(None, set(), {}, {})
+    adapter = wgpu.GPUAdapter(None, set(), {}, wgpu.GPUAdapterInfo({}))
     queue = wgpu.GPUQueue("", None, None)
     device = wgpu.GPUDevice("device08", -1, adapter, {42, 43}, {}, queue)
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -551,13 +551,16 @@ class GPUAdapterInfo:
     @property
     def subgroup_min_size(self):
         """If the "subgroups" feature is supported, the minimum supported subgroup size for the adapter."""
-        return self._info.get("subgroup_min_size", None)
+        return self._info.get("subgroup_min_size")
 
     # IDL: readonly attribute unsigned long subgroupMaxSize;
     @property
     def subgroup_max_size(self):
         """If the "subgroups" feature is supported, the maximum supported subgroup size for the adapter."""
-        return self._info.get("subgroup_max_size", None)
+        return self._info.get("subgroup_max_size")
+
+    def __getitem__(self, item):
+        return self._info.get(item, None)
 
 
 class GPUAdapter:
@@ -582,7 +585,7 @@ class GPUAdapter:
 
         assert isinstance(features, set)
         assert isinstance(limits, dict)
-        assert isinstance(adapter_info, dict)
+        assert isinstance(adapter_info, GPUAdapterInfo)
 
         self._features = features
         self._limits = limits
@@ -599,6 +602,12 @@ class GPUAdapter:
     def limits(self):
         """A dict with limits for the adapter."""
         return self._limits
+
+    # IDL: [SameObject] readonly attribute GPUAdapterInfo info;
+    @property
+    def info(self):
+        """Information associated with this adapter."""
+        return self._adapter_info
 
     # IDL: Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {}); -> USVString label = "", sequence<GPUFeatureName> requiredFeatures = [], record<DOMString, (GPUSize64 or undefined)> requiredLimits = {}, GPUQueueDescriptor defaultQueue = {}
     def request_device_sync(
@@ -647,19 +656,12 @@ class GPUAdapter:
         """Whether this adapter runs on software (rather than dedicated hardware)."""
         return self._adapter_info.get("adapter_type", "").lower() in ("software", "cpu")
 
-    # IDL: [SameObject] readonly attribute GPUAdapterInfo info;
-    @property
-    def info(self):
-        """A dict with information about this adapter, such as the vendor and device name."""
-        # Note: returns a dict rather than an GPUAdapterInfo instance.
-        return self._adapter_info
-
     @apidiff.add("Useful in multi-gpu environments")
     @property
     def summary(self):
         """A one-line summary of the info of this adapter (device, adapter_type, backend_type)."""
         d = self._adapter_info
-        return f"{d['device']} ({d['adapter_type']}) via {d['backend_type']}"
+        return f"{d.device} ({d['adapter_type']}) via {d['backend_type']}"
 
 
 class GPUObjectBase:

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -628,12 +628,15 @@ class GPU(classes.GPU):
         # Populate a dict according to the WebGPU spec: https://gpuweb.github.io/gpuweb/#gpuadapterinfo
         # And add all other info we get from wgpu-native too.
         # note: device is human readable. description is driver-description; usually more cryptic, or empty.
-        adapter_info = {
+        adapter_info_data = {
             # Spec
             "vendor": to_py_str("vendor"),
             "architecture": to_py_str("architecture"),
             "device": to_py_str("device"),
             "description": to_py_str("description"),
+            # Defaults for stackgroup info from §3.6.2.4 of webgpu specification
+            "stackgroup_min_size": getattr(c_info, "stackgroupMinSize", 4),
+            "stackgroup_max_size": getattr(c_info, "stackgroupMaxSize", 128),
             # Extra
             "vendor_id": int(c_info.vendorID),
             "device_id": int(c_info.deviceID),
@@ -644,6 +647,7 @@ class GPU(classes.GPU):
                 c_info.backendType, "unknown"
             ),
         }
+        adapter_info = GPUAdapterInfo(adapter_info_data)
 
         # Allow Rust to release its string objects
         # H: void f(WGPUAdapterInfo adapterInfo)

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -18,7 +18,7 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 122 methods, 49 properties
+* Validated 37 classes, 123 methods, 49 properties
 ### Patching API for backends/wgpu_native/_api.py
 * Validated 37 classes, 124 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py


### PR DESCRIPTION
Bug #695 
Use GPUAdapterInfo.  Add subgroup_min_size and subgroup_max_size.  

For now, we can use default sizes from Spec, but eventually these will be available in the C WGPUAdapterInfo.