### PR TITLE
[WIP] update to wgpu-native v25.0.0.1

### DIFF
--- a/wgpu/backends/wgpu_native/__init__.py
+++ b/wgpu/backends/wgpu_native/__init__.py
@@ -11,8 +11,8 @@ from .. import _register_backend
 
 
 # The wgpu-native version that we target/expect
-__version__ = "24.0.3.1"
-__commit_sha__ = "e305465e8f1abd2b13878274bf74bbde920096a3"
+__version__ = "25.0.0.1"
+__commit_sha__ = "059cb334dd07650d30ff58d10d5155766ea4376b" #+ recommended renames
 version_info = tuple(map(int, __version__.split(".")))  # noqa: RUF048
 _check_expected_version(version_info)  # produces a warning on mismatch
 

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -3,7 +3,7 @@
 * The webgpu.idl defines 37 classes with 76 functions
 * The webgpu.idl defines 5 flags, 34 enums, 60 structs
 * The wgpu.h defines 211 functions
-* The wgpu.h defines 7 flags, 58 enums, 101 structs
+* The wgpu.h defines 7 flags, 60 enums, 101 structs
 ## Updating API
 * Wrote 5 flags to flags.py
 * Wrote 34 enums to enums.py

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -118,14 +118,34 @@ typedef enum WGPUNativeQueryType {
     WGPUNativeQueryType_Force32 = 0x7FFFFFFF
 } WGPUNativeQueryType WGPU_ENUM_ATTRIBUTE;
 
+typedef enum WGPUDxcMaxShaderModel {
+    WGPUDxcMaxShaderModel_V6_0 = 0x00000000,
+    WGPUDxcMaxShaderModel_V6_1 = 0x00000001,
+    WGPUDxcMaxShaderModel_V6_2 = 0x00000002,
+    WGPUDxcMaxShaderModel_V6_3 = 0x00000003,
+    WGPUDxcMaxShaderModel_V6_4 = 0x00000004,
+    WGPUDxcMaxShaderModel_V6_5 = 0x00000005,
+    WGPUDxcMaxShaderModel_V6_6 = 0x00000006,
+    WGPUDxcMaxShaderModel_V6_7 = 0x00000007,
+    WGPUDxcMaxShaderModel_Force32 = 0x7FFFFFFF
+} WGPUDxcMaxShaderModel;
+
+typedef enum WGPUGLFenceBehaviour {
+    WGPUGLFenceBehaviour_Normal = 0x00000000,
+    WGPUGLFenceBehaviour_AutoFinish = 0x00000001,
+    WGPUGLFenceBehaviour_Force32 = 0x7FFFFFFF
+} WGPUGLFenceBehaviour;
+
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
     WGPUInstanceBackend backends;
     WGPUInstanceFlag flags;
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
+    WGPUGLFenceBehaviour glFenceBehaviour;
     WGPUStringView dxilPath;
     WGPUStringView dxcPath;
+    WGPUDxcMaxShaderModel dxcMaxShaderModel;
 } WGPUInstanceExtras;
 
 typedef struct WGPUDeviceExtras {


### PR DESCRIPTION
we don't have the upstream release just yet, but I compiled it locally and have a look.
seems to be a smaller update with no big changes. The examples and tests run on first try 😅!
as there were DirectX related changes I gave that backend a try and run into some crashes - so will look into that next.

It sounds like you can even target a specific shader model, which is actually a feature I am interested in for profiling support with model 6+, will figure out where to but the Instance extras and how that behaves.

(will update the PR with the checklist once a release lands)