### PR TITLE
More type improvements

### DIFF
--- a/codegen/apipatcher.py
+++ b/codegen/apipatcher.py
@@ -506,10 +506,9 @@ class IdlPatcherMixin:
             d = "optional"
         if t:
             # If default is None, the type won't match, so we need to mark it optional
+            result += f": {t}"
             if d == "None":
-                result += f": Optional[{t}]"
-            else:
-                result += f": {t}"
+                result += " | None"
         if d:
             d = {"false": "False", "true": "True"}.get(d, d)
             result += f"={d}"

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -232,11 +232,11 @@ class IdlParser:
         ) and name.endswith(">"):
             name = name.split("<")[-1].rstrip(">")
             name = self.resolve_type(name).strip("'")
-            return f"List[{name}]"
+            return f"list[{name}]"
         elif name.startswith("record<") and name.endswith(">"):
             name = name.split("<")[-1].rstrip(">")
             names = [self.resolve_type(t).strip("'") for t in name.split(",")]
-            return f"Dict[{', '.join(names)}]"
+            return f"dict[{', '.join(names)}]"
         elif " or " in name:
             name = name.strip("()")
             names = [self.resolve_type(t).strip("'") for t in name.split(" or ")]

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -243,7 +243,7 @@ class IdlParser:
             names = sorted(set(names))
             if len(names) == 1:
                 return names[0]
-            return f"Union[{', '.join(names)}]"
+            return " | ".join(names)
         if name.startswith("Promise<") and name.endswith(">"):
             name = name.split("<")[-1].rstrip(">")
             # recursive call if there are any of the above situations?

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -211,14 +211,14 @@ class IdlParser:
             "double": "float",
             "boolean": "bool",
             "object": "dict",
-            "ImageBitmap": "memoryview",
-            "ImageData": "memoryview",
-            "VideoFrame": "memoryview",
-            "AllowSharedBufferSource": "memoryview",
+            "ImageBitmap": "ArrayLike",
+            "ImageData": "ArrayLike",
+            "VideoFrame": "ArrayLike",
+            "AllowSharedBufferSource": "ArrayLike",
             "GPUPipelineConstantValue": "float",
             "GPUExternalTexture": "object",
             "undefined": "None",
-            "ArrayBuffer": "memoryview",
+            "ArrayBuffer": "ArrayLike",
             "WGSLLanguageFeatures": "set",
             "GPUSupportedFeatures": "set",
             "GPUSupportedLimits": "dict",
@@ -252,6 +252,8 @@ class IdlParser:
         # Triage
         if name in __builtins__:
             return name  # ok
+        elif name in ["ArrayLike"]:
+            return name  # virtual types
         elif name in self.classes:
             return name
         elif name.startswith("HTML"):

--- a/codegen/idlparser.py
+++ b/codegen/idlparser.py
@@ -223,6 +223,8 @@ class IdlParser:
             "GPUSupportedFeatures": "set",
             "GPUSupportedLimits": "dict",
             "EventHandler": "None",
+            "HTMLCanvasElement": "CanvasLike",
+            "OffscreenCanvas": "CanvasLike",
         }
         name = pythonmap.get(name, name)
 
@@ -252,14 +254,12 @@ class IdlParser:
         # Triage
         if name in __builtins__:
             return name  # ok
-        elif name in ["ArrayLike"]:
+        elif name in ["ArrayLike", "CanvasLike"]:
             return name  # virtual types
         elif name in self.classes:
             return name
         elif name.startswith("HTML"):
             return "object"  # anything, we ignore this stuff anyway
-        elif name in ["OffscreenCanvas"]:
-            return "object"
         elif name in ["PredefinedColorSpace"]:
             return "str"
         else:

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -11,6 +11,7 @@ as a script will use the auto-backend.
 # test_example = true
 
 import time
+from typing import Callable
 
 import wgpu
 import numpy as np
@@ -22,7 +23,9 @@ from rendercanvas.auto import RenderCanvas, loop
 # %% Entrypoints (sync and async)
 
 
-def setup_drawing_sync(canvas, power_preference="high-performance", limits=None):
+def setup_drawing_sync(
+    canvas, power_preference="high-performance", limits: dict = {}
+) -> Callable:
     """Setup to draw a rotating cube on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -42,7 +45,7 @@ def setup_drawing_sync(canvas, power_preference="high-performance", limits=None)
     )
 
 
-async def setup_drawing_async(canvas, limits=None):
+async def setup_drawing_async(canvas, limits: dict = {}):
     """Setup to async-draw a rotating cube on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -67,7 +70,7 @@ async def setup_drawing_async(canvas, limits=None):
 
 def get_render_pipeline_kwargs(
     canvas, device: wgpu.GPUDevice, pipeline_layout: wgpu.GPUPipelineLayout
-):
+) -> dict:
     context = canvas.get_context("wgpu")
     render_texture_format = context.get_preferred_format(device.adapter)
     context.configure(device=device, format=render_texture_format)

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -17,15 +17,16 @@ as a script will use the auto-backend.
 
 """
 
-import wgpu
+from typing import Callable
 
+import wgpu
 
 # %% Entrypoints (sync and async)
 
 
 def setup_drawing_sync(
-    canvas, power_preference="high-performance", limits=None, format=None
-):
+    canvas, power_preference="high-performance", limits={}, format=None
+) -> Callable:
     """Setup to draw a triangle on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -42,7 +43,7 @@ def setup_drawing_sync(
     return get_draw_function(canvas, device, render_pipeline, asynchronous=False)
 
 
-async def setup_drawing_async(canvas, limits=None, format=None):
+async def setup_drawing_async(canvas, limits={}, format=None) -> Callable:
     """Setup to async-draw a triangle on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -62,7 +63,7 @@ async def setup_drawing_async(canvas, limits=None, format=None):
 # %% Functions to create wgpu objects
 
 
-def get_render_pipeline_kwargs(canvas, device, render_texture_format):
+def get_render_pipeline_kwargs(canvas, device, render_texture_format) -> dict:
     context = canvas.get_context("wgpu")
     if render_texture_format is None:
         render_texture_format = context.get_preferred_format(device.adapter)
@@ -95,7 +96,7 @@ def get_render_pipeline_kwargs(canvas, device, render_texture_format):
     )
 
 
-def get_draw_function(canvas, device, render_pipeline, *, asynchronous):
+def get_draw_function(canvas, device, render_pipeline, *, asynchronous) -> Callable:
     def draw_frame_sync():
         current_texture = canvas.get_context("wgpu").get_current_texture()
         command_encoder = device.create_command_encoder()

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import weakref
 import logging
-from typing import List, Dict
 
 from ._coreutils import ApiDiff, str_flag_to_int, ArrayLike
 from ._diagnostics import diagnostics, texture_format_to_bpp
@@ -310,7 +309,7 @@ class GPUCanvasContext:
         device: GPUDevice,
         format: enums.TextureFormatEnum,
         usage: flags.TextureUsageFlags = 0x10,
-        view_formats: List[enums.TextureFormatEnum] = [],
+        view_formats: list[enums.TextureFormatEnum] = [],
         color_space: str = "srgb",
         tone_mapping: structs.CanvasToneMapping = {},
         alpha_mode: enums.CanvasAlphaModeEnum = "opaque",
@@ -654,8 +653,8 @@ class GPUAdapter:
         self,
         *,
         label: str = "",
-        required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, None | int] = {},
+        required_features: list[enums.FeatureNameEnum] = [],
+        required_limits: dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         """Sync version of `request_device_async()`.
@@ -669,8 +668,8 @@ class GPUAdapter:
         self,
         *,
         label: str = "",
-        required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, None | int] = {},
+        required_features: list[enums.FeatureNameEnum] = [],
+        required_limits: dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         """Request a `GPUDevice` from the adapter.
@@ -908,13 +907,13 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        size: List[int] | structs.Extent3D,
+        size: list[int] | structs.Extent3D,
         mip_level_count: int = 1,
         sample_count: int = 1,
         dimension: enums.TextureDimensionEnum = "2d",
         format: enums.TextureFormatEnum,
         usage: flags.TextureUsageFlags,
-        view_formats: List[enums.TextureFormatEnum] = [],
+        view_formats: list[enums.TextureFormatEnum] = [],
     ) -> GPUTexture:
         """Create a `GPUTexture` object.
 
@@ -976,7 +975,7 @@ class GPUDevice(GPUObjectBase):
 
     # IDL: GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor); -> USVString label = "", required sequence<GPUBindGroupLayoutEntry> entries
     def create_bind_group_layout(
-        self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]
+        self, *, label: str = "", entries: list[structs.BindGroupLayoutEntry]
     ) -> GPUBindGroupLayout:
         """Create a `GPUBindGroupLayout` object. One or more
         such objects are passed to `create_pipeline_layout()` to
@@ -1017,7 +1016,7 @@ class GPUDevice(GPUObjectBase):
         *,
         label: str = "",
         layout: GPUBindGroupLayout,
-        entries: List[structs.BindGroupEntry],
+        entries: list[structs.BindGroupEntry],
     ) -> GPUBindGroup:
         """Create a `GPUBindGroup` object, which can be used in
         `pass.set_bind_group()` to attach a group of resources.
