### PR TITLE
Improve get_current_texture for window resizing

### DIFF
--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -448,13 +448,12 @@ class GPUCanvasContext:
         # Note that the label 'present' is used by read_texture() to determine
         # that it can use a shared copy buffer.
         device = self._config["device"]
-        self._texture = device.create_texture(
+        return device.create_texture(
             label="present",
             size=(width, height, 1),
             format=self._config["format"],
             usage=self._config["usage"] | flags.TextureUsage.COPY_SRC,
         )
-        return self._texture
 
     def _create_texture_screen(self):
         raise NotImplementedError()

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -926,6 +926,7 @@ class GPUCanvasContext(classes.GPUCanvasContext):
                 texture_id = 0
             # Try to re-configure, if we can
             self._configure_screen_real()
+            # H: void f(WGPUSurface surface, WGPUSurfaceTexture * surfaceTexture)
             libf.wgpuSurfaceGetCurrentTexture(self._surface_id, surface_texture)
             status_int = surface_texture.status
             status_str = status_str_map.get(status_int, "Unknown")
@@ -1010,10 +1011,10 @@ class GPUCanvasContext(classes.GPUCanvasContext):
         return GPUTexture(label, texture_id, device, tex_info)
 
     def _present_screen(self):
-        # H: WGPUStatus f(WGPUSurface surface)
         if self._skip_present_screen:
             self._skip_present_screen = False
         else:
+            # H: WGPUStatus f(WGPUSurface surface)
             status = libf.wgpuSurfacePresent(self._surface_id)
             if status != lib.WGPUStatus_Success:
                 logger.warning("wgpuSurfacePresent failed")

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -890,10 +890,11 @@ class GPUCanvasContext(classes.GPUCanvasContext):
             raise RuntimeError("Cannot get texture for a canvas with zero pixels.")
 
         # Re-configure when the size has changed.
-        if new_size != old_size and testflag == 0:
+        if new_size != old_size:
             self._wgpu_config.width = new_size[0]
             self._wgpu_config.height = new_size[1]
-            self._configure_screen_real()
+            if testflag == 0:
+                self._configure_screen_real()
 
         # Prepare for obtaining a texture.
         status_str_map = enum_int2str["SurfaceGetCurrentTextureStatus"]

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -960,7 +960,7 @@ class GPUCanvasContext(classes.GPUCanvasContext):
                     )
                 else:
                     logger.warning(
-                        f"Surface texture is {status_str!r} ({self._number_of_successive_unsuccesful_textures})x, using dummy texture"
+                        f"Surface texture is {status_str!r} ({self._number_of_successive_unsuccesful_textures}x), using dummy texture"
                     )
                     self._skip_present_screen = True
                     return self._create_texture_bitmap()

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -29,6 +29,6 @@
 * Enum CanvasAlphaMode missing in wgpu.h
 * Enum CanvasToneMappingMode missing in wgpu.h
 * Wrote 255 enum mappings and 47 struct-field mappings to wgpu_native/_mappings.py
-* Validated 149 C function calls
+* Validated 151 C function calls
 * Not using 69 C functions
 * Validated 95 C structs


### PR DESCRIPTION
Ref https://github.com/pygfx/pygfx/issues/642

This PR improves the logic for `canvas_context.get_current_texture()`, especially with regard to window resizing. This covers a use-case where on some Linux systems the texture status is 'outdated`.

One problem is that we can get in a situation where we cannot successfully obtain a texture for the surface. There are a few options:
* I looked into introducing a special error type that can be used to "cancel" a draw, to be caught by the scheduling logic. But this is tricky for various reasons, so I decided against it.
* Define a special error type that the caller of `get_current_texture()` must catch. The downside is that it changes the API of the method compared to the WebGPU spec.
* Use the texture regardless of it being in an error state. I don't know if there is a texture with status 'outdated', and if there is, I don't know what happens when you try to use it as a render target.
* Return a dummy texture that will not actually get presented. As long as these cases are sporadic, this seems like an ok solution. The downside being that the code seems to be rendering, but no new data appears on screen. So we need to check that the texture status becomes successful within a few draws.