### PR TITLE
Bump wgpu native to 25.0.2.2

### DIFF
--- a/examples/compute_int64.py
+++ b/examples/compute_int64.py
@@ -1,0 +1,66 @@
+"""
+simple example of using the int64 shader feature
+"""
+
+import wgpu
+
+adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+device = adapter.request_device_sync(required_features=["shader-int64"])
+
+add_shader = """
+@group(0) @binding(0)
+var<storage, read_write> data: array<i64>;
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) index: vec3<u32>) {
+    let i: u32 = index.x;
+    let a_idx = i * 3u;
+    let b_idx = a_idx + 1u;
+    let c_idx = a_idx + 2u;
+    data[c_idx] = data[a_idx] + data[b_idx];
+}
+"""
+a = 0x1234567890
+b = 0x9876543210
+data = memoryview(bytearray(6*8)).cast("q") # signed long long >= 64 bits
+data[0] = a
+data[1] = b
+data[3] = -a
+data[4] = -b
+
+buffer = device.create_buffer_with_data(data=data, usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.COPY_SRC | wgpu.BufferUsage.COPY_DST)
+pipeline = device.create_compute_pipeline(
+    layout="auto",
+    compute={
+        "module": device.create_shader_module(code=add_shader),
+        "entry_point": "main",
+    }
+)
+
+bind_group = device.create_bind_group(
+    layout=pipeline.get_bind_group_layout(0),
+    entries=[
+        {
+            "binding": 0,
+            "resource": {"buffer": buffer, "offset": 0, "size": buffer.size},
+        }
+    ],
+)
+
+command_encoder = device.create_command_encoder()
+compute_pass = command_encoder.begin_compute_pass()
+compute_pass.set_pipeline(pipeline)
+compute_pass.set_bind_group(0, bind_group)
+compute_pass.dispatch_workgroups(2) # we do two calculations
+compute_pass.end()
+device.queue.submit([command_encoder.finish()])
+result = device.queue.read_buffer(buffer)
+res = result.cast("q").tolist()
+c = a + b
+assert res[2] == c, f"expected {c}, got {res[2]}"
+print(f"{a:#x} + {b:#x} = {c:#x}")
+d = -a + -b
+assert res[5] == d, f"expected {d}, got {res[5]}"
+print(f"{-a:#x} + {-b:#x} = {d:#x}")
+

