### PR TITLE
Fix ImguiRenderer and simplify gui callback function

### DIFF
--- a/examples/imgui_basic_example.py
+++ b/examples/imgui_basic_example.py
@@ -25,7 +25,6 @@ imgui_renderer = ImguiRenderer(device, canvas)
 
 
 def update_gui():
-    imgui.new_frame()
     if imgui.begin_main_menu_bar():
         if imgui.begin_menu("File", True):
             clicked_quit, _ = imgui.menu_item("Quit", "Cmd+Q", False, True)
@@ -66,11 +65,6 @@ def update_gui():
                 imgui.close_current_popup()
 
     imgui.end()
-
-    imgui.end_frame()
-    imgui.render()
-
-    return imgui.get_draw_data()
 
 
 # set the GUI update function that gets called to return the draw data

--- a/examples/imgui_cmap_picker.py
+++ b/examples/imgui_cmap_picker.py
@@ -81,7 +81,6 @@ current_cmap = cmaps[0]
 
 
 def update_gui():
-    imgui.new_frame()
     global current_cmap
 
     imgui.set_next_window_size((175, 0), imgui.Cond_.appearing)
@@ -109,11 +108,6 @@ def update_gui():
             current_cmap = cmap_name
 
     imgui.end()
-
-    imgui.end_frame()
-    imgui.render()
-
-    return imgui.get_draw_data()
 
 
 imgui_renderer.set_gui(update_gui)

--- a/examples/imgui_multi_canvas.py
+++ b/examples/imgui_multi_canvas.py
@@ -28,8 +28,6 @@ imgui_renderer3 = ImguiRenderer(device, canvas3)
 
 # Separate GUIs that are drawn to each canvas
 def update_gui1():
-    imgui.new_frame()
-
     imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
     imgui.set_next_window_pos((0, 20), imgui.Cond_.appearing)
 
@@ -38,15 +36,8 @@ def update_gui1():
 
     imgui.end()
 
-    imgui.end_frame()
-    imgui.render()
-
-    return imgui.get_draw_data()
-
 
 def update_gui2():
-    imgui.new_frame()
-
     imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
     imgui.set_next_window_pos((0, 20), imgui.Cond_.appearing)
 
@@ -55,15 +46,8 @@ def update_gui2():
 
     imgui.end()
 
-    imgui.end_frame()
-    imgui.render()
-
-    return imgui.get_draw_data()
-
 
 def update_gui3():
-    imgui.new_frame()
-
     imgui.set_next_window_size((300, 0), imgui.Cond_.appearing)
     imgui.set_next_window_pos((0, 20), imgui.Cond_.appearing)
 
@@ -71,11 +55,6 @@ def update_gui3():
     imgui.button("b3")
 
     imgui.end()
-
-    imgui.end_frame()
-    imgui.render()
-
-    return imgui.get_draw_data()
 
 
 # give the corresponding gui updater functions to the imgui renderers

--- a/examples/imgui_renderer_sea.py
+++ b/examples/imgui_renderer_sea.py
@@ -304,7 +304,6 @@ app_state = {
 
 
 def gui(app_state):
-    imgui.new_frame()
     imgui.set_next_window_pos((0, 0), imgui.Cond_.appearing)
     imgui.set_next_window_size((400, 0), imgui.Cond_.appearing)
     imgui.begin("Shader parameters", None)
@@ -333,9 +332,6 @@ def gui(app_state):
     )
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 global_time = time.perf_counter()

--- a/wgpu/utils/imgui/imgui_renderer.py
+++ b/wgpu/utils/imgui/imgui_renderer.py
@@ -115,8 +115,7 @@ class ImguiRenderer:
         Arguments
         ---------
         gui_updater: callable
-            GUI update function, must return imgui.ImDrawData: the draw data to
-            render, this is usually obtained by calling ``imgui.get_draw_data()``
+            GUI update function.
 
         Returns
         -------
@@ -146,7 +145,6 @@ class ImguiRenderer:
             )
 
         imgui.set_current_context(self.imgui_context)
-        draw_data = self._update_gui_function()
 
         pixel_ratio = self._canvas_context.canvas.get_pixel_ratio()
         lsize = self._canvas_context.canvas.get_logical_size()
@@ -166,6 +164,12 @@ class ImguiRenderer:
                 }
             ],
         )
+
+        imgui.new_frame()
+        self._update_gui_function()
+        imgui.render()
+        draw_data = imgui.get_draw_data()
+
         self._backend.render(draw_data, render_pass)
         render_pass.end()
         self._backend._device.queue.submit([command_encoder.finish()])

--- a/wgpu/utils/imgui/stats.py
+++ b/wgpu/utils/imgui/stats.py
@@ -74,8 +74,6 @@ class Stats:
         self.__window_size = None
 
     def _draw_imgui(self):
-        imgui.new_frame()
-
         imgui.set_next_window_size((0, 0), imgui.Cond_.always)
 
         if self._align == "right" and self.__window_size is not None:
@@ -124,10 +122,6 @@ class Stats:
         imgui.end()
 
         imgui.pop_style_color()
-
-        imgui.end_frame()
-        imgui.render()
-        return imgui.get_draw_data()
 
     def _on_mouse(self, event):
         if self._renderer.backend.io.want_capture_mouse:


### PR DESCRIPTION
This PR fixes an occasional issue in `ImguiRenderer` that could occur during window resizing. Specifically, we should obtain the frame's imgui `draw_data` after updating `backend.io.display_size`.

In addition, we previously modified the API in #539 to introduce a GUI update hook function for ImguiRenderer. This hook can be further simplified—users should only need to write their GUI logic within the function, without having to include repetitive boilerplate code such as obtaining `draw_data`.

While this API change is not urgent—since modifying the interface could introduce compatibility issues for downstream projects—it’s a good opportunity to streamline the API, given the major update to ImGui v1.92 in #725 .