@@ -1057,7 +1056,7 @@ class GPUDevice(GPUObjectBase):
 
     # IDL: GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor); -> USVString label = "", required sequence<GPUBindGroupLayout?> bindGroupLayouts
     def create_pipeline_layout(
-        self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
+        self, *, label: str = "", bind_group_layouts: list[GPUBindGroupLayout]
     ) -> GPUPipelineLayout:
         """Create a `GPUPipelineLayout` object, which can be
         used in `create_render_pipeline()` or `create_compute_pipeline()`.
@@ -1074,7 +1073,7 @@ class GPUDevice(GPUObjectBase):
         *,
         label: str = "",
         code: str,
-        compilation_hints: List[structs.ShaderModuleCompilationHint] = [],
+        compilation_hints: list[structs.ShaderModuleCompilationHint] = [],
     ) -> GPUShaderModule:
         """Create a `GPUShaderModule` object from shader source.
 
@@ -1298,7 +1297,7 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        color_formats: List[enums.TextureFormatEnum],
+        color_formats: list[enums.TextureFormatEnum],
         depth_stencil_format: enums.TextureFormatEnum = optional,
         sample_count: int = 1,
         depth_read_only: bool = False,
@@ -1990,7 +1989,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         *,
         label: str = "",
-        color_attachments: List[structs.RenderPassColorAttachment],
+        color_attachments: list[structs.RenderPassColorAttachment],
         depth_stencil_attachment: structs.RenderPassDepthStencilAttachment = optional,
         occlusion_query_set: GPUQuerySet = optional,
         timestamp_writes: structs.RenderPassTimestampWrites = optional,
@@ -2050,7 +2049,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         source: structs.TexelCopyBufferInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         """Copy the contents of a buffer to a texture (view).
 
@@ -2068,7 +2067,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyBufferInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         """Copy the contents of a texture (view) to a buffer.
 
@@ -2086,7 +2085,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         """Copy the contents of a texture (view) to another texture (view).
 
@@ -2232,7 +2231,7 @@ class GPURenderPassEncoder(
         raise NotImplementedError()
 
     # IDL: undefined setBlendConstant(GPUColor color);
-    def set_blend_constant(self, color: List[float] | structs.Color) -> None:
+    def set_blend_constant(self, color: list[float] | structs.Color) -> None:
         """Set the blend color for the render pass.
 
         Arguments:
@@ -2250,7 +2249,7 @@ class GPURenderPassEncoder(
         raise NotImplementedError()
 
     # IDL: undefined executeBundles(sequence<GPURenderBundle> bundles);
-    def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
+    def execute_bundles(self, bundles: list[GPURenderBundle]) -> None:
         """Executes commands previously recorded into the render bundles
           as part of this render pass.
 
@@ -2314,7 +2313,7 @@ class GPUQueue(GPUObjectBase):
     """
 
     # IDL: undefined submit(sequence<GPUCommandBuffer> commandBuffers);
-    def submit(self, command_buffers: List[GPUCommandBuffer]) -> None:
+    def submit(self, command_buffers: list[GPUCommandBuffer]) -> None:
         """Submit a `GPUCommandBuffer` to the queue.
 
         Arguments:
@@ -2378,7 +2377,7 @@ class GPUQueue(GPUObjectBase):
         destination: structs.TexelCopyTextureInfo,
         data: ArrayLike,
         data_layout: structs.TexelCopyBufferLayout,
-        size: List[int] | structs.Extent3D,
+        size: list[int] | structs.Extent3D,
     ) -> None:
         """Takes the data contents and schedules a write operation of
         these contents to the destination texture in the queue. A
@@ -2425,7 +2424,7 @@ class GPUQueue(GPUObjectBase):
         self,
         source: structs.CopyExternalImageSourceInfo,
         destination: structs.CopyExternalImageDestInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         raise NotImplementedError()
 
@@ -2572,7 +2571,7 @@ class GPUCompilationInfo:
 
     # IDL: readonly attribute FrozenArray<GPUCompilationMessage> messages;
     @property
-    def messages(self) -> List[GPUCompilationMessage]:
+    def messages(self) -> list[GPUCompilationMessage]:
         """A list of `GPUCompilationMessage` objects."""
         raise NotImplementedError()
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -655,7 +655,7 @@ class GPUAdapter:
         *,
         label: str = "",
         required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, Union[None, int]] = {},
+        required_limits: Dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         """Sync version of `request_device_async()`.
@@ -670,7 +670,7 @@ class GPUAdapter:
         *,
         label: str = "",
         required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, Union[None, int]] = {},
+        required_limits: Dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         """Request a `GPUDevice` from the adapter.
@@ -908,7 +908,7 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        size: Union[List[int], structs.Extent3D],
+        size: List[int] | structs.Extent3D,
         mip_level_count: int = 1,
         sample_count: int = 1,
         dimension: enums.TextureDimensionEnum = "2d",
@@ -1096,7 +1096,7 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         compute: structs.ProgrammableStage,
     ) -> GPUComputePipeline:
         """Create a `GPUComputePipeline` object.
@@ -1113,7 +1113,7 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         compute: structs.ProgrammableStage,
     ) -> GPUComputePipeline:
         """Async version of `create_compute_pipeline()`.
@@ -1126,7 +1126,7 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         vertex: structs.VertexState,
         primitive: structs.PrimitiveState = {},
         depth_stencil: structs.DepthStencilState = optional,
@@ -1270,7 +1270,7 @@ class GPUDevice(GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         vertex: structs.VertexState,
         primitive: structs.PrimitiveState = {},
         depth_stencil: structs.DepthStencilState = optional,
@@ -1351,11 +1351,7 @@ class GPUDevice(GPUObjectBase):
     # IDL: GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor); -> USVString label = "", required (HTMLVideoElement or VideoFrame) source, PredefinedColorSpace colorSpace = "srgb"
     @apidiff.hide("Specific to browsers")
     def import_external_texture(
-        self,
-        *,
-        label: str = "",
-        source: Union[memoryview, object],
-        color_space: str = "srgb",
+        self, *, label: str = "", source: memoryview | object, color_space: str = "srgb"
     ) -> object:
         """For browsers only."""
         raise NotImplementedError()
@@ -1420,7 +1416,7 @@ class GPUBuffer(GPUObjectBase):
 
     # IDL: Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def map_sync(
-        self, mode: flags.MapModeFlags, offset: int = 0, size: Optional[int] = None
+        self, mode: flags.MapModeFlags, offset: int = 0, size: int | None = None
     ) -> None:
         """Sync version of `map_async()`.
 
@@ -1430,7 +1426,7 @@ class GPUBuffer(GPUObjectBase):
 
     # IDL: Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     async def map_async(
-        self, mode: flags.MapModeFlags, offset: int = 0, size: Optional[int] = None
+        self, mode: flags.MapModeFlags, offset: int = 0, size: int | None = None
     ) -> None:
         """Maps the given range of the GPUBuffer.
 
@@ -1520,9 +1516,7 @@ class GPUBuffer(GPUObjectBase):
 
     # IDL: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     @apidiff.hide
-    def get_mapped_range(
-        self, offset: int = 0, size: Optional[int] = None
-    ) -> memoryview:
+    def get_mapped_range(self, offset: int = 0, size: int | None = None) -> memoryview:
         raise NotImplementedError("The Python API differs from WebGPU here")
 
     # IDL: undefined destroy();
@@ -1869,7 +1863,7 @@ class GPURenderCommandsMixin:
         buffer: GPUBuffer,
         index_format: enums.IndexFormatEnum,
         offset: int = 0,
-        size: Optional[int] = None,
+        size: int | None = None,
     ) -> None:
         """Set the index buffer for this render pass.
 
@@ -1886,7 +1880,7 @@ class GPURenderCommandsMixin:
 
     # IDL: undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer? buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def set_vertex_buffer(
-        self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
+        self, slot: int, buffer: GPUBuffer, offset: int = 0, size: int | None = None
     ) -> None:
         """Associate a vertex buffer with a bind slot.
 
@@ -2016,7 +2010,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
 
     # IDL: undefined clearBuffer( GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
     def clear_buffer(
-        self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
+        self, buffer: GPUBuffer, offset: int = 0, size: int | None = None
     ) -> None:
         """Set (part of) the given buffer to zeros.
 
@@ -2036,7 +2030,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         source_offset: int,
         destination: GPUBuffer,
         destination_offset: int,
-        size: Optional[int] = None,
+        size: int | None = None,
     ) -> None:
         """Copy the contents of a buffer to another buffer.
 
@@ -2056,7 +2050,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         source: structs.TexelCopyBufferInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         """Copy the contents of a buffer to a texture (view).
 
@@ -2074,7 +2068,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyBufferInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         """Copy the contents of a texture (view) to a buffer.
 
