### PR TITLE
Set the size via `imgui.io` instead of using the `psize` parameter of the render method.

### DIFF
--- a/wgpu/utils/imgui/imgui_backend.py
+++ b/wgpu/utils/imgui/imgui_backend.py
@@ -380,7 +380,6 @@ class ImguiWgpuBackend:
         self,
         draw_data: imgui.ImDrawData,
         render_pass: wgpu.GPURenderPassEncoder,
-        psize: tuple,
     ):
         """
         Render the imgui draw data with the given render pass.
@@ -395,7 +394,10 @@ class ImguiWgpuBackend:
         if draw_data is None:
             return
 
-        fb_width, fb_height = psize
+        display_width, display_height = draw_data.display_size
+        fb_width = int(display_width * draw_data.framebuffer_scale.x)
+        fb_height = int(display_height * draw_data.framebuffer_scale.y)
+
         if fb_width <= 0 or fb_height <= 0 or draw_data.cmd_lists_count == 0:
             return
 

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -149,8 +149,9 @@ class ImguiRenderer:
         draw_data = self._update_gui_function()
 
         pixel_ratio = self._canvas_context.canvas.get_pixel_ratio()
-        psize = self._canvas_context.canvas.get_physical_size()
+        lsize = self._canvas_context.canvas.get_logical_size()
         self._backend.io.display_framebuffer_scale = (pixel_ratio, pixel_ratio)
+        self._backend.io.display_size = lsize
 
         command_encoder = self._backend._device.create_command_encoder()
         current_texture_view = self._canvas_context.get_current_texture().create_view()
@@ -165,7 +166,7 @@ class ImguiRenderer:
                 }
             ],
         )
-        self._backend.render(draw_data, render_pass, psize)
+        self._backend.render(draw_data, render_pass)
         render_pass.end()
         self._backend._device.queue.submit([command_encoder.finish()])
 


### PR DESCRIPTION
See: https://github.com/pygfx/wgpu-py/pull/711#issuecomment-2853486448
We also need to update the `display_size` in `draw_data`, as it is used when setting the camera state.


I noticed that this change was made in #706, but I couldn’t really tell the difference. 🤔 

Also, in theory, if we update the size value every time the render method is called, we shouldn’t need to handle the canvas `on_resize` event anymore — but it seems we still can’t remove that event handler. 