### PR TITLE
Allow using renderpass/compute encoders as context manager

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -320,14 +320,13 @@ def get_draw_function(
                 )
             ],
         )
-
-        render_pass.set_pipeline(render_pipeline)
-        render_pass.set_index_buffer(index_buffer, "uint32")
-        render_pass.set_vertex_buffer(0, vertex_buffer)
-        for bind_group_id, bind_group in enumerate(bind_groups):
-            render_pass.set_bind_group(bind_group_id, bind_group)
-        render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
-        render_pass.end()
+        with render_pass:
+            render_pass.set_pipeline(render_pipeline)
+            render_pass.set_index_buffer(index_buffer, "uint32")
+            render_pass.set_vertex_buffer(0, vertex_buffer)
+            for bind_group_id, bind_group in enumerate(bind_groups):
+                render_pass.set_bind_group(bind_group_id, bind_group)
+            render_pass.draw_indexed(index_data.size, 1, 0, 0, 0)
 
         device.queue.submit([command_encoder.finish()])
 

--- a/examples/triangle.py
+++ b/examples/triangle.py
@@ -117,11 +117,10 @@ def get_draw_function(
                 )
             ],
         )
-
-        render_pass.set_pipeline(render_pipeline)
-        # render_pass.set_bind_group(0, no_bind_group)
-        render_pass.draw(3, 1, 0, 0)
-        render_pass.end()
+        with render_pass:
+            render_pass.set_pipeline(render_pipeline)
+            # render_pass.set_bind_group(0, no_bind_group)
+            render_pass.draw(3, 1, 0, 0)
         device.queue.submit([command_encoder.finish()])
 
     async def draw_frame_async():

--- a/wgpu/_classes.py
+++ b/wgpu/_classes.py
@@ -2159,6 +2159,12 @@ class GPUComputePassEncoder(
     Create a compute pass encoder using `GPUCommandEncoder.begin_compute_pass()`.
     """
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end()
+
     # IDL: undefined setPipeline(GPUComputePipeline pipeline);
     def set_pipeline(self, pipeline: GPUComputePipeline | None = None) -> None:
         """Set the pipeline for this compute pass.
@@ -2215,6 +2221,12 @@ class GPURenderPassEncoder(
 
     Create a render pass encoder using `GPUCommandEncoder.begin_render_pass`.
     """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end()
 
     # IDL: undefined setViewport(float x, float y, float width, float height, float minDepth, float maxDepth);
     def set_viewport(


### PR DESCRIPTION
Ref #394

This is one place where we can use a context manager to allow writing cleaner code.

I do like how code that uses it becomes more structured. But it also feels inconsistent, since there are more places where an object needs to be "ended", but where a context manager is harder to apply:

* `GPUBuffer.map()` / `.unmap()`, tricky bc `.map` is async.
* `GPUCommandEncoder.finish()`, tricky because it returns a list to be fed into `queue.submit`.

So in the sake of consistency (internally, but also with other WebGPU API's), and simplicity, I'm abandoning this idea. 