@@ -2092,7 +2086,7 @@ class GPUCommandEncoder(GPUCommandsMixin, GPUDebugCommandsMixin, GPUObjectBase):
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         """Copy the contents of a texture (view) to another texture (view).
 
@@ -2238,7 +2232,7 @@ class GPURenderPassEncoder(
         raise NotImplementedError()
 
     # IDL: undefined setBlendConstant(GPUColor color);
-    def set_blend_constant(self, color: Union[List[float], structs.Color]) -> None:
+    def set_blend_constant(self, color: List[float] | structs.Color) -> None:
         """Set the blend color for the render pass.
 
         Arguments:
@@ -2335,7 +2329,7 @@ class GPUQueue(GPUObjectBase):
         buffer_offset: int,
         data: memoryview,
         data_offset: int = 0,
-        size: Optional[int] = None,
+        size: int | None = None,
     ) -> None:
         """Takes the data contents and schedules a write operation to the buffer.
 
@@ -2384,7 +2378,7 @@ class GPUQueue(GPUObjectBase):
         destination: structs.TexelCopyTextureInfo,
         data: memoryview,
         data_layout: structs.TexelCopyBufferLayout,
-        size: Union[List[int], structs.Extent3D],
+        size: List[int] | structs.Extent3D,
     ) -> None:
         """Takes the data contents and schedules a write operation of
         these contents to the destination texture in the queue. A
@@ -2431,7 +2425,7 @@ class GPUQueue(GPUObjectBase):
         self,
         source: structs.CopyExternalImageSourceInfo,
         destination: structs.CopyExternalImageDestInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         raise NotImplementedError()
 

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import weakref
 import logging
-from typing import List, Dict, Union, Optional
+from typing import List, Dict
 
-from ._coreutils import ApiDiff, str_flag_to_int
+from ._coreutils import ApiDiff, str_flag_to_int, ArrayLike
 from ._diagnostics import diagnostics, texture_format_to_bpp
 from . import flags, enums, structs
 
@@ -1351,7 +1351,7 @@ class GPUDevice(GPUObjectBase):
     # IDL: GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor); -> USVString label = "", required (HTMLVideoElement or VideoFrame) source, PredefinedColorSpace colorSpace = "srgb"
     @apidiff.hide("Specific to browsers")
     def import_external_texture(
-        self, *, label: str = "", source: memoryview | object, color_space: str = "srgb"
+        self, *, label: str = "", source: ArrayLike | object, color_space: str = "srgb"
     ) -> object:
         """For browsers only."""
         raise NotImplementedError()
@@ -1516,7 +1516,7 @@ class GPUBuffer(GPUObjectBase):
 
     # IDL: ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     @apidiff.hide
-    def get_mapped_range(self, offset: int = 0, size: int | None = None) -> memoryview:
+    def get_mapped_range(self, offset: int = 0, size: int | None = None) -> ArrayLike:
         raise NotImplementedError("The Python API differs from WebGPU here")
 
     # IDL: undefined destroy();
@@ -2327,7 +2327,7 @@ class GPUQueue(GPUObjectBase):
         self,
         buffer: GPUBuffer,
         buffer_offset: int,
-        data: memoryview,
+        data: ArrayLike,
         data_offset: int = 0,
         size: int | None = None,
     ) -> None:
@@ -2376,7 +2376,7 @@ class GPUQueue(GPUObjectBase):
     def write_texture(
         self,
         destination: structs.TexelCopyTextureInfo,
-        data: memoryview,
+        data: ArrayLike,
         data_layout: structs.TexelCopyBufferLayout,
         size: List[int] | structs.Extent3D,
     ) -> None:

--- a/wgpu/_coreutils.py
+++ b/wgpu/_coreutils.py
@@ -17,6 +17,11 @@ from pathlib import Path
 _resource_files = ExitStack()
 atexit.register(_resource_files.close)
 
+# A stub type to annotate args that can be array-like (anything that can be cast to a memoryview)
+# Note that we don't depend on numpy, otherwise we could use np.typing.ArrayLike.
+# VSCode just shows "ArrayLike" in the user-facing hints. The type checker allows anything, I guess.
+ArrayLike = memoryview | object
+
 
 def get_header_filename(name):
     """Get the filename to a wgpu related header resource."""

--- a/wgpu/_coreutils.py
+++ b/wgpu/_coreutils.py
@@ -22,6 +22,9 @@ atexit.register(_resource_files.close)
 # VSCode just shows "ArrayLike" in the user-facing hints. The type checker allows anything, I guess.
 ArrayLike = memoryview | object
 
+# A stub type for a canvas-like object
+CanvasLike = object
+
 
 def get_header_filename(name):
     """Get the filename to a wgpu related header resource."""

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -1071,7 +1071,7 @@ class GPUAdapter(classes.GPUAdapter):
         *,
         label: str = "",
         required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, Union[None, int]] = {},
+        required_limits: Dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         check_can_use_sync_variants()
@@ -1087,7 +1087,7 @@ class GPUAdapter(classes.GPUAdapter):
         *,
         label: str = "",
         required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, Union[None, int]] = {},
+        required_limits: Dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         if default_queue:
@@ -1422,7 +1422,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        size: Union[List[int], structs.Extent3D],
+        size: List[int] | structs.Extent3D,
         mip_level_count: int = 1,
         sample_count: int = 1,
         dimension: enums.TextureDimensionEnum = "2d",
@@ -1851,7 +1851,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         compute: structs.ProgrammableStage,
     ) -> GPUComputePipeline:
         descriptor = self._create_compute_pipeline_descriptor(label, layout, compute)
@@ -1863,7 +1863,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         compute: structs.ProgrammableStage,
     ) -> GPUComputePipeline:
         descriptor = self._create_compute_pipeline_descriptor(label, layout, compute)
@@ -1950,7 +1950,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         vertex: structs.VertexState,
         primitive: structs.PrimitiveState = {},
         depth_stencil: structs.DepthStencilState = optional,
@@ -1968,7 +1968,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutModeEnum],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         vertex: structs.VertexState,
         primitive: structs.PrimitiveState = {},
         depth_stencil: structs.DepthStencilState = optional,
@@ -2387,14 +2387,14 @@ class GPUBuffer(classes.GPUBuffer, GPUObjectBase):
         return offset, size
 
     def map_sync(
-        self, mode: flags.MapModeFlags, offset: int = 0, size: Optional[int] = None
+        self, mode: flags.MapModeFlags, offset: int = 0, size: int | None = None
     ) -> None:
         check_can_use_sync_variants()
         awaitable = self._map(mode, offset, size)
         return awaitable.sync_wait()
 
     async def map_async(
-        self, mode: flags.MapModeFlags, offset: int = 0, size: Optional[int] = None
+        self, mode: flags.MapModeFlags, offset: int = 0, size: int | None = None
     ) -> None:
         awaitable = self._map(mode, offset, size)  # for now
         return await awaitable
@@ -2911,7 +2911,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         buffer: GPUBuffer,
         index_format: enums.IndexFormatEnum,
         offset: int = 0,
-        size: Optional[int] = None,
+        size: int | None = None,
     ) -> None:
         self._maybe_keep_alive(buffer)
         if not size:
@@ -2925,7 +2925,7 @@ class GPURenderCommandsMixin(classes.GPURenderCommandsMixin):
         )
 
     def set_vertex_buffer(
-        self, slot: int, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
+        self, slot: int, buffer: GPUBuffer, offset: int = 0, size: int | None = None
     ) -> None:
         self._maybe_keep_alive(buffer)
         if not size:
@@ -3190,7 +3190,7 @@ class GPUCommandEncoder(
         return c_depth_stencil_attachment
 
     def clear_buffer(
-        self, buffer: GPUBuffer, offset: int = 0, size: Optional[int] = None
+        self, buffer: GPUBuffer, offset: int = 0, size: int | None = None
     ) -> None:
         offset = int(offset)
         if offset % 4 != 0:  # pragma: no cover
@@ -3219,7 +3219,7 @@ class GPUCommandEncoder(
         source_offset: int,
         destination: GPUBuffer,
         destination_offset: int,
-        size: Optional[int] = None,
+        size: int | None = None,
     ) -> None:
         if source_offset % 4 != 0:  # pragma: no cover
             raise ValueError("source_offset must be a multiple of 4")
@@ -3248,7 +3248,7 @@ class GPUCommandEncoder(
         self,
         source: structs.TexelCopyBufferInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         check_struct("TexelCopyBufferInfo", source)
         check_struct("TexelCopyTextureInfo", destination)
@@ -3314,7 +3314,7 @@ class GPUCommandEncoder(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyBufferInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         check_struct("TexelCopyTextureInfo", source)
         check_struct("TexelCopyBufferInfo", destination)
@@ -3380,7 +3380,7 @@ class GPUCommandEncoder(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: Union[List[int], structs.Extent3D],
+        copy_size: List[int] | structs.Extent3D,
     ) -> None:
         check_struct("TexelCopyTextureInfo", source)
         check_struct("TexelCopyTextureInfo", destination)
@@ -3585,7 +3585,7 @@ class GPURenderPassEncoder(
             self._internal, int(x), int(y), int(width), int(height)
         )
 
-    def set_blend_constant(self, color: Union[List[float], structs.Color]) -> None:
+    def set_blend_constant(self, color: List[float] | structs.Color) -> None:
         if isinstance(color, dict):
             check_struct("Color", color)
             color = _tuple_from_color(color)
@@ -3733,7 +3733,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         buffer_offset: int,
         data: memoryview,
         data_offset: int = 0,
-        size: Optional[int] = None,
+        size: int | None = None,
     ) -> None:
         # We support anything that memoryview supports, i.e. anything
         # that implements the buffer protocol, including, bytes,
@@ -3807,7 +3807,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         destination: structs.TexelCopyTextureInfo,
         data: memoryview,
         data_layout: structs.TexelCopyBufferLayout,
-        size: Union[List[int], structs.Extent3D],
+        size: List[int] | structs.Extent3D,
     ) -> None:
         # Note that the bytes_per_row restriction does not apply for
         # this function; wgpu-native deals with it.

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -21,7 +21,7 @@ import os
 import time
 import logging
 from weakref import WeakKeyDictionary
-from typing import List, Dict, NoReturn
+from typing import NoReturn
 
 from ... import classes, flags, enums, structs
 from ..._coreutils import str_flag_to_int, ArrayLike
@@ -1070,8 +1070,8 @@ class GPUAdapter(classes.GPUAdapter):
         self,
         *,
         label: str = "",
-        required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, None | int] = {},
+        required_features: list[enums.FeatureNameEnum] = [],
+        required_limits: dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         check_can_use_sync_variants()
@@ -1086,8 +1086,8 @@ class GPUAdapter(classes.GPUAdapter):
         self,
         *,
         label: str = "",
