### PR TITLE
Give AdapterInfo a repr

### DIFF
--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -555,6 +555,10 @@ class GPUAdapterInfo:
     def __init__(self, info):
         self._info = info
 
+    def __repr__(self):
+        parts = [f"{k}={v!r}" for k, v in self._info.items()]
+        return f"<GPUAdapterInfo with {', '.join(parts)}>"
+
     # IDL: readonly attribute DOMString vendor;
     @property
     def vendor(self):
@@ -2648,8 +2652,11 @@ def generic_repr(self):
 
 
 def _set_repr_methods():
+    exceptions = ["GPUAdapterInfo"]
     m = globals()
     for class_name in __all__:
+        if class_name in exceptions:
+            continue
         cls = m[class_name]
         if len(cls.mro()) == 2:  # class itself and object
             cls.__repr__ = generic_repr

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -18,7 +18,7 @@
 * Diffs for GPUTextureView: add size, add texture
 * Diffs for GPUBindingCommandsMixin: change set_bind_group
 * Diffs for GPUQueue: add read_buffer, add read_texture, hide copy_external_image_to_texture
-* Validated 37 classes, 123 methods, 49 properties
+* Validated 37 classes, 124 methods, 49 properties
 ### Patching API for backends/wgpu_native/_api.py
 * Validated 37 classes, 124 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py


### PR DESCRIPTION
In #699 the `adapter.info` prop returned an `AdapterInfo` instance instead of a dict. This PR updates the `__repr__` so that use-code that did  something like the below will still produce something meaningful:
```py
for a in wgpu.gpu.enumerate_adapters_sync():
    print(a.info)
```