### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Test Linux py39
-            os: ubuntu-latest
-            pyversion: '3.9'
           - name: Test Linux py310
             os: ubuntu-latest
             pyversion: '3.10'

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -7,7 +7,7 @@ Install with pip
 ----------------
 
 You can install ``wgpu-py`` with your favourite package manager (we use ``pip`` in the example commands below).
-Python 3.9 or higher is required. Pypy is supported.
+Python 3.10 or higher is required. Pypy is supported.
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Almar Klein" }, { name = "Korijn van Golen" }]
 keywords = ["webgpu", "wgpu", "vulkan", "metal", "DX12", "opengl"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
     "cffi>=1.15.0",
     "rubicon-objc>=0.4.1; sys_platform == 'darwin'",


### PR DESCRIPTION
Makes typing a bit easier, and is EOL a month from now.