### PR TITLE
Add examples for instance extras

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -311,7 +311,7 @@ given in a different order in the list.
     :param query_set: The query set into which to save the result.
     :param index: The index of the query set into which to write the result.
 
-.. py:function:: wgpu.backends.wgpu_native.begin_pipeline_statistics_query(encoder, query_set, index)
+.. py:function:: wgpu.backends.wgpu_native.end_pipeline_statistics_query(encoder, query_set, index)
 
     Stop collecting statistics and write them into the query set.
 

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -45,6 +45,7 @@ It also works out of the box, because the wgpu-native DLL is shipped with wgpu-p
 The wgpu_native backend provides a few extra functionalities:
 
 .. py:function:: wgpu.backends.wgpu_native.request_device_sync(adapter, trace_path, *, label="", required_features, required_limits, default_queue)
+
     An alternative to :func:`wgpu.GPUAdapter.request_adapter`, that streams a trace
     of all low level calls to disk, so the visualization can be replayed (also on other systems),
     investigated, and debugged.
@@ -166,9 +167,9 @@ they reduce driver overhead on the CPU.
 
 The first two require that you enable the feature ``"multi-draw-indirect"``.
 
-.. py:function:: wgpu.backends.wgpu_native.multi_draw_indirect(render_pass_encoder, buffer, *, offset=0, count):
+.. py:function:: wgpu.backends.wgpu_native.multi_draw_indirect(render_pass_encoder, buffer, *, offset=0, count)
 
-     Equivalent to::
+    Equivalent to::
         for i in range(count):
             render_pass_encoder.draw_indirect(buffer, offset + i * 16)
 
@@ -179,9 +180,9 @@ The first two require that you enable the feature ``"multi-draw-indirect"``.
                    Must be a multiple of 4.
     :param count: The number of draw operations to perform.
 
-.. py:function:: wgpu.backends.wgpu_native.multi_draw_indexed_indirect(render_pass_encoder, buffer, *, offset=0, count):
+.. py:function:: wgpu.backends.wgpu_native.multi_draw_indexed_indirect(render_pass_encoder, buffer, *, offset=0, count)
 
-     Equivalent to::
+    Equivalent to::
 
         for i in range(count):
             render_pass_encoder.draw_indexed_indirect(buffer, offset + i * 2-)
@@ -199,9 +200,9 @@ They are identical to the previous two, except that the ``count`` argument is re
 three arguments. The value at ``count_buffer_offset`` in ``count_buffer`` is treated as
 an unsigned 32-bit integer. The ``count`` is the minimum of this value and ``max_count``.
 
-.. py:function:: wgpu.backends.wgpu_native.multi_draw_indirect_count(render_pass_encoder, buffer, *, offset=0, count_buffer, count_offset=0, max_count):
+.. py:function:: wgpu.backends.wgpu_native.multi_draw_indirect_count(render_pass_encoder, buffer, *, offset=0, count_buffer, count_offset=0, max_count)
 
-     Equivalent to::
+    Equivalent to::
 
         count = min(<u32 at count_buffer_offset in count_buffer>, max_count)
         for i in range(count):
@@ -217,9 +218,9 @@ an unsigned 32-bit integer. The ``count`` is the minimum of this value and ``max
                    Must be a multiple of 4.
     :param max_count: The maximum number of draw operations to perform.
 
-.. py:function:: wgpu.backends.wgpu_native.multi_draw_indexed_indirect_count(render_pass_encoder, buffer, *, offset=0, count_buffer, count_offset=0, max_count):
+.. py:function:: wgpu.backends.wgpu_native.multi_draw_indexed_indirect_count(render_pass_encoder, buffer, *, offset=0, count_buffer, count_offset=0, max_count)
 
-     Equivalent to::
+    Equivalent to::
 
         count = min(<u32 at count_buffer_offset in count_buffer>, max_count)
         for i in range(count):
@@ -250,9 +251,9 @@ that point in thie queue. This usage requires
 that the features ``"timestamp-query"`` and ``"timestamp-query-inside-passes"`` are
 both enabled.
 
-.. py:function:: wgpu.backends.wgpu_native.write_timestamp(encoder, query_set, query_index):
+.. py:function:: wgpu.backends.wgpu_native.write_timestamp(encoder, query_set, query_index)
 
-     Writes a timestamp to the timestamp query set and the indicated index.
+    Writes a timestamp to the timestamp query set and the indicated index.
 
     :param encoder: The ComputePassEncoder, RenderPassEncoder, or CommandEncoder.
     :param query_set: The timestamp query set into which to save the result.
@@ -293,7 +294,7 @@ the number of statistics chosen.
 The statistics are always output to the query set in the order above, even if they are
 given in a different order in the list.
 
-.. py:function:: wgpu.backends.wgpu_native.create_statistics_query_set(device, count, statistics):
+.. py:function:: wgpu.backends.wgpu_native.create_statistics_query_set(device, count, statistics)
 
     Create a query set that could hold count entries for the specified statistics.
     The statistics are specified as a list of strings.
@@ -302,7 +303,7 @@ given in a different order in the list.
     :param count: Number of entries that go into the query set.
     :param statistics: A sequence of strings giving the desired statistics.
 
-.. py:function:: wgpu.backends.wgpu_native.begin_pipeline_statistics_query(encoder, query_set, index):
+.. py:function:: wgpu.backends.wgpu_native.begin_pipeline_statistics_query(encoder, query_set, index)
 
     Start collecting statistics.
 
@@ -310,12 +311,42 @@ given in a different order in the list.
     :param query_set: The query set into which to save the result.
     :param index: The index of the query set into which to write the result.
 