-        required_features: List[enums.FeatureNameEnum] = [],
-        required_limits: Dict[str, None | int] = {},
+        required_features: list[enums.FeatureNameEnum] = [],
+        required_limits: dict[str, None | int] = {},
         default_queue: structs.QueueDescriptor = {},
     ) -> GPUDevice:
         if default_queue:
@@ -1422,13 +1422,13 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        size: List[int] | structs.Extent3D,
+        size: list[int] | structs.Extent3D,
         mip_level_count: int = 1,
         sample_count: int = 1,
         dimension: enums.TextureDimensionEnum = "2d",
         format: enums.TextureFormatEnum,
         usage: flags.TextureUsageFlags,
-        view_formats: List[enums.TextureFormatEnum] = [],
+        view_formats: list[enums.TextureFormatEnum] = [],
     ) -> GPUTexture:
         if isinstance(usage, str):
             usage = str_flag_to_int(flags.TextureUsage, usage)
@@ -1529,7 +1529,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         return GPUSampler(label, id, self)
 
     def create_bind_group_layout(
-        self, *, label: str = "", entries: List[structs.BindGroupLayoutEntry]
+        self, *, label: str = "", entries: list[structs.BindGroupLayoutEntry]
     ) -> GPUBindGroupLayout:
         c_entries_list = []
         for entry in entries:
@@ -1639,7 +1639,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         *,
         label: str = "",
         layout: GPUBindGroupLayout,
-        entries: List[structs.BindGroupEntry],
+        entries: list[structs.BindGroupEntry],
     ) -> GPUBindGroup:
         c_entries_list = []
         for entry in entries:
@@ -1701,7 +1701,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         return GPUBindGroup(label, id, self)
 
     def create_pipeline_layout(
-        self, *, label: str = "", bind_group_layouts: List[GPUBindGroupLayout]
+        self, *, label: str = "", bind_group_layouts: list[GPUBindGroupLayout]
     ) -> GPUPipelineLayout:
         return self._create_pipeline_layout(label, bind_group_layouts, [])
 
@@ -1756,7 +1756,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         *,
         label: str = "",
         code: str,
-        compilation_hints: List[structs.ShaderModuleCompilationHint] = [],
+        compilation_hints: list[structs.ShaderModuleCompilationHint] = [],
     ) -> GPUShaderModule:
         if False:
             # Trick the check_struct check in the codegen.
@@ -2242,7 +2242,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
         self,
         *,
         label: str = "",
-        color_formats: List[enums.TextureFormatEnum],
+        color_formats: list[enums.TextureFormatEnum],
         depth_stencil_format: enums.TextureFormatEnum = optional,
         sample_count: int = 1,
         depth_read_only: bool = False,
@@ -3036,7 +3036,7 @@ class GPUCommandEncoder(
         self,
         *,
         label: str = "",
-        color_attachments: List[structs.RenderPassColorAttachment],
+        color_attachments: list[structs.RenderPassColorAttachment],
         depth_stencil_attachment: structs.RenderPassDepthStencilAttachment = optional,
         occlusion_query_set: GPUQuerySet = optional,
         timestamp_writes: structs.RenderPassTimestampWrites = optional,
@@ -3248,7 +3248,7 @@ class GPUCommandEncoder(
         self,
         source: structs.TexelCopyBufferInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         check_struct("TexelCopyBufferInfo", source)
         check_struct("TexelCopyTextureInfo", destination)
@@ -3314,7 +3314,7 @@ class GPUCommandEncoder(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyBufferInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         check_struct("TexelCopyTextureInfo", source)
         check_struct("TexelCopyBufferInfo", destination)
@@ -3380,7 +3380,7 @@ class GPUCommandEncoder(
         self,
         source: structs.TexelCopyTextureInfo,
         destination: structs.TexelCopyTextureInfo,
-        copy_size: List[int] | structs.Extent3D,
+        copy_size: list[int] | structs.Extent3D,
     ) -> None:
         check_struct("TexelCopyTextureInfo", source)
         check_struct("TexelCopyTextureInfo", destination)
@@ -3585,7 +3585,7 @@ class GPURenderPassEncoder(
             self._internal, int(x), int(y), int(width), int(height)
         )
 
-    def set_blend_constant(self, color: List[float] | structs.Color) -> None:
+    def set_blend_constant(self, color: list[float] | structs.Color) -> None:
         if isinstance(color, dict):
             check_struct("Color", color)
             color = _tuple_from_color(color)
@@ -3608,7 +3608,7 @@ class GPURenderPassEncoder(
         # H: void f(WGPURenderPassEncoder renderPassEncoder)
         libf.wgpuRenderPassEncoderEnd(self._internal)
 
-    def execute_bundles(self, bundles: List[GPURenderBundle]) -> None:
+    def execute_bundles(self, bundles: list[GPURenderBundle]) -> None:
         bundle_ids = [bundle._internal for bundle in bundles]
         c_bundle_info = new_array("WGPURenderBundle[]", bundle_ids)
         # H: void f(WGPURenderPassEncoder renderPassEncoder, size_t bundleCount, WGPURenderBundle const * bundles)
@@ -3721,7 +3721,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
     # GPUObjectBaseMixin
     _release_function = libf.wgpuQueueRelease
 
-    def submit(self, command_buffers: List[GPUCommandBuffer]) -> None:
+    def submit(self, command_buffers: list[GPUCommandBuffer]) -> None:
         command_buffer_ids = [cb._internal for cb in command_buffers]
         c_command_buffers = new_array("WGPUCommandBuffer[]", command_buffer_ids)
         # H: void f(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands)
@@ -3807,7 +3807,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         destination: structs.TexelCopyTextureInfo,
         data: ArrayLike,
         data_layout: structs.TexelCopyBufferLayout,
-        size: List[int] | structs.Extent3D,
+        size: list[int] | structs.Extent3D,
     ) -> None:
         # Note that the bytes_per_row restriction does not apply for
         # this function; wgpu-native deals with it.

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -21,10 +21,10 @@ import os
 import time
 import logging
 from weakref import WeakKeyDictionary
-from typing import List, Dict, NoReturn, Union, Optional
+from typing import List, Dict, NoReturn
 
 from ... import classes, flags, enums, structs
-from ..._coreutils import str_flag_to_int
+from ..._coreutils import str_flag_to_int, ArrayLike
 
 from ._ffi import ffi, lib
 from ._mappings import cstructfield2enum, enummap, enum_str2int, enum_int2str
@@ -1912,7 +1912,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
     def _create_compute_pipeline_descriptor(
         self,
         label: str,
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutMode],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         compute: structs.ProgrammableStage,
     ):
         check_struct("ProgrammableStage", compute)
@@ -2024,7 +2024,7 @@ class GPUDevice(classes.GPUDevice, GPUObjectBase):
     def _create_render_pipeline_descriptor(
         self,
         label: str,
-        layout: Union[GPUPipelineLayout, enums.AutoLayoutMode],
+        layout: GPUPipelineLayout | enums.AutoLayoutModeEnum,
         vertex: structs.VertexState,
         primitive: structs.PrimitiveState,
         depth_stencil: structs.DepthStencilState,
@@ -3731,7 +3731,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         self,
         buffer: GPUBuffer,
         buffer_offset: int,
-        data: memoryview,
+        data: ArrayLike,
         data_offset: int = 0,
         size: int | None = None,
     ) -> None:
@@ -3805,7 +3805,7 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
     def write_texture(
         self,
         destination: structs.TexelCopyTextureInfo,
-        data: memoryview,
+        data: ArrayLike,
         data_layout: structs.TexelCopyBufferLayout,
         size: List[int] | structs.Extent3D,
     ) -> None:

--- a/wgpu/backends/wgpu_native/extras.py
+++ b/wgpu/backends/wgpu_native/extras.py
@@ -1,20 +1,28 @@
 import os
-from typing import List, Union
 
-from . import GPUCommandEncoder, GPUComputePassEncoder, GPURenderPassEncoder
+from . import (
+    GPUAdapter,
+    GPUDevice,
+    GPUBuffer,
+    GPUCommandEncoder,
+    GPUComputePassEncoder,
+    GPURenderPassEncoder,
+    GPUPipelineLayout,
+    GPUQuerySet,
+)
 from ._api import (
-    Dict,
     GPUBindGroupLayout,
     enums,
     logger,
     structs,
+    flags,
     new_struct_p,
     to_c_string_view,
     enum_str2int,
 )
 from ...enums import Enum
 from ._helpers import get_wgpu_instance
-from ..._coreutils import get_library_filename
+from ..._coreutils import get_library_filename, ArrayLike
 from ._ffi import lib
 from ._mappings import native_flags
 
@@ -34,14 +42,14 @@ class PipelineStatisticName(Enum):  # wgpu native
 
 
 def request_device_sync(
-    adapter,
-    trace_path,
+    adapter: GPUAdapter,
+    trace_path: str,
     *,
-    label="",
-    required_features: "list(enums.FeatureName)" = [],
-    required_limits: "Dict[str, int]" = {},
-    default_queue: "structs.QueueDescriptor" = {},
-):
+    label: str = "",
+    required_features: list[enums.FeatureName] = [],
+    required_limits: dict[str, int] = {},
+    default_queue: structs.QueueDescriptor = {},
+) -> GPUDevice:
     """Write a trace of all commands to a file so it can be reproduced
     elsewhere. The trace is cross-platform!
     """
@@ -63,19 +71,24 @@ def request_device(*args, **kwargs):
 
 
 def create_pipeline_layout(
-    device,
+    device: GPUDevice,
     *,
-    label="",
-    bind_group_layouts: "List[GPUBindGroupLayout]",
-    push_constant_layouts: "List[Dict]" = [],
-):
+    label: str = "",
+    bind_group_layouts: list[GPUBindGroupLayout],
+    push_constant_layouts: list[dict] = [],
+) -> GPUPipelineLayout:
     return device._create_pipeline_layout(
         label, bind_group_layouts, push_constant_layouts
     )
 
 
 def set_push_constants(
-    render_pass_encoder, visibility, offset, size_in_bytes, data, data_offset=0
+    render_pass_encoder: GPURenderPassEncoder,
+    visibility: flags.ShaderStageFlags,
+    offset: int,
+    size_in_bytes: int,
+    data: ArrayLike,
+    data_offset: int = 0,
 ):
     """
     Set push-constant data for subsequent draw calls.
@@ -91,7 +104,13 @@ def set_push_constants(
     )
 
 
-def multi_draw_indirect(render_pass_encoder, buffer, *, offset=0, count):
+def multi_draw_indirect(
+    render_pass_encoder: GPURenderPassEncoder,
+    buffer: GPUBuffer,
+    *,
+    offset: int = 0,
+    count: int,
+):
     """
     This is equivalent to
     for i in range(count):
