### PR TITLE
Remove additional call to `._release`

### DIFF
--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -3508,9 +3508,6 @@ class GPUComputePassEncoder(
     def end(self) -> None:
         # H: void f(WGPUComputePassEncoder computePassEncoder)
         libf.wgpuComputePassEncoderEnd(self._internal)
-        # Need to release, see https://github.com/gfx-rs/wgpu-native/issues/412
-        # As of wgpu-native v22.1.0.5, this bug is still present.
-        self._release()
 
     def _maybe_keep_alive(self, object):
         pass
@@ -3596,9 +3593,6 @@ class GPURenderPassEncoder(
     def end(self) -> None:
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEnd(self._internal)
-        # Need to release, see https://github.com/gfx-rs/wgpu-native/issues/412
-        # As of wgpu-native v22.1.0.5, this bug is still present.
-        self._release()
 
     def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
         bundle_ids = [bundle._internal for bundle in bundles]


### PR DESCRIPTION
This was an upstream bug that got fixed a while ago: https://github.com/gfx-rs/wgpu-native/issues/412

Now seems to work without the call to release