-.. py:function:: wgpu.backends.wgpu_native.begin_pipeline_statistics_query(encoder, query_set, index):
+.. py:function:: wgpu.backends.wgpu_native.begin_pipeline_statistics_query(encoder, query_set, index)
 
     Stop collecting statistics and write them into the query set.
 
     :param encoder: The ComputePassEncoder or RenderPassEncoder.
 
+.. py:function:: wgpu.backends.wgpu_native.set_instance_extras(backends, flags, dx12_compiler, gles3_minor_version, fence_behavior, dxil_path, dxc_path, dxc_max_shader_model)
+
+    Sets the global instance with extras. Needs to be called before instance is created (in enumerate_adapters or request_adapters).
+
+    :param backends: bitflags as list[str], which backends to enable on the instance level. Defaults to ``["All"]``. Can be any combination of ``["Vulkan", "GL", "Metal", "DX12", "BrowserWebGPU"]`` or the premade combinations ``["All", "Primary", "secondary"]``. Note that your device needs to support these backends, for detailed information see https://docs.rs/wgpu/latest/wgpu/struct.Backends.html
+    :param flags: bitflags as list[str], debug flags for the compiler. Defaults to ``["Default"]``, can be any combination of ``["Debug", "Validation", "DiscardHalLabels"]``.
+    :param dx12_compiler: enum/str, either "Fxc", "Dxc" or "Undefined". Defaults to "Fxc" same as "Undefined". Dxc requires additional library files.
+    :param gles3_minor_version: enum/int 0, 1 or 2. Defaults to "Atomic" (handled by driver).
+    :param fence_behavior: enum/int, "Normal" or "AutoFinish", Default to "Normal".
+    :param dxil_path: str, path to dxil.dll, defaults to ``None``. None looks in the resource directory.
+    :param dxc_path: str, path to dxcompiler.dll, defaults to ``None``. None looks in the resource directory.
+    :param dxc_max_shader_model: float between 6.0 and 6.7, Maximum shader model the given dll supports. Defaults to 6.5.
+
+Use like the following before the instance is created, which happens during request_adapters or enumerate_adapters.
+
+.. code-block:: py
+
+    import wgpu
+    from wgpu.backends.wgpu_native.extras import set_instance_extras
+    set_instance_extras(
+        backends=["Vulkan"],
+        flags=["Debug"],
+    )
+
+    # ...
+
+    for a in wgpu.gpu.enumerate_adapters_sync():
+        print(a.summary)
+
+For additional useage examples look at `extras_dxc.py` and `extras_debug.py` in the examples directory.
 
 The js_webgpu backend
 ---------------------

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -247,7 +247,7 @@ both enabled.
 
 When ``write_timestamp`` is called with a render pass or compute pass as its first
 argument, a timestamp is written to the indicated query set at the indicated index at
-that point in thie queue. This usage requires
+that point in this queue. This usage requires
 that the features ``"timestamp-query"`` and ``"timestamp-query-inside-passes"`` are
 both enabled.
 
@@ -346,7 +346,7 @@ Use like the following before the instance is created, which happens during requ
     for a in wgpu.gpu.enumerate_adapters_sync():
         print(a.summary)
 
-For additional useage examples look at `extras_dxc.py` and `extras_debug.py` in the examples directory.
+For additional usage examples look at `extras_dxc.py` and `extras_debug.py` in the examples directory.
 
 The js_webgpu backend
 ---------------------

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -319,7 +319,7 @@ given in a different order in the list.
 
 .. py:function:: wgpu.backends.wgpu_native.set_instance_extras(backends, flags, dx12_compiler, gles3_minor_version, fence_behavior, dxil_path, dxc_path, dxc_max_shader_model)
 
-    Sets the global instance with extras. Needs to be called before instance is created (in enumerate_adapters or request_adapters).
+    Sets the global instance with extras. Needs to be called before instance is created (in enumerate_adapters or request_adapter).
 
     :param backends: bitflags as list[str], which backends to enable on the instance level. Defaults to ``["All"]``. Can be any combination of ``["Vulkan", "GL", "Metal", "DX12", "BrowserWebGPU"]`` or the premade combinations ``["All", "Primary", "secondary"]``. Note that your device needs to support these backends, for detailed information see https://docs.rs/wgpu/latest/wgpu/struct.Backends.html
     :param flags: bitflags as list[str], debug flags for the compiler. Defaults to ``["Default"]``, can be any combination of ``["Debug", "Validation", "DiscardHalLabels"]``.
@@ -330,7 +330,7 @@ given in a different order in the list.
     :param dxc_path: str, path to dxcompiler.dll, defaults to ``None``. None looks in the resource directory.
     :param dxc_max_shader_model: float between 6.0 and 6.7, Maximum shader model the given dll supports. Defaults to 6.5.
 
-Use like the following before the instance is created, which happens during request_adapters or enumerate_adapters.
+Use like the following before the instance is created, which happens during request_adapter or enumerate_adapters.
 
 .. code-block:: py
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -328,11 +328,15 @@ def get_draw_function(
             ],
         )
 
+        # debug groups and markers can optionally added to help debugging.
+        render_pass.push_debug_group("Cube Example debug group")
         render_pass.set_pipeline(render_pipeline)
         render_pass.set_index_buffer(index_buffer, "uint32")
         render_pass.set_vertex_buffer(0, vertex_buffer)
         render_pass.set_bind_group(0, bind_group)
+        render_pass.insert_debug_marker("Cube Example draw call here!")
         render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
+        render_pass.pop_debug_group()
         render_pass.end()
 
         device.queue.submit([command_encoder.finish(label="Cube Example render pass command buffer")])

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -227,14 +227,14 @@ def create_pipeline_layout(device: wgpu.GPUDevice):
     ):
         bind_group_layout = device.create_bind_group_layout(
             entries=layout_entries,
-            label=f"Cube Example bind group layout {entries[0]['binding']}",
+            label="Cube Example bind group layout",
         )
         bind_group_layouts.append(bind_group_layout)
         bind_groups.append(
             device.create_bind_group(
                 layout=bind_group_layout,
                 entries=entries,
-                label=f"Cube Example bind group {entries[0]['binding']}",
+                label=f"Cube Example bind group with {len(entries)} entries",
             )
         )
 
