### PR TITLE
Implement proper support for alt texture formats for offscreen use

### DIFF
--- a/examples/offscreen_hdr.py
+++ b/examples/offscreen_hdr.py
@@ -1,0 +1,44 @@
+"""
+Render offscreen using a 16bit (HDR) render target
+--------------------------------------------------
+
+Render a wgpu example offscreen, safe to 16bit PNG, and show the result.
+
+"""
+
+import os
+import tempfile
+import webbrowser
+
+import numpy as np
+import png  # provided by the pypng package
+
+# from rendercanvas.offscreen import RenderCanvas
+from wgpu.gui.offscreen import WgpuCanvas as RenderCanvas
+from triangle import setup_drawing_sync
+
+
+canvas = RenderCanvas(size=(640, 480), pixel_ratio=2)
+draw_frame = setup_drawing_sync(canvas, format="rgba16float")
+canvas.request_draw(draw_frame)
+
+image = canvas.draw()
+image = np.asarray(image)
+
+# Convert to RGB
+image = image[:, :, :3]
+
+# Convert float16 to uint16
+image = (image.astype(np.float32) * 65535).astype("uint16")
+
+
+# Save with pypng. It's API is not great, but imageio/pillow cannot do 16bit png
+filename = os.path.join(tempfile.gettempdir(), "wgpuexample.png")
+with open(filename, "wb") as f:
+    writer = png.Writer(
+        width=image.shape[1], height=image.shape[0], bitdepth=16, greyscale=False
+    )
+    writer.write(f, image.reshape(image.shape[0], -1).tolist())
+
+# Show the written file
+webbrowser.open("file://" + filename)

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -23,7 +23,9 @@ import wgpu
 # %% Entrypoints (sync and async)
 
 
-def setup_drawing_sync(canvas, power_preference="high-performance", limits=None):
+def setup_drawing_sync(
+    canvas, power_preference="high-performance", limits=None, format=None
+):
     """Setup to draw a triangle on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -33,14 +35,14 @@ def setup_drawing_sync(canvas, power_preference="high-performance", limits=None)
     adapter = wgpu.gpu.request_adapter_sync(power_preference=power_preference)
     device = adapter.request_device_sync(required_limits=limits)
 
-    pipeline_kwargs = get_render_pipeline_kwargs(canvas, device)
+    pipeline_kwargs = get_render_pipeline_kwargs(canvas, device, format)
 
     render_pipeline = device.create_render_pipeline(**pipeline_kwargs)
 
     return get_draw_function(canvas, device, render_pipeline, asynchronous=False)
 
 
-async def setup_drawing_async(canvas, limits=None):
+async def setup_drawing_async(canvas, limits=None, format=None):
     """Setup to async-draw a triangle on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -50,7 +52,7 @@ async def setup_drawing_async(canvas, limits=None):
     adapter = await wgpu.gpu.request_adapter_async(power_preference="high-performance")
     device = await adapter.request_device_async(required_limits=limits)
 
-    pipeline_kwargs = get_render_pipeline_kwargs(canvas, device)
+    pipeline_kwargs = get_render_pipeline_kwargs(canvas, device, format)
 
     render_pipeline = await device.create_render_pipeline_async(**pipeline_kwargs)
 
@@ -60,9 +62,10 @@ async def setup_drawing_async(canvas, limits=None):
 # %% Functions to create wgpu objects
 
 
-def get_render_pipeline_kwargs(canvas, device):
+def get_render_pipeline_kwargs(canvas, device, render_texture_format):
     context = canvas.get_context("wgpu")
-    render_texture_format = context.get_preferred_format(device.adapter)
+    if render_texture_format is None:
+        render_texture_format = context.get_preferred_format(device.adapter)
     context.configure(device=device, format=render_texture_format)
 
     shader = device.create_shader_module(code=shader_source)

--- a/wgpu/gui/offscreen.py
+++ b/wgpu/gui/offscreen.py
@@ -18,7 +18,7 @@ class WgpuManualOffscreenCanvas(WgpuAutoGui, WgpuCanvasBase):
         self._last_image = None
 
     def get_present_methods(self):
-        return {"bitmap": {"formats": ["rgba-u8"]}}
+        return {"bitmap": {"formats": ["rgba-u8", "rgba-f16", "rgba-f32", "rgba-u16"]}}
 
     def present_image(self, image, **kwargs):
         self._last_image = image


### PR DESCRIPTION
Closes #698

* [x] Offscreen canvas defines that it supports more formats.
* [x] CanvasContext queries the formats from the canvas to get canvas capabilities (instead of assuming only `rgba8unorm`.
* [x] CanvasContext converts the downloaded data to the appropriate dtype.
* [x] Update triangle example to allow setting format.
* [x] Add example.

Will also adust the `rendercanvas` to make it compatible.