### PR TITLE
Adding missing enums to FeatureName and CanvasAlphaMode.

### DIFF
--- a/wgpu/enums.py
+++ b/wgpu/enums.py
@@ -81,6 +81,9 @@ class FeatureName(Enum):
     clip_distances = "clip-distances"
     dual_source_blending = "dual-source-blending"
     subgroups = "subgroups"
+    texture_adapter_specific_format_features = (
+        "texture-adapter-specific-format-features"
+    )
 
 
 class BufferMapState(Enum):
@@ -406,6 +409,7 @@ class QueryType(Enum):
 class CanvasAlphaMode(Enum):
     opaque = "opaque"
     premultiplied = "premultiplied"
+    unpremultiplied = "unpremultiplied"
 
 
 class CanvasToneMappingMode(Enum):

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -23,6 +23,7 @@
 * Validated 37 classes, 124 methods, 0 properties
 ## Validating backends/wgpu_native/_api.py
 * Enum field FeatureName.subgroups missing in wgpu.h
+* Enum field FeatureName.texture-adapter-specific-format-features missing in wgpu.h
 * Enum PipelineErrorReason missing in wgpu.h
 * Enum AutoLayoutMode missing in wgpu.h
 * Enum field VertexFormat.unorm10-10-10-2 missing in wgpu.h

--- a/wgpu/resources/webgpu.idl
+++ b/wgpu/resources/webgpu.idl
@@ -134,6 +134,7 @@ enum GPUFeatureName {
     "clip-distances",
     "dual-source-blending",
     "subgroups",
+    "texture-adapter-specific-format-features",
 };
 
 [Exposed=(Window, Worker), SecureContext]
@@ -1214,6 +1215,7 @@ interface GPUCanvasContext {
 enum GPUCanvasAlphaMode {
     "opaque",
     "premultiplied",
+    "unpremultiplied",
 };
 
 enum GPUCanvasToneMappingMode {


### PR DESCRIPTION
Hi friends,

Please let me know if I am missing something in this PR! I tried going through the how-to-contribute docs but it's highly likely I missed something.

I ran into an issue where `unpremultiplied` was the only canvas alpha mode available on my Mac, but the  check on line 350 of `_classes.py` inside of `GPUCanvasConfigure` would fail. Adding this to the enum fixes it and I am able to use alpha blending.

I also had to use `texture-adapter-specific-format-features` to enable multisampling on f32 textures. Using the string works, but I figured I'd add it too since I am changing things.

Looking forward to feedback!

Best,
Ana