--- a/examples/compute_int64.py
+++ b/examples/compute_int64.py
@@ -23,19 +23,24 @@ fn main(@builtin(global_invocation_id) index: vec3<u32>) {
 """
 a = 0x1234567890
 b = 0x9876543210
-data = memoryview(bytearray(6*8)).cast("q") # signed long long >= 64 bits
+data = memoryview(bytearray(6 * 8)).cast("q")  # signed long long >= 64 bits
 data[0] = a
 data[1] = b
 data[3] = -a
 data[4] = -b
 
-buffer = device.create_buffer_with_data(data=data, usage=wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.COPY_SRC | wgpu.BufferUsage.COPY_DST)
+buffer = device.create_buffer_with_data(
+    data=data,
+    usage=wgpu.BufferUsage.STORAGE
+    | wgpu.BufferUsage.COPY_SRC
+    | wgpu.BufferUsage.COPY_DST,
+)
 pipeline = device.create_compute_pipeline(
     layout="auto",
     compute={
         "module": device.create_shader_module(code=add_shader),
         "entry_point": "main",
-    }
+    },
 )
 
 bind_group = device.create_bind_group(
@@ -52,7 +57,7 @@ command_encoder = device.create_command_encoder()
 compute_pass = command_encoder.begin_compute_pass()
 compute_pass.set_pipeline(pipeline)
 compute_pass.set_bind_group(0, bind_group)
-compute_pass.dispatch_workgroups(2) # we do two calculations
+compute_pass.dispatch_workgroups(2)  # we do two calculations
 compute_pass.end()
 device.queue.submit([command_encoder.finish()])
 result = device.queue.read_buffer(buffer)
@@ -63,4 +68,3 @@ print(f"{a:#x} + {b:#x} = {c:#x}")
 d = -a + -b
 assert res[5] == d, f"expected {d}, got {res[5]}"
 print(f"{-a:#x} + {-b:#x} = {d:#x}")
-

--- a/examples/imgui_cmap_picker.py
+++ b/examples/imgui_cmap_picker.py
@@ -94,7 +94,7 @@ def update_gui():
     # add the items for the picker
     for cmap_name, tex_ref in cmap_data.items():
         # text part of each item
-        clicked, enabled = imgui.menu_item(
+        _clicked, enabled = imgui.menu_item(
             cmap_name, "", p_selected=current_cmap == cmap_name
         )
         imgui.same_line()

--- a/tests/test_set_constant.py
+++ b/tests/test_set_constant.py
@@ -179,7 +179,7 @@ def test_render_bundle_push_constants():
 
 
 def test_bad_set_push_constants():
-    device, pipeline, render_pass_descriptor = setup_pipeline()
+    device, _pipeline, render_pass_descriptor = setup_pipeline()
     encoder = device.create_command_encoder()
     this_pass = encoder.begin_render_pass(**render_pass_descriptor)
 

--- a/wgpu/backends/wgpu_native/__init__.py
+++ b/wgpu/backends/wgpu_native/__init__.py
@@ -11,8 +11,8 @@ from .. import _register_backend
 
 
 # The wgpu-native version that we target/expect
-__version__ = "25.0.2.1"
-__commit_sha__ = "af9074edf144efe4f1432b2e42c477429c4964c1"
+__version__ = "25.0.2.2"
+__commit_sha__ = "a2f5109b0da3c87d356a6a876f5b203c6a68924a"
 version_info = tuple(map(int, __version__.split(".")))  # noqa: RUF048
 _check_expected_version(version_info)  # produces a warning on mismatch
 

--- a/wgpu/backends/wgpu_native/_mappings.py
+++ b/wgpu/backends/wgpu_native/_mappings.py
@@ -357,6 +357,7 @@ enum_str2int = {
         "subgroup-barrier": 196643,
         "timestamp-query-inside-encoders": 196644,
         "timestamp-query-inside-passes": 196645,
+        "shader-int64": 196646,
     },
     "PipelineStatisticName": {
         "vertex-shader-invocations": 0,

--- a/wgpu/resources/codegen_report.md
+++ b/wgpu/resources/codegen_report.md
@@ -3,7 +3,7 @@
 * The webgpu.idl defines 37 classes with 76 functions
 * The webgpu.idl defines 5 flags, 34 enums, 60 structs
 * webgpu.h/wgpu.h define 211 functions
-* webgpu.h/wgpu.h define 7 flags, 60 enums, 101 structs
+* webgpu.h/wgpu.h define 7 flags, 60 enums, 102 structs
 ## Updating API
 * Wrote 5 flags to flags.py
 * Wrote 34 enums to enums.py

--- a/wgpu/resources/wgpu.h
+++ b/wgpu/resources/wgpu.h
@@ -14,6 +14,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
     WGPUSType_QuerySetDescriptorExtras = 0x00030009,
     WGPUSType_SurfaceConfigurationExtras = 0x0003000A,
+    WGPUSType_SurfaceSourceSwapChainPanel = 0x0003000B,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -55,6 +56,7 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_SubgroupBarrier = 0x00030023,
     WGPUNativeFeature_TimestampQueryInsideEncoders = 0x00030024,
     WGPUNativeFeature_TimestampQueryInsidePasses = 0x00030025,
+    WGPUNativeFeature_ShaderInt64 = 0x00030026,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 
@@ -255,6 +257,18 @@ typedef struct WGPUSurfaceConfigurationExtras {
     WGPUChainedStruct chain;
     uint32_t desiredMaximumFrameLatency;
 } WGPUSurfaceConfigurationExtras WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Chained in @ref WGPUSurfaceDescriptor to make a @ref WGPUSurface wrapping a WinUI [`SwapChainPanel`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.swapchainpanel).
+ */
+typedef struct WGPUSurfaceSourceSwapChainPanel {
+    WGPUChainedStruct chain;
+    /**
+     * A pointer to the [`ISwapChainPanelNative`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.media.dxinterop/nn-microsoft-ui-xaml-media-dxinterop-iswapchainpanelnative)
+     * interface of the SwapChainPanel that will be wrapped by the @ref WGPUSurface.
+     */
+    void * panelNative;
+} WGPUSurfaceSourceSwapChainPanel WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void * userdata);
 


### PR DESCRIPTION
I wanted to try the v26 branch so thought like updating to the latest v25 release.

adds two things: `shader-int64` features and `WGPUSurfaceSourceSwapChainPanel` chain. I added an example for the new feature (should I move it to tests?), no clue about the utility of native winUI swap chain.

