### PR TITLE
Imgui get up-to-date framebuffer size

### DIFF
--- a/wgpu/utils/imgui/imgui_backend.py
+++ b/wgpu/utils/imgui/imgui_backend.py
@@ -377,7 +377,7 @@ class ImguiWgpuBackend:
         )
 
     def render(
-        self, draw_data: imgui.ImDrawData, render_pass: wgpu.GPURenderPassEncoder
+        self, draw_data: imgui.ImDrawData, render_pass: wgpu.GPURenderPassEncoder, psize: tuple
     ):
         """
         Render the imgui draw data with the given render pass.
@@ -392,10 +392,7 @@ class ImguiWgpuBackend:
         if draw_data is None:
             return
 
-        display_width, display_height = draw_data.display_size
-        fb_width = int(display_width * draw_data.framebuffer_scale.x)
-        fb_height = int(display_height * draw_data.framebuffer_scale.y)
-
+        fb_width, fb_height = psize
         if fb_width <= 0 or fb_height <= 0 or draw_data.cmd_lists_count == 0:
             return
 

--- a/wgpu/utils/imgui/imgui_backend.py
+++ b/wgpu/utils/imgui/imgui_backend.py
@@ -377,7 +377,10 @@ class ImguiWgpuBackend:
         )
 
     def render(
-        self, draw_data: imgui.ImDrawData, render_pass: wgpu.GPURenderPassEncoder, psize: tuple
+        self,
+        draw_data: imgui.ImDrawData,
+        render_pass: wgpu.GPURenderPassEncoder,
+        psize: tuple,
     ):
         """
         Render the imgui draw data with the given render pass.

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -149,7 +149,7 @@ class ImguiRenderer:
         draw_data = self._update_gui_function()
 
         pixel_ratio = self._canvas_context.canvas.get_pixel_ratio()
-        psize =  self._canvas_context.canvas.get_physical_size()
+        psize = self._canvas_context.canvas.get_physical_size()
         self._backend.io.display_framebuffer_scale = (pixel_ratio, pixel_ratio)
 
         command_encoder = self._backend._device.create_command_encoder()

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -149,6 +149,7 @@ class ImguiRenderer:
         draw_data = self._update_gui_function()
 
         pixel_ratio = self._canvas_context.canvas.get_pixel_ratio()
+        psize =  self._canvas_context.canvas.get_physical_size()
         self._backend.io.display_framebuffer_scale = (pixel_ratio, pixel_ratio)
 
         command_encoder = self._backend._device.create_command_encoder()
@@ -164,7 +165,7 @@ class ImguiRenderer:
                 }
             ],
         )
-        self._backend.render(draw_data, render_pass)
+        self._backend.render(draw_data, render_pass, psize)
         render_pass.end()
         self._backend._device.queue.submit([command_encoder.finish()])
 


### PR DESCRIPTION
With the recent change in `rendercanvas` where it draws during resize (https://github.com/pygfx/rendercanvas/pull/70), there are draws while the event for that resize has not been emitted yet. This tweaks the imgui adapter to get the real physical size, instead of relying on the resize event.