@@ -102,7 +121,13 @@ def multi_draw_indirect(render_pass_encoder, buffer, *, offset=0, count):
     render_pass_encoder._multi_draw_indirect(buffer, offset, count)
 
 
-def multi_draw_indexed_indirect(render_pass_encoder, buffer, *, offset=0, count):
+def multi_draw_indexed_indirect(
+    render_pass_encoder: GPURenderPassEncoder,
+    buffer: GPUBuffer,
+    *,
+    offset: int = 0,
+    count: int,
+):
     """
     This is equivalent to
 
@@ -115,13 +140,13 @@ def multi_draw_indexed_indirect(render_pass_encoder, buffer, *, offset=0, count)
 
 
 def multi_draw_indirect_count(
-    render_pass_encoder,
-    buffer,
+    render_pass_encoder: GPURenderPassEncoder,
+    buffer: GPUBuffer,
     *,
-    offset=0,
-    count_buffer,
-    count_buffer_offset=0,
-    max_count,
+    offset: int = 0,
+    count_buffer: GPUBuffer,
+    count_buffer_offset: int = 0,
+    max_count: int,
 ):
     """
     This is equivalent to:
@@ -138,13 +163,13 @@ def multi_draw_indirect_count(
 
 
 def multi_draw_indexed_indirect_count(
-    render_pass_encoder,
-    buffer,
+    render_pass_encoder: GPURenderPassEncoder,
+    buffer: GPUBuffer,
     *,
-    offset=0,
-    count_buffer,
-    count_buffer_offset=0,
-    max_count,
+    offset: int = 0,
+    count_buffer: GPUBuffer,
+    count_buffer_offset: int = 0,
+    max_count: int,
 ):
     """
     This is equivalent to:
@@ -169,18 +194,28 @@ def create_statistics_query_set(device, *, label="", count: int, statistics):
     return device._create_statistics_query_set(label, count, statistics)
 
 
-def begin_pipeline_statistics_query(encoder, query_set, query_index):
+def begin_pipeline_statistics_query(
+    encoder: GPURenderPassEncoder | GPUComputePassEncoder,
+    query_set: GPUQuerySet,
+    query_index: int,
+):
     print(encoder, type(encoder))
     assert isinstance(encoder, (GPURenderPassEncoder, GPUComputePassEncoder))
     encoder._begin_pipeline_statistics_query(query_set, query_index)
 
 
-def end_pipeline_statistics_query(encoder):
+def end_pipeline_statistics_query(
+    encoder: GPURenderPassEncoder | GPUComputePassEncoder,
+):
     assert isinstance(encoder, (GPURenderPassEncoder, GPUComputePassEncoder))
     encoder._end_pipeline_statistics_query()
 
 
-def write_timestamp(encoder, query_set, query_index):
+def write_timestamp(
+    encoder: GPURenderPassEncoder | GPUComputePassEncoder | GPUCommandEncoder,
+    query_set: GPUQuerySet,
+    query_index: int,
+):
     assert isinstance(
         encoder, (GPURenderPassEncoder, GPUComputePassEncoder, GPUCommandEncoder)
     )
@@ -193,8 +228,8 @@ def set_instance_extras(
     dx12_compiler="fxc",
     gles3_minor_version="Atomic",
     fence_behavior="Normal",
-    dxil_path: Union[os.PathLike, None] = None,
-    dxc_path: Union[os.PathLike, None] = None,
+    dxil_path: os.PathLike | None = None,
+    dxc_path: os.PathLike | None = None,
     dxc_max_shader_model: float = 6.5,
 ):
     """

--- a/wgpu/structs.py
+++ b/wgpu/structs.py
@@ -553,12 +553,12 @@ CopyExternalImageDestInfo = Struct(
     premultiplied_alpha="bool",
 )
 
-#: * source :: ArrayLike | object
+#: * source :: ArrayLike | CanvasLike | object
 #: * origin :: list[int] | :obj:`structs.Origin2D <Origin2D>` = {}
 #: * flipY :: bool = false
 CopyExternalImageSourceInfo = Struct(
     "CopyExternalImageSourceInfo",
-    source="ArrayLike | object",
+    source="ArrayLike | CanvasLike | object",
     origin="list[int] | structs.Origin2D",
     flip_y="bool",
 )

--- a/wgpu/structs.py
+++ b/wgpu/structs.py
@@ -106,14 +106,14 @@ RequestAdapterOptions = Struct(
 )
 
 #: * label :: str = ""
-#: * requiredFeatures :: List[:obj:`enums.FeatureNameEnum <wgpu.enums.FeatureNameEnum>`] = []
-#: * requiredLimits :: Dict[str, None | int] = {}
+#: * requiredFeatures :: list[:obj:`enums.FeatureNameEnum <wgpu.enums.FeatureNameEnum>`] = []
+#: * requiredLimits :: dict[str, None | int] = {}
 #: * defaultQueue :: :obj:`structs.QueueDescriptor <QueueDescriptor>` = {}
 DeviceDescriptor = Struct(
     "DeviceDescriptor",
     label="str",
-    required_features="List[enums.FeatureNameEnum]",
-    required_limits="Dict[str, None | int]",
+    required_features="list[enums.FeatureNameEnum]",
+    required_limits="dict[str, None | int]",
     default_queue="structs.QueueDescriptor",
 )
 
@@ -130,23 +130,23 @@ BufferDescriptor = Struct(
 )
 
 #: * label :: str = ""
-#: * size :: List[int] | :obj:`structs.Extent3D <Extent3D>`
+#: * size :: list[int] | :obj:`structs.Extent3D <Extent3D>`
 #: * mipLevelCount :: int = 1
 #: * sampleCount :: int = 1
 #: * dimension :: :obj:`enums.TextureDimension <wgpu.enums.TextureDimension>` = "2d"
 #: * format :: :obj:`enums.TextureFormat <wgpu.enums.TextureFormat>`
 #: * usage :: :obj:`flags.TextureUsage <wgpu.flags.TextureUsage>`
-#: * viewFormats :: List[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`] = []
+#: * viewFormats :: list[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`] = []
 TextureDescriptor = Struct(
     "TextureDescriptor",
     label="str",
-    size="List[int] | structs.Extent3D",
+    size="list[int] | structs.Extent3D",
     mip_level_count="int",
     sample_count="int",
     dimension="enums.TextureDimensionEnum",
     format="enums.TextureFormatEnum",
     usage="flags.TextureUsageFlags",
-    view_formats="List[enums.TextureFormatEnum]",
+    view_formats="list[enums.TextureFormatEnum]",
 )
 
 #: * label :: str = ""
@@ -208,11 +208,11 @@ SamplerDescriptor = Struct(
 )
 
 #: * label :: str = ""
-#: * entries :: List[:obj:`structs.BindGroupLayoutEntry <BindGroupLayoutEntry>`]
+#: * entries :: list[:obj:`structs.BindGroupLayoutEntry <BindGroupLayoutEntry>`]
 BindGroupLayoutDescriptor = Struct(
     "BindGroupLayoutDescriptor",
     label="str",
-    entries="List[structs.BindGroupLayoutEntry]",
+    entries="list[structs.BindGroupLayoutEntry]",
 )
 
 #: * binding :: int
@@ -275,12 +275,12 @@ ExternalTextureBindingLayout = Struct(
 
 #: * label :: str = ""
 #: * layout :: :class:`GPUBindGroupLayout <wgpu.GPUBindGroupLayout>`
-#: * entries :: List[:obj:`structs.BindGroupEntry <BindGroupEntry>`]
+#: * entries :: list[:obj:`structs.BindGroupEntry <BindGroupEntry>`]
 BindGroupDescriptor = Struct(
     "BindGroupDescriptor",
     label="str",
     layout="GPUBindGroupLayout",
-    entries="List[structs.BindGroupEntry]",
+    entries="list[structs.BindGroupEntry]",
 )
 
 #: * binding :: int
@@ -302,21 +302,21 @@ BufferBinding = Struct(
 )
 
 #: * label :: str = ""
-#: * bindGroupLayouts :: List[:class:`GPUBindGroupLayout <wgpu.GPUBindGroupLayout>`]
+#: * bindGroupLayouts :: list[:class:`GPUBindGroupLayout <wgpu.GPUBindGroupLayout>`]
 PipelineLayoutDescriptor = Struct(
     "PipelineLayoutDescriptor",
     label="str",
-    bind_group_layouts="List[GPUBindGroupLayout]",
+    bind_group_layouts="list[GPUBindGroupLayout]",
 )
 
 #: * label :: str = ""
 #: * code :: str
-#: * compilationHints :: List[:obj:`structs.ShaderModuleCompilationHint <ShaderModuleCompilationHint>`] = []
+#: * compilationHints :: list[:obj:`structs.ShaderModuleCompilationHint <ShaderModuleCompilationHint>`] = []
 ShaderModuleDescriptor = Struct(
     "ShaderModuleDescriptor",
     label="str",
     code="str",
-    compilation_hints="List[structs.ShaderModuleCompilationHint]",
+    compilation_hints="list[structs.ShaderModuleCompilationHint]",
 )
 
 #: * entryPoint :: str
@@ -335,12 +335,12 @@ PipelineErrorInit = Struct(
 
 #: * module :: :class:`GPUShaderModule <wgpu.GPUShaderModule>`
 #: * entryPoint :: str
-#: * constants :: Dict[str, float] = {}
+#: * constants :: dict[str, float] = {}
 ProgrammableStage = Struct(
     "ProgrammableStage",
     module="GPUShaderModule",
     entry_point="str",
-    constants="Dict[str, float]",
+    constants="dict[str, float]",
 )
 
 #: * label :: str = ""
@@ -397,14 +397,14 @@ MultisampleState = Struct(
 
 #: * module :: :class:`GPUShaderModule <wgpu.GPUShaderModule>`
 #: * entryPoint :: str
-#: * constants :: Dict[str, float] = {}
-#: * targets :: List[:obj:`structs.ColorTargetState <ColorTargetState>`]
+#: * constants :: dict[str, float] = {}
+#: * targets :: list[:obj:`structs.ColorTargetState <ColorTargetState>`]
 FragmentState = Struct(
     "FragmentState",
     module="GPUShaderModule",
     entry_point="str",
-    constants="Dict[str, float]",
-    targets="List[structs.ColorTargetState]",
+    constants="dict[str, float]",
+    targets="list[structs.ColorTargetState]",
 )
 
 #: * format :: :obj:`enums.TextureFormat <wgpu.enums.TextureFormat>`
@@ -473,24 +473,24 @@ StencilFaceState = Struct(
 
 #: * module :: :class:`GPUShaderModule <wgpu.GPUShaderModule>`
 #: * entryPoint :: str
-#: * constants :: Dict[str, float] = {}
-#: * buffers :: List[:obj:`structs.VertexBufferLayout <VertexBufferLayout>`] = []
+#: * constants :: dict[str, float] = {}
+#: * buffers :: list[:obj:`structs.VertexBufferLayout <VertexBufferLayout>`] = []
 VertexState = Struct(
     "VertexState",
     module="GPUShaderModule",
     entry_point="str",
-    constants="Dict[str, float]",
-    buffers="List[structs.VertexBufferLayout]",
+    constants="dict[str, float]",
+    buffers="list[structs.VertexBufferLayout]",
 )
 
 #: * arrayStride :: int
 #: * stepMode :: :obj:`enums.VertexStepMode <wgpu.enums.VertexStepMode>` = "vertex"
-#: * attributes :: List[:obj:`structs.VertexAttribute <VertexAttribute>`]
+#: * attributes :: list[:obj:`structs.VertexAttribute <VertexAttribute>`]
 VertexBufferLayout = Struct(
     "VertexBufferLayout",
     array_stride="int",
     step_mode="enums.VertexStepModeEnum",
-    attributes="List[structs.VertexAttribute]",
+    attributes="list[structs.VertexAttribute]",
 )
 
 #: * format :: :obj:`enums.VertexFormat <wgpu.enums.VertexFormat>`
@@ -527,19 +527,19 @@ TexelCopyBufferInfo = Struct(
 
 #: * texture :: :class:`GPUTexture <wgpu.GPUTexture>`
 #: * mipLevel :: int = 0
-#: * origin :: List[int] | :obj:`structs.Origin3D <Origin3D>` = {}
+#: * origin :: list[int] | :obj:`structs.Origin3D <Origin3D>` = {}
 #: * aspect :: :obj:`enums.TextureAspect <wgpu.enums.TextureAspect>` = "all"
 TexelCopyTextureInfo = Struct(
     "TexelCopyTextureInfo",
     texture="GPUTexture",
     mip_level="int",
-    origin="List[int] | structs.Origin3D",
+    origin="list[int] | structs.Origin3D",
     aspect="enums.TextureAspectEnum",
 )
 
 #: * texture :: :class:`GPUTexture <wgpu.GPUTexture>`
 #: * mipLevel :: int = 0
-#: * origin :: List[int] | :obj:`structs.Origin3D <Origin3D>` = {}
+#: * origin :: list[int] | :obj:`structs.Origin3D <Origin3D>` = {}
 #: * aspect :: :obj:`enums.TextureAspect <wgpu.enums.TextureAspect>` = "all"
 #: * colorSpace :: str = "srgb"
 #: * premultipliedAlpha :: bool = false
@@ -547,19 +547,19 @@ CopyExternalImageDestInfo = Struct(
     "CopyExternalImageDestInfo",
     texture="GPUTexture",
     mip_level="int",
-    origin="List[int] | structs.Origin3D",
+    origin="list[int] | structs.Origin3D",
     aspect="enums.TextureAspectEnum",
     color_space="str",
     premultiplied_alpha="bool",
 )
 
 #: * source :: ArrayLike | object
-#: * origin :: List[int] | :obj:`structs.Origin2D <Origin2D>` = {}
+#: * origin :: list[int] | :obj:`structs.Origin2D <Origin2D>` = {}
 #: * flipY :: bool = false
 CopyExternalImageSourceInfo = Struct(
     "CopyExternalImageSourceInfo",
     source="ArrayLike | object",
-    origin="List[int] | structs.Origin2D",
+    origin="list[int] | structs.Origin2D",
     flip_y="bool",
 )
 
@@ -604,7 +604,7 @@ RenderPassTimestampWrites = Struct(
 )
 
 #: * label :: str = ""
-#: * colorAttachments :: List[:obj:`structs.RenderPassColorAttachment <RenderPassColorAttachment>`]
+#: * colorAttachments :: list[:obj:`structs.RenderPassColorAttachment <RenderPassColorAttachment>`]
 #: * depthStencilAttachment :: :obj:`structs.RenderPassDepthStencilAttachment <RenderPassDepthStencilAttachment>`
 #: * occlusionQuerySet :: :class:`GPUQuerySet <wgpu.GPUQuerySet>`
 #: * timestampWrites :: :obj:`structs.RenderPassTimestampWrites <RenderPassTimestampWrites>`
@@ -612,7 +612,7 @@ RenderPassTimestampWrites = Struct(
 RenderPassDescriptor = Struct(
     "RenderPassDescriptor",
     label="str",
-    color_attachments="List[structs.RenderPassColorAttachment]",
+    color_attachments="list[structs.RenderPassColorAttachment]",
     depth_stencil_attachment="structs.RenderPassDepthStencilAttachment",
     occlusion_query_set="GPUQuerySet",
     timestamp_writes="structs.RenderPassTimestampWrites",
@@ -622,7 +622,7 @@ RenderPassDescriptor = Struct(
 #: * view :: :class:`GPUTexture <wgpu.GPUTexture>` | :class:`GPUTextureView <wgpu.GPUTextureView>`
 #: * depthSlice :: int
 #: * resolveTarget :: :class:`GPUTexture <wgpu.GPUTexture>` | :class:`GPUTextureView <wgpu.GPUTextureView>`
-#: * clearValue :: List[float] | :obj:`structs.Color <Color>`
+#: * clearValue :: list[float] | :obj:`structs.Color <Color>`
 #: * loadOp :: :obj:`enums.LoadOp <wgpu.enums.LoadOp>`
 #: * storeOp :: :obj:`enums.StoreOp <wgpu.enums.StoreOp>`
 RenderPassColorAttachment = Struct(
@@ -630,7 +630,7 @@ RenderPassColorAttachment = Struct(
     view="GPUTexture | GPUTextureView",
     depth_slice="int",
     resolve_target="GPUTexture | GPUTextureView",
-    clear_value="List[float] | structs.Color",
+    clear_value="list[float] | structs.Color",
     load_op="enums.LoadOpEnum",
     store_op="enums.StoreOpEnum",
 )
@@ -658,13 +658,13 @@ RenderPassDepthStencilAttachment = Struct(
 )
 
 #: * label :: str = ""
-#: * colorFormats :: List[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`]
+#: * colorFormats :: list[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`]
 #: * depthStencilFormat :: :obj:`enums.TextureFormat <wgpu.enums.TextureFormat>`
 #: * sampleCount :: int = 1
 RenderPassLayout = Struct(
     "RenderPassLayout",
     label="str",
-    color_formats="List[enums.TextureFormatEnum]",
+    color_formats="list[enums.TextureFormatEnum]",
     depth_stencil_format="enums.TextureFormatEnum",
     sample_count="int",
 )
@@ -676,7 +676,7 @@ RenderBundleDescriptor = Struct(
 )
 
 #: * label :: str = ""
-#: * colorFormats :: List[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`]
+#: * colorFormats :: list[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`]
 #: * depthStencilFormat :: :obj:`enums.TextureFormat <wgpu.enums.TextureFormat>`
 #: * sampleCount :: int = 1
 #: * depthReadOnly :: bool = false
@@ -684,7 +684,7 @@ RenderBundleDescriptor = Struct(
 RenderBundleEncoderDescriptor = Struct(
     "RenderBundleEncoderDescriptor",
     label="str",
-    color_formats="List[enums.TextureFormatEnum]",
+    color_formats="list[enums.TextureFormatEnum]",
     depth_stencil_format="enums.TextureFormatEnum",
     sample_count="int",
     depth_read_only="bool",
@@ -716,7 +716,7 @@ CanvasToneMapping = Struct(
 #: * device :: :class:`GPUDevice <wgpu.GPUDevice>`
 #: * format :: :obj:`enums.TextureFormat <wgpu.enums.TextureFormat>`
 #: * usage :: :obj:`flags.TextureUsage <wgpu.flags.TextureUsage>` = 0x10
-#: * viewFormats :: List[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`] = []
+#: * viewFormats :: list[:obj:`enums.TextureFormatEnum <wgpu.enums.TextureFormatEnum>`] = []
 #: * colorSpace :: str = "srgb"
 #: * toneMapping :: :obj:`structs.CanvasToneMapping <CanvasToneMapping>` = {}
 #: * alphaMode :: :obj:`enums.CanvasAlphaMode <wgpu.enums.CanvasAlphaMode>` = "opaque"
@@ -725,7 +725,7 @@ CanvasConfiguration = Struct(
     device="GPUDevice",
     format="enums.TextureFormatEnum",
     usage="flags.TextureUsageFlags",
-    view_formats="List[enums.TextureFormatEnum]",
+    view_formats="list[enums.TextureFormatEnum]",
     color_space="str",
     tone_mapping="structs.CanvasToneMapping",
     alpha_mode="enums.CanvasAlphaModeEnum",

--- a/wgpu/structs.py
+++ b/wgpu/structs.py
@@ -172,12 +172,12 @@ TextureViewDescriptor = Struct(
 )
 
 #: * label :: str = ""
-#: * source :: memoryview | object
+#: * source :: ArrayLike | object
 #: * colorSpace :: str = "srgb"
 ExternalTextureDescriptor = Struct(
     "ExternalTextureDescriptor",
     label="str",
-    source="memoryview | object",
+    source="ArrayLike | object",
     color_space="str",
 )
 
@@ -553,12 +553,12 @@ CopyExternalImageDestInfo = Struct(
     premultiplied_alpha="bool",
 )
 
-#: * source :: memoryview | object
+#: * source :: ArrayLike | object
 #: * origin :: List[int] | :obj:`structs.Origin2D <Origin2D>` = {}
 #: * flipY :: bool = false
 CopyExternalImageSourceInfo = Struct(
     "CopyExternalImageSourceInfo",
-    source="memoryview | object",
+    source="ArrayLike | object",
     origin="List[int] | structs.Origin2D",
     flip_y="bool",
 )

--- a/wgpu/structs.py
+++ b/wgpu/structs.py
@@ -107,13 +107,13 @@ RequestAdapterOptions = Struct(
 
 #: * label :: str = ""
 #: * requiredFeatures :: List[:obj:`enums.FeatureNameEnum <wgpu.enums.FeatureNameEnum>`] = []
-#: * requiredLimits :: Dict[str, Union[None, int]] = {}
+#: * requiredLimits :: Dict[str, None | int] = {}
 #: * defaultQueue :: :obj:`structs.QueueDescriptor <QueueDescriptor>` = {}
 DeviceDescriptor = Struct(
     "DeviceDescriptor",
     label="str",
     required_features="List[enums.FeatureNameEnum]",
-    required_limits="Dict[str, Union[None, int]]",
+    required_limits="Dict[str, None | int]",
     default_queue="structs.QueueDescriptor",
 )
 
@@ -130,7 +130,7 @@ BufferDescriptor = Struct(
 )
 
 #: * label :: str = ""
-#: * size :: Union[List[int], :obj:`structs.Extent3D <Extent3D>`]
+#: * size :: List[int] | :obj:`structs.Extent3D <Extent3D>`
 #: * mipLevelCount :: int = 1
 #: * sampleCount :: int = 1
 #: * dimension :: :obj:`enums.TextureDimension <wgpu.enums.TextureDimension>` = "2d"
@@ -140,7 +140,7 @@ BufferDescriptor = Struct(
 TextureDescriptor = Struct(
     "TextureDescriptor",
     label="str",
-    size="Union[List[int], structs.Extent3D]",
+    size="List[int] | structs.Extent3D",
     mip_level_count="int",
     sample_count="int",
     dimension="enums.TextureDimensionEnum",
@@ -172,12 +172,12 @@ TextureViewDescriptor = Struct(
 )
 
 #: * label :: str = ""
-#: * source :: Union[memoryview, object]
+#: * source :: memoryview | object
 #: * colorSpace :: str = "srgb"
 ExternalTextureDescriptor = Struct(
     "ExternalTextureDescriptor",
     label="str",
-    source="Union[memoryview, object]",
+    source="memoryview | object",
     color_space="str",
 )
 
@@ -284,11 +284,11 @@ BindGroupDescriptor = Struct(
 )
 
 #: * binding :: int
-#: * resource :: Union[:class:`GPUBuffer <wgpu.GPUBuffer>`, :class:`GPUSampler <wgpu.GPUSampler>`, :class:`GPUTexture <wgpu.GPUTexture>`, :class:`GPUTextureView <wgpu.GPUTextureView>`, object, :obj:`structs.BufferBinding <BufferBinding>`]
+#: * resource :: :class:`GPUBuffer <wgpu.GPUBuffer>` | :class:`GPUSampler <wgpu.GPUSampler>` | :class:`GPUTexture <wgpu.GPUTexture>` | :class:`GPUTextureView <wgpu.GPUTextureView>` | object | :obj:`structs.BufferBinding <BufferBinding>`
 BindGroupEntry = Struct(
     "BindGroupEntry",
     binding="int",
-    resource="Union[GPUBuffer, GPUSampler, GPUTexture, GPUTextureView, object, structs.BufferBinding]",
+    resource="GPUBuffer | GPUSampler | GPUTexture | GPUTextureView | object | structs.BufferBinding",
 )
 
 #: * buffer :: :class:`GPUBuffer <wgpu.GPUBuffer>`
@@ -320,11 +320,11 @@ ShaderModuleDescriptor = Struct(
 )
 
 #: * entryPoint :: str
-#: * layout :: Union[:class:`GPUPipelineLayout <wgpu.GPUPipelineLayout>`, :obj:`enums.AutoLayoutModeEnum <wgpu.enums.AutoLayoutModeEnum>`]
+#: * layout :: :class:`GPUPipelineLayout <wgpu.GPUPipelineLayout>` | :obj:`enums.AutoLayoutMode <wgpu.enums.AutoLayoutMode>`
 ShaderModuleCompilationHint = Struct(
     "ShaderModuleCompilationHint",
     entry_point="str",
-    layout="Union[GPUPipelineLayout, enums.AutoLayoutModeEnum]",
+    layout="GPUPipelineLayout | enums.AutoLayoutModeEnum",
 )
 
 #: * reason :: :obj:`enums.PipelineErrorReason <wgpu.enums.PipelineErrorReason>`
@@ -344,17 +344,17 @@ ProgrammableStage = Struct(
 )
 
 #: * label :: str = ""
-#: * layout :: Union[:class:`GPUPipelineLayout <wgpu.GPUPipelineLayout>`, :obj:`enums.AutoLayoutModeEnum <wgpu.enums.AutoLayoutModeEnum>`]
+#: * layout :: :class:`GPUPipelineLayout <wgpu.GPUPipelineLayout>` | :obj:`enums.AutoLayoutMode <wgpu.enums.AutoLayoutMode>`
 #: * compute :: :obj:`structs.ProgrammableStage <ProgrammableStage>`
 ComputePipelineDescriptor = Struct(
     "ComputePipelineDescriptor",
     label="str",
-    layout="Union[GPUPipelineLayout, enums.AutoLayoutModeEnum]",
+    layout="GPUPipelineLayout | enums.AutoLayoutModeEnum",
     compute="structs.ProgrammableStage",
 )
 
 #: * label :: str = ""
-#: * layout :: Union[:class:`GPUPipelineLayout <wgpu.GPUPipelineLayout>`, :obj:`enums.AutoLayoutModeEnum <wgpu.enums.AutoLayoutModeEnum>`]
+#: * layout :: :class:`GPUPipelineLayout <wgpu.GPUPipelineLayout>` | :obj:`enums.AutoLayoutMode <wgpu.enums.AutoLayoutMode>`
 #: * vertex :: :obj:`structs.VertexState <VertexState>`
 #: * primitive :: :obj:`structs.PrimitiveState <PrimitiveState>` = {}
 #: * depthStencil :: :obj:`structs.DepthStencilState <DepthStencilState>`
@@ -363,7 +363,7 @@ ComputePipelineDescriptor = Struct(
 RenderPipelineDescriptor = Struct(
     "RenderPipelineDescriptor",
     label="str",
-    layout="Union[GPUPipelineLayout, enums.AutoLayoutModeEnum]",
+    layout="GPUPipelineLayout | enums.AutoLayoutModeEnum",
     vertex="structs.VertexState",
     primitive="structs.PrimitiveState",
     depth_stencil="structs.DepthStencilState",
@@ -527,19 +527,19 @@ TexelCopyBufferInfo = Struct(
 
 #: * texture :: :class:`GPUTexture <wgpu.GPUTexture>`
 #: * mipLevel :: int = 0
-#: * origin :: Union[List[int], :obj:`structs.Origin3D <Origin3D>`] = {}
+#: * origin :: List[int] | :obj:`structs.Origin3D <Origin3D>` = {}
 #: * aspect :: :obj:`enums.TextureAspect <wgpu.enums.TextureAspect>` = "all"
 TexelCopyTextureInfo = Struct(
     "TexelCopyTextureInfo",
     texture="GPUTexture",
     mip_level="int",
-    origin="Union[List[int], structs.Origin3D]",
+    origin="List[int] | structs.Origin3D",
     aspect="enums.TextureAspectEnum",
 )
 
 #: * texture :: :class:`GPUTexture <wgpu.GPUTexture>`
 #: * mipLevel :: int = 0
-#: * origin :: Union[List[int], :obj:`structs.Origin3D <Origin3D>`] = {}
+#: * origin :: List[int] | :obj:`structs.Origin3D <Origin3D>` = {}
 #: * aspect :: :obj:`enums.TextureAspect <wgpu.enums.TextureAspect>` = "all"
 #: * colorSpace :: str = "srgb"
 #: * premultipliedAlpha :: bool = false
@@ -547,19 +547,19 @@ CopyExternalImageDestInfo = Struct(
     "CopyExternalImageDestInfo",
     texture="GPUTexture",
     mip_level="int",
-    origin="Union[List[int], structs.Origin3D]",
+    origin="List[int] | structs.Origin3D",
     aspect="enums.TextureAspectEnum",
     color_space="str",
     premultiplied_alpha="bool",
 )
 
-#: * source :: Union[memoryview, object]
-#: * origin :: Union[List[int], :obj:`structs.Origin2D <Origin2D>`] = {}
+#: * source :: memoryview | object
+#: * origin :: List[int] | :obj:`structs.Origin2D <Origin2D>` = {}
 #: * flipY :: bool = false
 CopyExternalImageSourceInfo = Struct(
     "CopyExternalImageSourceInfo",
-    source="Union[memoryview, object]",
-    origin="Union[List[int], structs.Origin2D]",
+    source="memoryview | object",
+    origin="List[int] | structs.Origin2D",
     flip_y="bool",
 )
 
@@ -619,23 +619,23 @@ RenderPassDescriptor = Struct(
     max_draw_count="int",
 )
 
-#: * view :: Union[:class:`GPUTexture <wgpu.GPUTexture>`, :class:`GPUTextureView <wgpu.GPUTextureView>`]
+#: * view :: :class:`GPUTexture <wgpu.GPUTexture>` | :class:`GPUTextureView <wgpu.GPUTextureView>`
 #: * depthSlice :: int
-#: * resolveTarget :: Union[:class:`GPUTexture <wgpu.GPUTexture>`, :class:`GPUTextureView <wgpu.GPUTextureView>`]
-#: * clearValue :: Union[List[float], :obj:`structs.Color <Color>`]
+#: * resolveTarget :: :class:`GPUTexture <wgpu.GPUTexture>` | :class:`GPUTextureView <wgpu.GPUTextureView>`
+#: * clearValue :: List[float] | :obj:`structs.Color <Color>`
 #: * loadOp :: :obj:`enums.LoadOp <wgpu.enums.LoadOp>`
 #: * storeOp :: :obj:`enums.StoreOp <wgpu.enums.StoreOp>`
 RenderPassColorAttachment = Struct(
     "RenderPassColorAttachment",
-    view="Union[GPUTexture, GPUTextureView]",
+    view="GPUTexture | GPUTextureView",
     depth_slice="int",
-    resolve_target="Union[GPUTexture, GPUTextureView]",
-    clear_value="Union[List[float], structs.Color]",
+    resolve_target="GPUTexture | GPUTextureView",
+    clear_value="List[float] | structs.Color",
     load_op="enums.LoadOpEnum",
     store_op="enums.StoreOpEnum",
 )
 
-#: * view :: Union[:class:`GPUTexture <wgpu.GPUTexture>`, :class:`GPUTextureView <wgpu.GPUTextureView>`]
+#: * view :: :class:`GPUTexture <wgpu.GPUTexture>` | :class:`GPUTextureView <wgpu.GPUTextureView>`
 #: * depthClearValue :: float
 #: * depthLoadOp :: :obj:`enums.LoadOp <wgpu.enums.LoadOp>`
 #: * depthStoreOp :: :obj:`enums.StoreOp <wgpu.enums.StoreOp>`
@@ -646,7 +646,7 @@ RenderPassColorAttachment = Struct(
 #: * stencilReadOnly :: bool = false
 RenderPassDepthStencilAttachment = Struct(
     "RenderPassDepthStencilAttachment",
-    view="Union[GPUTexture, GPUTextureView]",
+    view="GPUTexture | GPUTextureView",
     depth_clear_value="float",
     depth_load_op="enums.LoadOpEnum",
     depth_store_op="enums.StoreOpEnum",


### PR DESCRIPTION
* [x] Use `FooType | None` instead of `Optional[FooType]`
* [x] Use `FooType | BarType` instead of `Union[Footype, BarType]` 
* [x] Use `dict[..]` and `list[..]` instead of `Dict[..]` and `List[..]`
* [x] Add a `ArrayLike` type annotation. It allows anything, so it does not help type checking, but it helps users bc they see "ArrayLike" in the autocompletion/signature in tools like VSCode.
* [x] Add a `CanvasLike` type annotation.
* [x] Checked type annotations in method signatures that are not generated (apidiffs and privates) to make sure they are properly typed, including a return type.