### PR TITLE
Fix `on_submitted_work_done_async` crash: missing `WGPUStringView` in callback signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ Possible sections in each release:
   Downstream code should capture that error and skip the frame, optionally invoking some sort of sleep to save energy.
   See https://github.com/pygfx/wgpu-py/pull/820 for context.
 
+### Fixed:
+* `GPUQueue.on_submitted_work_done_async()` no longer raises `TypeError` when
+  building its callback struct. The ffi callback was missing the
+  `WGPUStringView message` argument that the `WGPUQueueWorkDoneCallback` typedef
+  requires, so any call to it crashed. Also un-shadowed the test that covers
+  this path (it was named `make_pipeline_async` so pytest never collected it).
+
 
 ## [v0.31.1] - 23-06-2026
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -769,7 +769,7 @@ async def test_buffer_map_async():
 
 @mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 @mark.anyio
-async def make_pipeline_async():
+async def test_pipeline_async():
     device = wgpu.utils.get_default_device()
 
     shader_source = """
@@ -799,7 +799,7 @@ async def make_pipeline_async():
                 vertex={
                     "module": shader,
                 },
-                depth_stencil={"format": TextureFormat.rgba8unorm},
+                depth_stencil={"format": TextureFormat.depth32float},
             )
 
         tg.start_soon(create_compute_pipeline)

--- a/wgpu/backends/wgpu_native/_api.py
+++ b/wgpu/backends/wgpu_native/_api.py
@@ -4080,8 +4080,8 @@ class GPUQueue(classes.GPUQueue, GPUObjectBase):
         return data
 
     def on_submitted_work_done_async(self) -> GPUPromise[None]:
-        @ffi.callback("void(WGPUQueueWorkDoneStatus, void *, void *)")
-        def work_done_callback(status, _userdata1, _userdata2):
+        @ffi.callback("void(WGPUQueueWorkDoneStatus, WGPUStringView, void *, void *)")
+        def work_done_callback(status, _message, _userdata1, _userdata2):
             token.set_done()
             if status == lib.WGPUQueueWorkDoneStatus_Success:
                 promise._wgpu_set_input(True)


### PR DESCRIPTION
Hi! Thanks for creating this package, I've been really enjoying it!

Although It seems the latest 0.32 crashes due to an argument mis-match, that the tests didn't catch. I was a bit puzzled at first, but the default pytest config only runs `test_*` prefixed functions :sweat_smile:

Disclaimer: I used LLMs to investigate/draft/test/brainstorm. I think it made everything a bit better, especially the explanation below - but thought I should let you know!

## What

`GPUQueue.on_submitted_work_done_async()` raises `TypeError` for everyone,
it can never succeed on the current release.

```
TypeError: initializer for ctype
'void(*)(WGPUQueueWorkDoneStatus, WGPUStringView, void *, void *)'
must be a pointer to same type, not cdata
'void(*)(WGPUQueueWorkDoneStatus, void *, void *)'
```

The ffi callback is declared with three parameters:

```python
@ffi.callback("void(WGPUQueueWorkDoneStatus, void *, void *)")
def work_done_callback(status, _userdata1, _userdata2):
```

but wgpu-native's `WGPUQueueWorkDoneCallback` typedef (`webgpu.h`) takes a
`WGPUStringView message` between the status and the two userdata pointers:

```c
typedef void (*WGPUQueueWorkDoneCallback)(
    WGPUQueueWorkDoneStatus status, WGPUStringView message,
    WGPU_NULLABLE void *userdata1, WGPU_NULLABLE void *userdata2);
```

Because the callback stored in `WGPUQueueWorkDoneCallbackInfo.callback` must
match that typedef exactly, merely *constructing* the struct raises. Every
other status callback in `_api.py` (request-adapter, request-device,
device-lost, uncaptured-error) already includes the `WGPUStringView` message
argument — this one was simply missing it.

## Fix

Add the missing `message` parameter (ignored, like the userdata args) so the
signature matches the header:

```python
@ffi.callback("void(WGPUQueueWorkDoneStatus, WGPUStringView, void *, void *)")
def work_done_callback(status, _message, _userdata1, _userdata2):
```

## How it slipped through

Two independent gaps, worth flagging:

1. **The regression test was never collected.** The only code exercising
   `on_submitted_work_done_async()` lived in a function named
   `make_pipeline_async` (in `tests/test_async.py`), which doesn't match
   pytest's `test_*` prefix — so it was silently uncollected and the path had
   zero CI coverage. This PR renames it to `test_pipeline_async`. Collecting it
   also surfaced a second latent error in that test (a render pipeline asking
   for `depth_stencil` format `rgba8unorm`, a color format); fixed by using
   `depth32float`.

   I audited the rest of the suite for the same failure mode (functions
   decorated as tests but not matching the `test_*` prefix, and uncalled
   assert-bearing functions in test files) and cross-checked against pytest's
   own collector — `make_pipeline_async` was the only instance, so this isn't
   the tip of a larger pile.

2. **Codegen doesn't validate `@ffi.callback(...)` strings.** The codegen
   checks C function-call signatures and struct-field *types*, but nothing
   cross-checks the hand-written callback signatures against native's callback
   *typedefs*, so this mismatch was invisible until runtime. Happy to open a
   follow-up issue to add such a check — it would close this whole class of bug.

## Introduced by

The three-arg signature was introduced in #673 (update to wgpu-native
24.0.0.2), which migrated status callbacks to the callback-info ABI by hand;
the `message` argument was added to the other callbacks but not this one.

## Testing

- `test_pipeline_async` now passes on both the asyncio and trio backends.
- Reverting just the callback signature makes it fail at exactly the
  `on_submitted_work_done` call with the original `TypeError`, confirming it
  guards the regression.
- Verified against wgpu-native 29 on an NVIDIA RTX A2000.

## Note on releasing

This affects the current release (0.32.0) — any caller of
`on_submitted_work_done` is broken. Would you consider a 0.32.1 patch release
once this lands? Happy to help however is useful