@@ -342,7 +342,9 @@ def get_draw_function(
 
     def draw_frame():
         current_texture_view = (
-            canvas.get_context("wgpu").get_current_texture().create_view(label="Cube Example current surface texture view")
+            canvas.get_context("wgpu")
+            .get_current_texture()
+            .create_view(label="Cube Example current surface texture view")
         )
         command_encoder = device.create_command_encoder(
             label="Cube Example render pass command encoder"
@@ -360,12 +362,18 @@ def get_draw_function(
             label="Cube Example render pass",
         )
 
+        # debug groups and markers can optionally be added to help debugging.
+        render_pass.push_debug_group("Cube Example Debug Group")
         render_pass.set_pipeline(render_pipeline)
         render_pass.set_index_buffer(index_buffer, wgpu.IndexFormat.uint32)
         render_pass.set_vertex_buffer(0, vertex_buffer)
         for bind_group_id, bind_group in enumerate(bind_groups):
             render_pass.set_bind_group(bind_group_id, bind_group)
+            render_pass.insert_debug_marker(
+                f"Cube Example bind group {bind_group_id=} set"
+            )
         render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
+        render_pass.pop_debug_group()
         render_pass.end()
 
         device.queue.submit(

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -11,6 +11,7 @@ as a script will use the auto-backend.
 # test_example = true
 
 import time
+from typing import Callable
 
 import wgpu
 import numpy as np
@@ -22,7 +23,9 @@ from rendercanvas.auto import RenderCanvas, loop
 # %% Entrypoints (sync and async)
 
 
-def setup_drawing_sync(canvas, power_preference="high-performance", limits=None):
+def setup_drawing_sync(
+    canvas, power_preference="high-performance", limits: dict = {}
+) -> Callable:
     """Setup to draw a rotating cube on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -37,16 +40,14 @@ def setup_drawing_sync(canvas, power_preference="high-performance", limits=None)
     pipeline_layout, uniform_buffer, bind_group = create_pipeline_layout(device)
     pipeline_kwargs = get_render_pipeline_kwargs(canvas, device, pipeline_layout)
 
-    render_pipeline = device.create_render_pipeline(
-        **pipeline_kwargs, label="Cube Example render pipeline"
-    )
+    render_pipeline = device.create_render_pipeline(**pipeline_kwargs)
 
     return get_draw_function(
         canvas, device, render_pipeline, uniform_buffer, bind_group, asynchronous=False
     )
 
 
-async def setup_drawing_async(canvas, limits=None):
+async def setup_drawing_async(canvas, limits: dict = {}):
     """Setup to async-draw a rotating cube on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -61,9 +62,7 @@ async def setup_drawing_async(canvas, limits=None):
     pipeline_layout, uniform_buffer, bind_group = create_pipeline_layout(device)
     pipeline_kwargs = get_render_pipeline_kwargs(canvas, device, pipeline_layout)
 
-    render_pipeline = await device.create_render_pipeline_async(
-        **pipeline_kwargs, label="Cube Example async render pipeline"
-    )
+    render_pipeline = await device.create_render_pipeline_async(**pipeline_kwargs)
 
     return get_draw_function(
         canvas, device, render_pipeline, uniform_buffer, bind_group, asynchronous=True
@@ -74,11 +73,9 @@ async def setup_drawing_async(canvas, limits=None):
 
 
 def get_render_pipeline_kwargs(
-    canvas,
-    device: wgpu.GPUDevice,
-    pipeline_layout: wgpu.GPUPipelineLayout,
+    canvas, device: wgpu.GPUDevice, pipeline_layout: wgpu.GPUPipelineLayout
 ) -> dict:
-    context: wgpu.GPUCanvasContext = canvas.get_context("wgpu")
+    context = canvas.get_context("wgpu")
     render_texture_format = context.get_preferred_format(device.adapter)
     context.configure(device=device, format=render_texture_format)
 
@@ -87,6 +84,7 @@ def get_render_pipeline_kwargs(
     )
 
     return dict(
+        label="Cube Example render pipeline",
         layout=pipeline_layout,
         vertex={
             "module": shader,
@@ -359,7 +357,7 @@ def get_draw_function(
         render_pass.set_index_buffer(index_buffer, wgpu.IndexFormat.uint32)
         render_pass.set_vertex_buffer(0, vertex_buffer)
         render_pass.set_bind_group(0, bind_group)
-        render_pass.insert_debug_marker("Cube Example bind group set")
+        render_pass.insert_debug_marker("Cube Example draw call here!")
         render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
         render_pass.pop_debug_group()
         render_pass.end()

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -74,7 +74,7 @@ async def setup_drawing_async(canvas, limits=None):
 
 
 def get_render_pipeline_kwargs(
-    canvas: wgpu.WgpuCanvasInterface,
+    canvas,
     device: wgpu.GPUDevice,
     pipeline_layout: wgpu.GPUPipelineLayout,
 ) -> dict:
@@ -237,7 +237,7 @@ def create_pipeline_layout(device: wgpu.GPUDevice):
 
 
 def get_draw_function(
-    canvas: wgpu.WgpuCanvasInterface,
+    canvas,
     device: wgpu.GPUDevice,
     render_pipeline: wgpu.GPURenderPipeline,
     uniform_buffer: wgpu.GPUBuffer,

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -123,8 +123,7 @@ def renderdoc_launcher():
 if __name__ == "__main__":
     # awful hack: if the script is run by a user, we write the tempfile to then run the launcher and auto catpure
     # while the capture itself has an envvar to launch the gui instead.
-    is_renderdoc = os.environ.get("RENDERDOC_CAPTURE", "0") == "1"
-    if is_renderdoc:
+    if "RENDERDOC_CAPTURE" in os.environ:
         setup_demo()
         loop.run()
     else:

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -1,7 +1,10 @@
 """
-Basic example of how to use wgpu-native instance extras to enable debug symbols.
+Basic example of how to use wgpu-native instance extras to enable debug symbols and labels in the shader compiler.
 As debugger we will use RenderDoc (https://renderdoc.org/) - other tools will require a similar setup.
-While RenderDoc doesn't fully support WebGPU - it still works to inspect the Pipeline or with translated shaders.
+While RenderDoc doesn't fully support WebGPU - it can still be useful for inspecting the render pipeline.
+RenderDoc also doesn't support WGSL, so it will work off the naga translated shaders for debug stepping and editing.
+Using DX12 (HLSL) or OpenGL (GLSL) gives a better decompilation experience compared to Vulkan (SPIR-V).
+The Vulkan research structure most closely matches WebGPU.
 """
 
 # run_example = false
@@ -14,8 +17,7 @@ import sys
 import tempfile
 from rendercanvas.auto import RenderCanvas, loop
 
-# this skript has two behaviours, either be an example - or launch RenderDoc.
-
+# this script has two behaviours: launch RenderDoc and run the example.
 
 def setup_demo():
     """

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -6,53 +6,131 @@ While RenderDoc doesn't support WebGPU - it still works to inspect the Pipeline 
 
 # run_example = false
 
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
 from rendercanvas.auto import RenderCanvas, loop
 
-# before we enumerate or request a device, we need to set the instance extras
-# as we import from the base examples, those do the request_device call
-from wgpu.backends.wgpu_native.extras import set_instance_extras
-
-# this communicates with the compiler to enable debug symbols.
-# I have confirmed this works for Vulkan and Dx12, however it seems like it's always enabled for Fxc and doesn't work for Dxc
-# OpenGL sorta works, but even GLSL shader code gets translated by naga, so the code is messed up but symbols are part way still there.
-# TODO can someone test this on Metal?
-set_instance_extras(
-    flags=["Debug"]  # an additional option here is "Validation".
-)
-
-# TODO: replace the default examples by including additional debug markers using Encoder.inser_debug_marker(label)
-try:
-    from .cube import setup_drawing_sync
-except ImportError:
-    from cube import setup_drawing_sync
+# this skript has two behaviours, either be an example - or launch RenderDoc.
 
 
-canvas = RenderCanvas(title="Cube example with debug symbols")
-draw_frame = setup_drawing_sync(canvas)
+def setup_demo():
+    """
+    this is inside a function so it's only called later.
+    """
+    # before we enumerate or request a device, we need to set the instance extras
+    # as we import from the base examples, those do the request_device call
+    from wgpu.backends.wgpu_native.extras import set_instance_extras
+
+    # this communicates with the compiler to enable debug symbols.
+    # I have confirmed this works for Vulkan and Dx12, however it seems like it's always enabled for Fxc and doesn't work for Dxc
+    # OpenGL sorta works, but even GLSL shader code gets translated by naga, so the code is messed up but symbols are part way still there.
+    # TODO can someone test this on Metal?
+    set_instance_extras(
+        flags=["Debug"]  # an additional option here is "Validation".
+    )
+
+    # TODO: replace the default examples by including additional debug markers using Encoder.inser_debug_marker(label)
+    try:
+        from .cube import setup_drawing_sync
+    except ImportError:
+        from cube import setup_drawing_sync
+
+    canvas = RenderCanvas(title="Cube example with debug symbols")
+    draw_frame = setup_drawing_sync(canvas)
+
+    # we set the auto capture on frame 50, so after 100 frames gui should exit
+    # this will lead to RenderDoc automatically opening the capture!
+    frame_count = 0
+
+    @canvas.request_draw
+    def animate():
+        nonlocal frame_count
+        frame_count += 1
+        draw_frame()
+        canvas.request_draw()
+        if frame_count > 100:
+            print("Stopping the loop after 100 frames")
+            canvas.close()
 
 
-@canvas.request_draw
-def animate():
-    draw_frame()
-    canvas.request_draw()
+def renderdoc_launcher():
+    """
+    This writes a temporary .cap file which contains all the renderdoc capture setup.
+    Then launches the gui.
+    """
+    cap_settings = {
+        "rdocCaptureSettings": 1,
+        "settings": {
+            "autoStart": "true",
+            "commandLine": str(Path(__file__).name),
+            "environment": [
+                {
+                    "separator": "Platform style",
+                    "type": "Set",
+                    "value": "Vulkan",  # not required but you can set something else here!
+                    "variable": "WGPU_BACKEND_TYPE",
+                },
+                {
+                    "separator": "Platform style",
+                    "type": "Set",
+                    "value": 1,
+                    "variable": "RENDERDOC_CAPTURE",  # this is used specifically for this example to avoid a fork bomb.
+                },
+            ],
+            "executable": str(sys.executable),
+            "inject": "false",
+            "numQueuedFrames": 1,
+            "options": {
+                "allowFullscreen": "true",
+                "allowVSync": "true",
+                "apiValidation": "false",
+                "captureAllCmdLists": "false",
+                "captureCallstacks": "false",
+                "captureCallstacksOnlyDraws": "false",
+                "debugOutputMute": "true",
+                "delayForDebugger": 0,
+                "hookIntoChildren": "true",
+                "refAllResources": "false",
+                "softMemoryLimit": 0,
+                "verifyBufferAccess": "false",
+            },
+            "queuedFrameCap": 50,
+            "workingDir": str(Path(__file__).parent),
+        },
+    }
+
+    cap_str = json.dumps(cap_settings, indent=4)
+    cap_file = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".cap", delete=False, encoding="utf-8"
+    )
+    with open(cap_file.name, "w") as f:
+        f.write(cap_str)
+    cap_file.close()  # doesn't the contextmanager make sure the file is closed and not blocked?
+
+    # relies on having associated the .cap file with RenderDoc in Windows?
+    # TODO: other OS???
+    # is this now a child process or can the python script end?
+    subprocess.run(["start", cap_file.name], shell=True)
+    # TODO: cleanup tempfiles?
 
 
 if __name__ == "__main__":
-    loop.run()
-    # the first thing you might notice is that additional information is logged in your terminal.
+    # awful hack: if the script is run by a user, we write the tempfile to then run the launcher and auto catpure
+    # while the capture itself has an envvar to launch the gui instead.
+    is_renderdoc = os.environ.get("RENDERDOC_CAPTURE", "0") == "1"
+    if is_renderdoc:
+        setup_demo()
+        loop.run()
+    else:
+        renderdoc_launcher()
+        print("Should have opened the RenderDoc GUI, python process should close")
 
-# TODO maybe write this as a doc instead with screenshots perhaps?
-# to launch this script using RenderDoc and capture a frame there use the following settings in the Launch Application tab:
-# - Executable Path: python path
-# - Working Directory: ~\wgpu-py\examples
-# - Command Line Arguments: extras_debug.py
-# - Environment Variables: - # can be left empty, `WGPU_BACKEND_TYPE=D3D12` for example works here
-# make sure to check "Capture Child Processes"
-# click on "Launch"! the GUI should start and you should see an overlay text in the frame telling you to hit F12 to capture a frame.
-# Open the capture and on the left hand side in the Event Browser find the `vkCmdDrawIndexed` event. Click to open this event.
+# The capture should have opened now, on the left hand side in the Event Browser find the `vkCmdDrawIndexed` event. Click to open this event.
 # Now the Pipeline State should let you chose either Vertex Shader or Fragment Shader and see a button called "View" next to the ShaderModule.
 # If you see the source code from the example including symbols and comments then it worked!
 # Note that using Dx12 will not show the the same source, as naga translated the shader to HLSL.
 # as RenderDoc doesn't support WGSL, you won't be able to edit or step the source directly with Vulkan.
-
-# TODO: automate the launching and capturing using the scripting api?

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -83,6 +83,12 @@ def renderdoc_launcher():
                     "value": 1,
                     "variable": "RENDERDOC_CAPTURE",  # this is used specifically for this example to avoid a fork bomb.
                 },
+                # {
+                #     "separator": "Platform style",
+                #     "type": "Set",
+                #     "value": 1,
+                #     "variable": "WGPU_DEBUG", # if you have a debug build of wgpu-native in your resource directory, you can use it like this.
+                # },
             ],
             "executable": str(sys.executable),
             "inject": "false",

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -4,7 +4,7 @@ As debugger we will use RenderDoc (https://renderdoc.org/) - other tools will re
 While RenderDoc doesn't support WebGPU - it still works to inspect the Pipeline or with translated shaders.
 """
 
-# test_example = false
+# run_example = false
 
 from rendercanvas.auto import RenderCanvas, loop
 
@@ -14,7 +14,8 @@ from wgpu.backends.wgpu_native.extras import set_instance_extras
 
 # this communicates with the compiler to enable debug symbols.
 # I have confirmed this works for Vulkan and Dx12, however it seems like it's always enabled for Fxc and doesn't work for Dxc
-# TODO can someone test this on Metal (OpenGL?)
+# OpenGL sorta works, but even GLSL shader code gets translated by naga, so the code is messed up but symbols are part way still there.
+# TODO can someone test this on Metal?
 set_instance_extras(
     flags=["Debug"]  # an additional option here is "Validation".
 )
@@ -52,5 +53,6 @@ if __name__ == "__main__":
 # Now the Pipeline State should let you chose either Vertex Shader or Fragment Shader and see a button called "View" next to the ShaderModule.
 # If you see the source code from the example including symbols and comments then it worked!
 # Note that using Dx12 will not show the the same source, as naga translated the shader to HLSL.
+# as RenderDoc doesn't support WGSL, you won't be able to edit or step the source directly with Vulkan.
 
 # TODO: automate the launching and capturing using the scripting api?

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -1,0 +1,56 @@
+"""
+Basic example of how to use wgpu-native instance extras to enable debug symbols.
+As debugger we will use RenderDoc (https://renderdoc.org/) - other tools will require a similar setup.
+While RenderDoc doesn't support WebGPU - it still works to inspect the Pipeline or with translated shaders.
+"""
+
+# test_example = false
+
+from rendercanvas.auto import RenderCanvas, loop
+
+# before we enumerate or request a device, we need to set the instance extras
+# as we import from the base examples, those do the request_device call
+from wgpu.backends.wgpu_native.extras import set_instance_extras
+
+# this communicates with the compiler to enable debug symbols.
+# I have confirmed this works for Vulkan and Dx12, however it seems like it's always enabled for Fxc and doesn't work for Dxc
+# TODO can someone test this on Metal (OpenGL?)
+set_instance_extras(
+    flags=["Debug"]  # an additional option here is "Validation".
+)
+
+# TODO: replace the default examples by including additional debug markers using Encoder.inser_debug_marker(label)
+try:
+    from .cube import setup_drawing_sync
+except ImportError:
+    from cube import setup_drawing_sync
+
+
+canvas = RenderCanvas(title="Cube example with debug symbols")
+draw_frame = setup_drawing_sync(canvas)
+
+
+@canvas.request_draw
+def animate():
+    draw_frame()
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    loop.run()
+    # the first thing you might notice is that additional information is logged in your terminal.
+
+# TODO maybe write this as a doc instead with screenshots perhaps?
+# to launch this script using RenderDoc and capture a frame there use the following settings in the Launch Application tab:
+# - Executable Path: python path
+# - Working Directory: ~\wgpu-py\examples
+# - Command Line Arguments: extras_debug.py
+# - Environment Variables: - # can be left empty, `WGPU_BACKEND_TYPE=D3D12` for example works here
+# make sure to check "Capture Child Processes"
+# click on "Launch"! the GUI should start and you should see an overlay text in the frame telling you to hit F12 to capture a frame.
+# Open the capture and on the left hand side in the Event Browser find the `vkCmdDrawIndexed` event. Click to open this event.
+# Now the Pipeline State should let you chose either Vertex Shader or Fragment Shader and see a button called "View" next to the ShaderModule.
+# If you see the source code from the example including symbols and comments then it worked!
+# Note that using Dx12 will not show the the same source, as naga translated the shader to HLSL.
+
+# TODO: automate the launching and capturing using the scripting api?

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -1,7 +1,7 @@
 """
 Basic example of how to use wgpu-native instance extras to enable debug symbols.
 As debugger we will use RenderDoc (https://renderdoc.org/) - other tools will require a similar setup.
-While RenderDoc doesn't support WebGPU - it still works to inspect the Pipeline or with translated shaders.
+While RenderDoc doesn't fully support WebGPU - it still works to inspect the Pipeline or with translated shaders.
 """
 
 # run_example = false
@@ -19,9 +19,9 @@ from rendercanvas.auto import RenderCanvas, loop
 
 def setup_demo():
     """
-    this is inside a function so it's only called later.
+    this is inside a function so it's only called later. Similar to other examples
     """
-    # before we enumerate or request a device, we need to set the instance extras
+    # before we enumerate or request a device, we need to set instance extras
     # as we import from the base examples, those do the request_device call
     from wgpu.backends.wgpu_native.extras import set_instance_extras
 
@@ -33,7 +33,7 @@ def setup_demo():
         flags=["Debug"]  # an additional option here is "Validation".
     )
 
-    # TODO: replace the default examples by including additional debug markers using Encoder.inser_debug_marker(label)
+    # TODO: replace the default examples by including additional debug markers using encoder.inser_debug_marker(label)
     try:
         from .cube import setup_drawing_sync
     except ImportError:
@@ -62,6 +62,9 @@ def renderdoc_launcher():
     This writes a temporary .cap file which contains all the renderdoc capture setup.
     Then launches the gui.
     """
+    # see https://renderdoc.org/docs/window/capture_attach.html for explanation
+    # and https://renderdoc.org/docs/python_api/qrenderdoc/main.html#qrenderdoc.CaptureSettings for details
+    # the following settings work for me, although variations should mostly work.
     cap_settings = {
         "rdocCaptureSettings": 1,
         "settings": {
@@ -113,8 +116,7 @@ def renderdoc_launcher():
 
     # relies on having associated the .cap file with RenderDoc in Windows?
     # TODO: other OS???
-    # is this now a child process or can the python script end?
-    subprocess.run(["start", cap_file.name], shell=True)
+    subprocess.run([cap_file.name], shell=True)
     # TODO: cleanup tempfiles?
 
 

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -114,9 +114,15 @@ def renderdoc_launcher():
         f.write(cap_str)
     cap_file.close()  # doesn't the contextmanager make sure the file is closed and not blocked?
 
-    # relies on having associated the .cap file with RenderDoc in Windows?
-    # TODO: other OS???
-    subprocess.run([cap_file.name], shell=True)
+    # relies on having associated the .cap file with RenderDoc
+    # TODO: other OS - untested
+    if sys.platform.startswith("win"):
+        # apparently this should be none blocking and safer
+        os.startfile(cap_file.name)
+    elif sys.platform.startswith("darwin"):  # macOS
+        subprocess.Popen(["open", cap_file.name])
+    else:  # likely Linux
+        subprocess.Popen(["xdg-open", cap_file.name])
     # TODO: cleanup tempfiles?
 
 

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -19,6 +19,7 @@ from rendercanvas.auto import RenderCanvas, loop
 
 # this script has two behaviours: launch RenderDoc and run the example.
 
+
 def renderdoc_launcher():
     """
     This writes a temporary .cap file which contains all the renderdoc capture setup.
@@ -31,7 +32,8 @@ def renderdoc_launcher():
         "rdocCaptureSettings": 1,
         "settings": {
             "autoStart": "true",
-            "commandLine": str(Path(__file__).name) + " 1", # by adding an argument we signal that the script should run the example
+            "commandLine": str(Path(__file__).name)
+            + " example",  # by adding an argument we signal that the script should run the example
             "environment": [
                 {
                     "separator": "Platform style",
@@ -88,6 +90,7 @@ def renderdoc_launcher():
         subprocess.Popen(["xdg-open", cap_file.name])
     # TODO: cleanup tempfiles?
 
+
 def setup_demo():
     """
     this is inside a function so it's only called later. Similar to other examples
@@ -127,19 +130,22 @@ def setup_demo():
             canvas.close()
 
 
-
 if __name__ == "__main__":
     # if the script is run by a user, we write the tempfile to then run the launcher and auto catpure
     # to know if the script is launched by the launcher, we call it with an argument
-    if len(sys.argv) == 1: # essentially means no arguments provided
+    if len(sys.argv) == 1:  # essentially means no arguments provided
         renderdoc_launcher()
         print("Should have opened the RenderDoc GUI, python process should close")
     else:
         setup_demo()
         loop.run()
 
-# The capture should have opened now, on the left hand side in the Event Browser find the `vkCmdDrawIndexed` event. Click to open this event.
-# Now the Pipeline State should let you chose either Vertex Shader or Fragment Shader and see a button called "View" next to the ShaderModule.
+# The capture should have opened now, on the left hand side in the Event Browser find the `vkCmdDrawIndexed` event. Inside the render pass inside the debug group.
+# Clicking the timer button at the top of the Event Browser helps to locate interesting events. https://renderdoc.org/docs/window/event_browser.html#timing-actions
+# Now the Pipeline State tab should let you chose either Vertex Shader or Fragment Shader and see a button called "View" next to the ShaderModule.
 # If you see the source code from the example including symbols and comments then it worked!
-# Note that using Dx12 will not show the the same source, as naga translated the shader to HLSL.
-# as RenderDoc doesn't support WGSL, you won't be able to edit or step the source directly with Vulkan.
+
+# known issues:
+# Other backends don't always capture automatically. Make sure to press F11 to cycle if the overlays says so.
+# If the child process isn't automatically hooked, select the `python.exe` from the Child Processes list manually.
+# the auto capture and auto exit might be too quick, so increase those values don't capture manually.

--- a/examples/extras_debug.py
+++ b/examples/extras_debug.py
@@ -131,7 +131,7 @@ def setup_demo():
 
 
 if __name__ == "__main__":
-    # if the script is run by a user, we write the tempfile to then run the launcher and auto catpure
+    # if the script is run by a user, we write the tempfile to then run the launcher with auto capture
     # to know if the script is launched by the launcher, we call it with an argument
     if len(sys.argv) == 1:  # essentially means no arguments provided
         renderdoc_launcher()

--- a/examples/extras_dxc.py
+++ b/examples/extras_dxc.py
@@ -4,19 +4,21 @@ Since this will only work on Windows it's not meant for the test suite.
 You can run the download script using `python tools/download_dxc.py` to download the latest Dxc release from GitHub. And extract it to the resource directory.
 """
 
-# test_examples = false
+# test_example = false
 
 from rendercanvas.auto import RenderCanvas, loop
 
-# before we enumerate or request a device, we need to set the extras
+# before we enumerate or request a device, we need to set the instance extras
 # as we import from the base examples, those do the request_device call
 from wgpu.backends.wgpu_native.extras import set_instance_extras
 
 set_instance_extras(
-    backends=["DX12"], # we only want to use Dx12 for this example
-    dx12_compiler="Dxc", # request the Dxc compiler to be used
+    backends=[
+        "DX12"
+    ],  # using the env var `WGPU_BACKEND_TYPE` happens later during request_device, so you can only select backends that are requested for the instance
+    dx12_compiler="Dxc",  # request the Dxc compiler to be used
     # dxil_path and dxc_path can be set for a custom Dxc location
-    dxc_max_shader_model=6.7
+    dxc_max_shader_model=6.7,
 )
 
 
@@ -40,4 +42,3 @@ if __name__ == "__main__":
     loop.run()
     # But how do you know this is actually using Dxc over Fxc?
     # perhaps performance, but we can also use Debug tools to be sure.
-    # TODO: renderdoc launcher example?

--- a/examples/extras_dxc.py
+++ b/examples/extras_dxc.py
@@ -1,0 +1,43 @@
+"""
+Simple example to show how the wgpu-native extras can be used to use dxc compiler for DX12.
+Since this will only work on Windows it's not meant for the test suite.
+You can run the download script using `python tools/download_dxc.py` to download the latest Dxc release from GitHub. And extract it to the resource directory.
+"""
+
+# test_examples = false
+
+from rendercanvas.auto import RenderCanvas, loop
+
+# before we enumerate or request a device, we need to set the extras
+# as we import from the base examples, those do the request_device call
+from wgpu.backends.wgpu_native.extras import set_instance_extras
+
+set_instance_extras(
+    backends=["DX12"], # we only want to use Dx12 for this example
+    dx12_compiler="Dxc", # request the Dxc compiler to be used
+    # dxil_path and dxc_path can be set for a custom Dxc location
+    dxc_max_shader_model=6.7
+)
+
+
+try:
+    from .cube import setup_drawing_sync
+except ImportError:
+    from cube import setup_drawing_sync
+
+
+canvas = RenderCanvas(title="Cube example on DX12 using Dxc")
+draw_frame = setup_drawing_sync(canvas)
+
+
+@canvas.request_draw
+def animate():
+    draw_frame()
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    loop.run()
+    # But how do you know this is actually using Dxc over Fxc?
+    # perhaps performance, but we can also use Debug tools to be sure.
+    # TODO: renderdoc launcher example?

--- a/examples/extras_dxc.py
+++ b/examples/extras_dxc.py
@@ -4,7 +4,7 @@ Since this will only work on Windows it's not meant for the test suite.
 You can run the download script using `python tools/download_dxc.py` to download the latest Dxc release from GitHub. And extract it to the resource directory.
 """
 
-# test_example = false
+# run_example = false
 
 from rendercanvas.auto import RenderCanvas, loop
 

--- a/tools/download_dxc.py
+++ b/tools/download_dxc.py
@@ -1,0 +1,78 @@
+# helper script to download files needed to use dxc. Information based on: https://docs.rs/wgpu/25.0.2/wgpu/enum.Dx12Compiler.html#variant.DynamicDxc
+# this will improve for v26 so this script should be updated for wgpu 26, let @Vipitis know if this script is outdated.
+# inspired by download_wgpu_native.py
+
+import argparse
+import os
+import tempfile
+from zipfile import ZipFile
+import requests
+
+from download_wgpu_native import RESOURCE_DIR, download_file, get_os_string
+
+# changed to use a specific arch
+def extract_file(zip_filename, member, path):
+    # Read file from archive, find it no matter the folder structure
+    z = ZipFile(zip_filename)
+    bb = z.read(f"bin/x64/{member}") # this one works for me... maybe we can parameterize arch?
+    # Write to disk
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, member), "wb") as f:
+        f.write(bb)
+
+
+def get_latest_release() -> str:
+    url = "https://api.github.com/repos/microsoft/DirectXShaderCompiler/releases/latest"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to get latest release: {response.status_code=}")
+    data = response.json()
+    return data["tag_name"] #.removeprefix("v") # to be inline with the other script?
+
+def get_filename(version: str) -> str:
+    """returns the filename of the dxc_yyyy_mm_dd.zip file so we can download it"""
+    url = f"https://api.github.com/repos/microsoft/DirectXShaderCompiler/releases/tags/{version}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to get release info: {response.status_code=}")
+    data = response.json()
+    for asset in data["assets"]:
+        if asset["name"].startswith("dxc_") and asset["name"].endswith(".zip"):
+            return asset["name"]
+    raise RuntimeError(f"Couldn't find dxc archive for release {version}")
+
+def main(version=None):
+    if version is None:
+        version = get_latest_release()
+    os_string = get_os_string()
+    if os_string != "windows":
+        raise RuntimeError("Dxc only supported on Windows")
+    filename = get_filename(version)
+    url = f"https://github.com/microsoft/DirectXShaderCompiler/releases/download/{version}/{filename}" # or use the api response for "browser_download_url"?
+    tmp = tempfile.gettempdir()
+    zip_filename = os.path.join(tmp, filename)
+    print(f"Downloading {url}")
+    download_file(url, zip_filename)
+    compiler_file = "dxcompiler.dll"
+    signing_file = "dxil.dll" # in v26 this won't be needed anymore
+    print(f"Extracting {compiler_file} to {RESOURCE_DIR}")
+    extract_file(zip_filename, compiler_file, RESOURCE_DIR)
+    print(f"Extracting {signing_file} to {RESOURCE_DIR}")
+    extract_file(zip_filename, signing_file, RESOURCE_DIR)
+
+    # cleanup of tempfile?
+    # os.remove(zip_filename)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download Dxc from github release."
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default=None,
+        help="Version of dxc to download, defaults to latest.",
+    )
+    args = parser.parse_args()
+
+    main(version=args.version)

--- a/tools/download_dxc.py
+++ b/tools/download_dxc.py
@@ -10,11 +10,14 @@ import requests
 
 from download_wgpu_native import RESOURCE_DIR, download_file, get_os_string
 
+
 # changed to use a specific arch
 def extract_file(zip_filename, member, path):
     # Read file from archive, find it no matter the folder structure
     z = ZipFile(zip_filename)
-    bb = z.read(f"bin/x64/{member}") # this one works for me... maybe we can parameterize arch?
+    bb = z.read(
+        f"bin/x64/{member}"
+    )  # this one works for me... maybe we can parameterize arch?
     # Write to disk
     os.makedirs(path, exist_ok=True)
     with open(os.path.join(path, member), "wb") as f:
@@ -27,7 +30,8 @@ def get_latest_release() -> str:
     if response.status_code != 200:
         raise RuntimeError(f"Failed to get latest release: {response.status_code=}")
     data = response.json()
-    return data["tag_name"] #.removeprefix("v") # to be inline with the other script?
+    return data["tag_name"]  # .removeprefix("v") # to be inline with the other script?
+
 
 def get_filename(version: str) -> str:
     """returns the filename of the dxc_yyyy_mm_dd.zip file so we can download it"""
@@ -41,6 +45,7 @@ def get_filename(version: str) -> str:
             return asset["name"]
     raise RuntimeError(f"Couldn't find dxc archive for release {version}")
 
+
 def main(version=None):
     if version is None:
         version = get_latest_release()
@@ -48,13 +53,13 @@ def main(version=None):
     if os_string != "windows":
         raise RuntimeError("Dxc only supported on Windows")
     filename = get_filename(version)
-    url = f"https://github.com/microsoft/DirectXShaderCompiler/releases/download/{version}/{filename}" # or use the api response for "browser_download_url"?
+    url = f"https://github.com/microsoft/DirectXShaderCompiler/releases/download/{version}/{filename}"  # or use the api response for "browser_download_url"?
     tmp = tempfile.gettempdir()
     zip_filename = os.path.join(tmp, filename)
     print(f"Downloading {url}")
     download_file(url, zip_filename)
     compiler_file = "dxcompiler.dll"
-    signing_file = "dxil.dll" # in v26 this won't be needed anymore
+    signing_file = "dxil.dll"  # in v26 this won't be needed anymore
     print(f"Extracting {compiler_file} to {RESOURCE_DIR}")
     extract_file(zip_filename, compiler_file, RESOURCE_DIR)
     print(f"Extracting {signing_file} to {RESOURCE_DIR}")
@@ -63,10 +68,9 @@ def main(version=None):
     # cleanup of tempfile?
     # os.remove(zip_filename)
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Download Dxc from github release."
-    )
+    parser = argparse.ArgumentParser(description="Download Dxc from github release.")
     parser.add_argument(
         "--version",
         type=str,


### PR DESCRIPTION
This was mentioned in reply https://github.com/pygfx/wgpu-py/pull/718#pullrequestreview-2961214178

PR adds two examples regarding instance extras:

* Using DXC(over FXC) on Windows, includes a script to download the required library files.
* Debugging using a graphics debugger like RenderDoc, includes a portable variant with a .cap file: works when your OS is setup to open .cap file with RenderDoc. Adds annotation and labels to the cube example.
* documents the function in docs.

todos:
- [x] insert debug markers for the example
- [x] add labels to the example so they show up during debugging
- [ ] fix more typos
- [ ] add hyperlinks to other parts of the docs
- [ ] update guide docs debug section?
- [ ] file issue with Dxc not using debug flags in wgpu-core (perhaps in v26?) ref: https://github.com/gfx-rs/wgpu-native/issues/487
- [ ] resolve arch, if needed?